### PR TITLE
fix(deps): caret-range kernel dep + republish hosts (CI ERESOLVE + wasm reachability) — hosts 0.1.2, metaharness 0.1.18

### DIFF
--- a/.github/workflows/published-smoke.yml
+++ b/.github/workflows/published-smoke.yml
@@ -232,7 +232,10 @@ jobs:
         run: |
           mkdir -p /tmp/ex && cd /tmp/ex
           fail=0
-          # host wrapper (hermes), vertical wrapper (devops), claude-code wrapper
+          # host wrapper (hermes), vertical wrapper (devops), claude-code wrapper.
+          # `.claude-plugin/plugin.json` is a Claude-Code artifact: only claude-code-
+          # host scaffolds emit it (GH #11 dropped it for non-claude hosts like
+          # hermes/rvm). So only assert plugin.json for the claude-code-host wrappers.
           for pkg in hermes devops claude-code; do
             echo ""
             echo "=== @metaharness/$pkg ==="
@@ -241,10 +244,17 @@ jobs:
               test -f "$pkg-bot/.harness/manifest.json" \
                 && echo "PASS @metaharness/$pkg — manifest present" \
                 || { echo "FAIL @metaharness/$pkg — no manifest"; fail=1; }
-              # iter-132 propagation: the scaffold must carry the plugin manifest
-              test -f "$pkg-bot/.claude-plugin/plugin.json" \
-                && echo "PASS @metaharness/$pkg — .claude-plugin/plugin.json present" \
-                || { echo "FAIL @metaharness/$pkg — no plugin.json"; fail=1; }
+              # plugin.json only for claude-code-host wrappers (devops + claude-code)
+              case "$pkg" in
+                hermes)
+                  test ! -f "$pkg-bot/.claude-plugin/plugin.json" \
+                    && echo "PASS @metaharness/$pkg — correctly no plugin.json (non-claude host, GH #11)" \
+                    || { echo "FAIL @metaharness/$pkg — unexpected plugin.json on non-claude host"; fail=1; } ;;
+                *)
+                  test -f "$pkg-bot/.claude-plugin/plugin.json" \
+                    && echo "PASS @metaharness/$pkg — .claude-plugin/plugin.json present" \
+                    || { echo "FAIL @metaharness/$pkg — no plugin.json"; fail=1; } ;;
+              esac
             else
               echo "FAIL @metaharness/$pkg — npx invocation errored"; fail=1
             fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -4114,7 +4114,7 @@
         "@metaharness/host-opencode": "0.1.0",
         "@metaharness/host-pi-dev": "0.1.0",
         "@metaharness/host-rvm": "0.1.0",
