### PR TITLE
fix(scaffold): emit license + LICENSE; stop README WASM overclaim (GH #23, #24) — v0.1.16

### DIFF
--- a/packages/create-agent-harness/__tests__/generated-templates.test.ts
+++ b/packages/create-agent-harness/__tests__/generated-templates.test.ts
@@ -115,6 +115,18 @@ describe('generated templates scaffold cleanly', () => {
           `${t.id} bin[${binName}] must not start with "./" (npm strips it on publish)`).toBe(true);
       }
 
+      // Regression for issue #23: every scaffold must carry a license field
+      // AND emit a matching LICENSE file (package.json `files` lists LICENSE).
+      expect(pkg.license, `${t.id} package.json missing license field`).toBe('MIT');
+      expect(r.paths, `${t.id} missing LICENSE file`).toContain('LICENSE');
+      const license = await readFile(join(target, 'LICENSE'), 'utf-8');
+      expect(license).toContain('MIT License');
+
+      // Regression for issue #24: the generated README must not overclaim a WASM
+      // kernel that the published beta doesn't ship (it resolves to js).
+      const readme = await readFile(join(target, 'README.md'), 'utf-8');
+      expect(readme).not.toContain('WASM kernel, multi-host support, witness-signed releases');
+
       // One agent file per declared agent.
       for (const a of t.agents) {
         expect(r.paths, `${t.id} missing agent ${a.id}`).toContain(`src/agents/${a.id}.ts`);

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "MetaHarness — mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/src/index.ts
+++ b/packages/create-agent-harness/src/index.ts
@@ -230,6 +230,34 @@ export interface ScaffoldResult {
  * Returns the list of paths written + the manifest path + any unresolved
  * template variables (should be empty for a clean run).
  */
+
+/** Standard MIT license text for a scaffolded harness (GH #23). */
+function mitLicense(name: string): string {
+  const year = new Date().getFullYear();
+  return `MIT License
+
+Copyright (c) ${year} ${name} authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+}
+
 export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
   const nameCheck = validateHarnessName(opts.name);
   if (!nameCheck.valid) {
@@ -286,6 +314,33 @@ export async function scaffold(opts: ScaffoldOptions): Promise<ScaffoldResult> {
         rendered[pkgIdx]!.content = JSON.stringify(pkg, null, 2) + '\n';
       } catch { /* leave package.json untouched if it doesn't parse */ }
     }
+  }
+
+  // GH #23: every scaffold must carry a license. The bin/cli.js template already
+  // ships an `SPDX-License-Identifier: MIT` header and package.json `files`
+  // lists "LICENSE", but neither the `license` field nor the LICENSE file were
+  // emitted — so `npm publish` warned and the published package showed
+  // "license: undefined". Inject both here, single-sourced for every template.
+  {
+    const pkgIdx = rendered.findIndex(r => r.path === 'package.json');
+    if (pkgIdx !== -1) {
+      try {
+        const pkg = JSON.parse(rendered[pkgIdx]!.content) as Record<string, unknown>;
+        if (!pkg.license) {
+          // place `license` right after `description` for conventional ordering
+          const ordered: Record<string, unknown> = {};
+          for (const [k, v] of Object.entries(pkg)) {
+            ordered[k] = v;
+            if (k === 'description') ordered.license = 'MIT';
+          }
+          if (!ordered.license) ordered.license = 'MIT';
+          rendered[pkgIdx]!.content = JSON.stringify(ordered, null, 2) + '\n';
+        }
+      } catch { /* leave package.json untouched if it doesn't parse */ }
+    }
+  }
+  if (!rendered.some(r => r.path === 'LICENSE')) {
+    rendered.push({ path: 'LICENSE', content: mitLicense(opts.name), rendered: false, unresolved: [] });
   }
 
   const fileMap = asFileMap(rendered);

--- a/packages/create-agent-harness/templates/minimal/README.md.tmpl
+++ b/packages/create-agent-harness/templates/minimal/README.md.tmpl
@@ -2,7 +2,7 @@
 
 {{description}}
 
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_advertising/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_advertising/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Advertising** — Media-plan → copy → performance, spanning digital (PPC/social) and traditional (print/OOH/radio).
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_agentics/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_agentics/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Agentics** — Orchestrator → planner → workers → critic, with a swarm-bus MCP and shared memory.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_ai/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_ai/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **AI / ML Engineering** — Curate → train → evaluate → deploy, with an experiment-tracking MCP and eval gates.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_business/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_business/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Business Operations** — Analyst → strategist → ops-coordinator, with a metrics MCP for KPI grounding.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_coding/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_coding/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Advanced Coding** — Architect → implement → review → test, with a code-index MCP and push-guarded git perms.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_crm/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_crm/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Customer Management** — Qualify → manage → watch-churn, with a CRM-store MCP and lifecycle memory.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_education/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_education/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Education / Tutoring** — Tutor → explain → quiz → grade, over per-learner mastery memory with an abstain-not-hallucinate policy.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_exotic/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_exotic/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Exotic / Self-Evolving** — Hypothesizer → experimenter → federator over a witness-signed evolution log (ADR-014).
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_gaming/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_gaming/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Game Design / Playtest** — Playtest reader → balance critic → economy modeler → narrative keeper over per-build telemetry memory.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_health/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_health/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Health & Wellness** — Intake → triage → coordinate, with a knowledge MCP. Hard-codes "see a clinician" for anything clinical.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_marketing/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_marketing/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Marketing** — Strategy → content → SEO, with an analytics MCP for grounding claims in real traffic.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_repo-maintainer/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_repo-maintainer/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Repo Maintainer** — Maintainer triages the diff → benchmarker reports regressions → release drafts the GH release body → security flags risky MCP grants. Drop into any repo and run.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_ruview/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_ruview/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Ruvector Review** — Index → retrieve → review, on a ruvector HNSW store with emergent-time decay.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 

--- a/packages/create-agent-harness/templates/vertical_sales/README.md.tmpl
+++ b/packages/create-agent-harness/templates/vertical_sales/README.md.tmpl
@@ -4,7 +4,7 @@
 
 > **Sales / Pipeline** — Prospect → qualify → demo → close with hidden-pain framework + objection-handling memory.
 >
-> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). WASM kernel, multi-host support, witness-signed releases.
+> Generated with [`create-agent-harness`](https://github.com/ruvnet/agent-harness-generator). Multi-host scaffolding with a kernel that resolves native → wasm → js (js backend in the published beta; see `harness doctor`).
 
 ## Install
 


### PR DESCRIPTION
Fixes **#23** and **#24**, bumps metaharness 0.1.15 → 0.1.16.

**#23 — scaffold omitted license + LICENSE.** `scaffold()` now injects `"license": "MIT"` into the rendered package.json and emits a standard MIT LICENSE file (single-sourced for all templates). Verified: a scaffolded harness shows `license: MIT`, ships LICENSE in the tarball, and `npm publish --dry-run` no longer warns.

**#24 — README overclaimed a WASM kernel.** The published beta resolves to the js backend; softened the 15 README templates to `resolves native → wasm → js (js backend in the published beta; see \`harness doctor\`)`.

Tests: 294 pass; generated-templates now asserts license==MIT + LICENSE present + no overclaim, for every template.

Note: kernel-backend issues #20/#21/#22/#25 live in `@metaharness/kernel` (publish is CI-gated on GCP WIF vars) — separate follow-up.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)