### PR TITLE
fix(kernel): ship wasm in tarball (rm pkg/.gitignore) — published 0.1.2

### DIFF
--- a/packages/kernel-js/package.json
+++ b/packages/kernel-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/kernel",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cross-platform kernel for the agent-harness-generator — wasm primary, NAPI-RS native fallback",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -41,7 +41,7 @@
     "build": "tsc",
     "test": "vitest run",
     "lint": "tsc --noEmit",
-    "build:wasm": "RUSTFLAGS= wasm-pack build ../../crates/kernel-wasm --target nodejs --release --out-dir pkg && node -e \"const f=require('fs');const j=require('./pkg/package.json');j.type='commonjs';f.writeFileSync('./pkg/package.json',JSON.stringify(j,null,2)+'\\n')\""
+    "build:wasm": "RUSTFLAGS= wasm-pack build ../../crates/kernel-wasm --target nodejs --release --out-dir ../../packages/kernel-js/pkg && rm -f pkg/.gitignore && node -e \"const f=require('fs');const j=require('./pkg/package.json');j.type='commonjs';f.writeFileSync('./pkg/package.json',JSON.stringify(j,null,2)+'\\n')\""
   },
   "keywords": [
     "agent-harness",


### PR DESCRIPTION
wasm-pack drops a `pkg/.gitignore` (`*`) that made npm prune pkg/ from the tarball; `build:wasm` now removes it. @metaharness/kernel@0.1.2 is published and verified to auto-resolve the wasm backend on a clean install. Closes the packaging half of #20.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)