-        "@metaharness/kernel": "0.1.0",
+        "@metaharness/kernel": "^0.1.0",
         "@metaharness/router": "^0.2.0"
       },
       "devDependencies": {
@@ -4124,6 +4124,141 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-claude-code": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-claude-code/-/host-claude-code-0.1.0.tgz",
+      "integrity": "sha512-ZKrYpOZBfVgETHvF4c7yV41JSwdfZP/7YmkE/aT77Iz4M1pokaiLPI7frsY+wm6LNP92iRAlTcj81tiEB4VZng==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-codex": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-codex/-/host-codex-0.1.0.tgz",
+      "integrity": "sha512-iC2VyJwagbj/NhPdO2ExUsR0qYR6WPxrmFvi+xNP5+tICCm+q/bxXFBvftv62rTZ4Jk/ef2/N7VQXF0E8BXNuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-copilot": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-copilot/-/host-copilot-0.1.0.tgz",
+      "integrity": "sha512-ZP4j2x+ta5CKF/azRdme78kzwIq6Ks0V5VYTCsUn0thfi+/Um7ze4ecdoZDNCOvAu40GNy9IZBpFNUQ17rHQBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-github-actions": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-github-actions/-/host-github-actions-0.1.0.tgz",
+      "integrity": "sha512-wT2teZZFrLB3TiGFmNdkb+cfaOOgaOxdKVInbHDKsXAqfePOGIBtNVRqoNOqvrpeYujIQFd8+ag/PCoU5LI4ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-hermes": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-hermes/-/host-hermes-0.1.0.tgz",
+      "integrity": "sha512-1covE/WBVch+9YkA9l6CAPfzmF19gNIPvzw0AspmMPsyeoeJYVPfXtnsIz/2nZNoL9RSb3rrQhNhAN+9RvT70w==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-openclaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-openclaw/-/host-openclaw-0.1.0.tgz",
+      "integrity": "sha512-JMyuVEfEzzlNEeIxpMChwq7RYyT7ncOzpu0uZYDrUzGf+DE0eESchWnka0TJKOHPdGtxGE7DNptbiOq1JTPz+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-opencode": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-opencode/-/host-opencode-0.1.0.tgz",
+      "integrity": "sha512-s5gf3LBhLi2eN/iSrDULrfuWtm+gPu57MnUYyyfnvpawvOMfJmLn8TmPi0sJ1fBrecvHLGjYZCu2cWtJP38u0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-pi-dev": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-pi-dev/-/host-pi-dev-0.1.0.tgz",
+      "integrity": "sha512-O8RJaPlJUyVn39fqUu8MgErLXU5Bfho8poDrQPjFjkWJs0ZmQ91h0Ps42ooAtrh67Kd76u5SQTJV11Ci/GV1LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/host-rvm": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/host-rvm/-/host-rvm-0.1.0.tgz",
+      "integrity": "sha512-KgX1IrclsnwpG2cdw0VZdb5n22Xrc624TaEpcb+sZyQ07xkCKUeATT+ZOErNKi7nZuJwMv+JzGPDHpaUQjRwsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@metaharness/kernel": "0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "packages/bench/node_modules/@metaharness/kernel": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@metaharness/kernel/-/kernel-0.1.0.tgz",
+      "integrity": "sha512-KDrrdbtw39S3o8YS/r52k3GGQyX5LvQ78raaZ1NiHxAyApwWnLfVLX/66ZdzjUZwwU2xjUs/3GkrHgQXtOUtFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ruvector/emergent-time": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@metaharness/kernel-darwin-arm64": "0.1.0",
+        "@metaharness/kernel-darwin-x64": "0.1.0",
+        "@metaharness/kernel-linux-arm64-gnu": "0.1.0",
+        "@metaharness/kernel-linux-x64-gnu": "0.1.0",
+        "@metaharness/kernel-win32-x64-msvc": "0.1.0"
+      },
+      "peerDependencies": {
+        "@ruvector/rvf": "^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@ruvector/rvf": {
+          "optional": true
+        }
       }
     },
     "packages/bench/node_modules/@metaharness/router": {
@@ -4137,7 +4272,7 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.1.11",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "kolorist": "^1.8.0",
@@ -4160,7 +4295,7 @@
         "@ruvector/ruvllm": "^2.5.6"
       },
       "peerDependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "peerDependenciesMeta": {
         "@metaharness/kernel": {
@@ -4182,10 +4317,10 @@
     },
     "packages/host-claude-code": {
       "name": "@metaharness/host-claude-code",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4198,10 +4333,10 @@
     },
     "packages/host-codex": {
       "name": "@metaharness/host-codex",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4214,10 +4349,10 @@
     },
     "packages/host-copilot": {
       "name": "@metaharness/host-copilot",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4230,10 +4365,10 @@
     },
     "packages/host-github-actions": {
       "name": "@metaharness/host-github-actions",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4246,10 +4381,10 @@
     },
     "packages/host-hermes": {
       "name": "@metaharness/host-hermes",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4262,10 +4397,10 @@
     },
     "packages/host-openclaw": {
       "name": "@metaharness/host-openclaw",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4278,10 +4413,10 @@
     },
     "packages/host-opencode": {
       "name": "@metaharness/host-opencode",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4294,10 +4429,10 @@
     },
     "packages/host-pi-dev": {
       "name": "@metaharness/host-pi-dev",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4310,10 +4445,10 @@
     },
     "packages/host-rvm": {
       "name": "@metaharness/host-rvm",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4326,7 +4461,7 @@
     },
     "packages/kernel-js": {
       "name": "@metaharness/kernel",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@ruvector/emergent-time": "^0.1.0"
@@ -4376,7 +4511,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/kernel": "0.1.0"
+        "@metaharness/kernel": "^0.1.2"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -4405,7 +4540,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/vertical-base": "0.1.0"
+        "@metaharness/vertical-base": "^0.1.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -14,7 +14,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0",
+    "@metaharness/kernel": "^0.1.0",
     "@metaharness/host-claude-code": "0.1.0",
     "@metaharness/host-codex": "0.1.0",
     "@metaharness/host-pi-dev": "0.1.0",

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metaharness",
-  "version": "0.1.17",
-  "description": "MetaHarness — mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
+  "version": "0.1.18",
+  "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
     "type": "git",
@@ -99,7 +99,7 @@
     "prompts": "^2.4.2"
   },
   "peerDependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "peerDependenciesMeta": {
     "@metaharness/kernel": {

--- a/packages/host-claude-code/package.json
+++ b/packages/host-claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-claude-code",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Claude Code host adapter for agent-harness-generator (MCP + hooks + .claude/settings.json)",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-codex/package.json
+++ b/packages/host-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-codex",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenAI Codex CLI host adapter for agent-harness-generator (MCP via ~/.codex/config.toml)",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-copilot/package.json
+++ b/packages/host-copilot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-copilot",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GitHub Copilot (VSCode) host adapter for agent-harness-generator. Emits .vscode/mcp.json for the Copilot MCP client (ADR-032).",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-github-actions/package.json
+++ b/packages/host-github-actions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-github-actions",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "GitHub Actions host adapter for agent-harness-generator. Emits .github/workflows/<name>.yml + a composite action.yml for non-interactive CI/CD agent harnesses (ADR-033).",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -43,7 +43,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-hermes/package.json
+++ b/packages/host-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-hermes",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Hermes Agent (NousResearch) host adapter for agent-harness-generator (MCP + <think>/<tool_call> scrubbing)",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-openclaw/package.json
+++ b/packages/host-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-openclaw",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenClaw (personal AI assistant) host adapter for agent-harness-generator (MCP via ~/.openclaw/openclaw.json + workspace skills)",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -39,7 +39,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-opencode/package.json
+++ b/packages/host-opencode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-opencode",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "OpenCode (sst/opencode) host adapter for agent-harness-generator. Emits .opencode/opencode.json (ADR-036).",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -42,7 +42,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-pi-dev/package.json
+++ b/packages/host-pi-dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-pi-dev",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "pi.dev coding-agent host adapter for agent-harness-generator (Pi extension, no MCP by design)",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/packages/host-rvm/package.json
+++ b/packages/host-rvm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaharness/host-rvm",
-  "version": "0.1.1",
-  "description": "RVM (Agentic Virtual Machine) host adapter for agent-harness-generator — hardware-isolated deployment via capability tokens",
+  "version": "0.1.2",
+  "description": "RVM (Agentic Virtual Machine) host adapter for agent-harness-generator \u2014 hardware-isolated deployment via capability tokens",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
     "type": "git",
@@ -41,7 +41,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@metaharness/kernel": "0.1.0"
+    "@metaharness/kernel": "^0.1.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",


### PR DESCRIPTION
Bumping the workspace kernel to 0.1.2 broke `npm ci` (every internal consumer pinned kernel "0.1.0" exact) AND meant end-user scaffolds resolved the old js-only kernel 0.1.0 instead of the wasm 0.1.2 (host adapters pin exact 0.1.0). Fix: caret-range (`^0.1.0`) the kernel dep across bench, create-agent-harness (+peerOptional), and the 9 host adapters; regen lockfile (resolves clean). Bump hosts 0.1.1→0.1.2 + metaharness 0.1.18 to ship it. Also fixes published-smoke (don't require plugin.json on non-claude hosts, GH #11).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)