### PR TITLE
fix(deps): align sdk/vertical deps for first publish

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,19 +19,33 @@
       "import": "./dist/index.js"
     }
   },
-  "files": ["dist/**", "README.md"],
+  "files": [
+    "dist/**",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
     "test": "vitest run --passWithNoTests",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["agent-harness", "sdk", "kernel", "ruflo"],
-  "publishConfig": { "access": "public" },
-  "dependencies": { "@metaharness/kernel": "0.1.0" },
+  "keywords": [
+    "agent-harness",
+    "sdk",
+    "kernel",
+    "ruflo"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@metaharness/kernel": "^0.1.2"
+  },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "typescript": "^5.4.0",
     "vitest": "^2.0.0"
   },
-  "engines": { "node": ">=20.0.0" }
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }

--- a/packages/vertical-trading/package.json
+++ b/packages/vertical-trading/package.json
@@ -36,14 +36,18 @@
     "backtesting",
     "ruflo"
   ],
-  "publishConfig": { "access": "public" },
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
-    "@metaharness/vertical-base": "0.1.0"
+    "@metaharness/vertical-base": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",
     "typescript": "^5.4.0",
     "vitest": "^2.0.0"
   },
-  "engines": { "node": ">=20.0.0" }
+  "engines": {
+    "node": ">=20.0.0"
+  }
 }


### PR DESCRIPTION
sdk → @metaharness/kernel ^0.1.2 (wasm backend); vertical-trading → vertical-base ^0.1.0. Prep for first npm publish of @metaharness/sdk, vertical-base, vertical-trading (tests: 18/9/5 pass).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)