### PR TITLE
feat(poker-darwin): CFR/CFR+ poker solver + non-stationary Darwin (Chebyshev schedules)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/kernel-wasm",
     "crates/kernel-napi",
     "crates/template-catalog",
+    "crates/poker-darwin",
 ]
 resolver = "2"
 

--- a/crates/poker-darwin/Cargo.toml
+++ b/crates/poker-darwin/Cargo.toml
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: MIT
+#
+# poker-darwin — a poker trainer/solver built on three pillars:
+#   1. A CFR / CFR+ counterfactual-regret solver that converges to Nash on
+#      extensive-form poker games (Kuhn, Leduc), measured by *exact*
+#      exploitability — the real game-theoretic benchmark.
+#   2. Darwin Mode: an evolutionary search over the solver's policy genome
+#      (mirrors @metaharness/projects discovery-evolve — mutate structured
+#      policies, not prompts; fitness = -exploitability).
+#   3. Optional, feature-gated integrations:
+#        - `ruvector`  : ruvnet/ruvector vector DB for infoset state
+#                        abstraction + episodic experience memory.
+#        - `neural`    : candle Deep-CFR advantage network.
+#        - `realgames` : rs_poker real Texas Hold'em hand evaluation + equity.
+#
+# The default build is pure Rust (no heavy/native deps) so the workspace stays
+# fast and wasm-safe; the integrations are opt-in.
+[package]
+name = "poker-darwin"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Poker trainer/solver: CFR/CFR+ equilibrium solver, Darwin evolutionary policy tuning, ruvector state abstraction, candle Deep-CFR value net, rs_poker real-game benchmarking."
+keywords = ["poker", "cfr", "game-theory", "evolution", "darwin"]
+categories = ["algorithms", "science"]
+
+[lib]
+name = "poker_darwin"
+crate-type = ["lib"]
+
+[[bin]]
+name = "poker-darwin"
+path = "src/bin/poker-darwin.rs"
+
+[features]
+default = []
+# ruvnet/ruvector vector DB — infoset abstraction + experience memory.
+ruvector = ["dep:ruvector-core"]
+# candle Deep-CFR advantage network.
+neural = ["dep:candle-core", "dep:candle-nn"]
+# rs_poker real Texas Hold'em hand evaluation + Monte Carlo equity.
+realgames = ["dep:rs_poker"]
+# Everything on.
+full = ["ruvector", "neural", "realgames"]
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+ruvector-core = { version = "0.1.31", default-features = false, features = ["hnsw", "memory-only", "parallel"], optional = true }
+candle-core = { version = "0.8", optional = true }
+candle-nn = { version = "0.8", optional = true }
+rs_poker = { version = "5", optional = true }
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+[[bench]]
+name = "cfr_bench"
+harness = false

--- a/crates/poker-darwin/README.md
+++ b/crates/poker-darwin/README.md
@@ -1,0 +1,66 @@
+# poker-darwin
+
+A poker **trainer/solver** built on three pillars:
+
+1. **CFR / CFR+ / Linear / Discounted-CFR solver** — counterfactual regret
+   minimization that converges to a Nash equilibrium of two-player zero-sum
+   poker, measured by **exact exploitability** (the real game-theoretic
+   benchmark, not a sampled estimate).
+2. **Darwin Mode** — an evolutionary search over the solver's *policy genome*
+   (which regret/averaging variant, DCFR discount exponents), scored by
+   measured exploitability. The CFR algorithm stays frozen; the harness around
+   it **learns** the fastest-converging configuration from its own results.
+   This mirrors the `@metaharness/projects` `discovery-evolve` pattern —
+   *mutate structured policies, not prompts.*
+3. **Optional integrations** (feature-gated, off by default):
+   - `ruvector` — [`ruvnet/ruvector`](https://github.com/ruvnet/ruvector)
+     (`ruvector-core`) vector DB for information-set **state abstraction** and
+     episodic **experience memory**.
+   - `neural` — a [candle](https://github.com/huggingface/candle) MLP
+     **Deep-CFR advantage network**.
+   - `realgames` — [`rs_poker`](https://crates.io/crates/rs_poker) **real Texas
+     Hold'em** hand evaluation + Monte Carlo equity, for benchmarking against
+     full poker.
+
+## Games
+
+| Game | Info sets | Why |
+|------|-----------|-----|
+| Kuhn Poker | 12 | Known closed-form Nash; game value −1/18. Correctness proof. |
+| Leduc Hold'em | 288 | Two betting rounds, a public card, raises. Real convergence test. |
+
+## Quick start
+
+```bash
+# Solve Kuhn/Leduc and print the exploitability convergence curve (eval harness):
+cargo run -p poker-darwin -- solve --game leduc --iters 1000
+
+# Run Darwin self-learning: evolve the solver policy, show the learning curve:
+cargo run -p poker-darwin -- evolve --game leduc --generations 8
+
+# Real Texas Hold'em equity via rs_poker:
+cargo run -p poker-darwin --features realgames -- equity "AsKs" "QdQh"
+```
+
+## Library
+
+```rust
+use poker_darwin::{Solver, SolverConfig, KuhnPoker, exploitability};
+
+let mut s = Solver::new(KuhnPoker::new(), SolverConfig::default()); // CFR+
+s.train(1000);
+let avg = s.average_strategy();
+println!("exploitability = {:.5}", exploitability(s.game(), &avg));
+```
+
+## Tests & benchmarks
+
+- `cargo test -p poker-darwin` — Nash value of Kuhn (−1/18), exploitability
+  convergence, Darwin monotone learning + deterministic receipt.
+- `cargo bench -p poker-darwin` — CFR iteration throughput and exploitability
+  vs. iterations for Kuhn and Leduc.
+
+See the ADRs: `docs/adrs/ADR-186…188`.
+
+> Default build is pure Rust (no heavy/native deps) so it stays fast and
+> wasm-safe. The `ruvector` / `neural` / `realgames` integrations are opt-in.

--- a/crates/poker-darwin/benches/cfr_bench.rs
+++ b/crates/poker-darwin/benches/cfr_bench.rs
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+//
+// Criterion benchmarks: CFR iteration throughput (the inner loop that
+// dominates training cost) and one-shot exploitability evaluation (the cost the
+// Darwin fitness function pays per candidate). Run with `cargo bench -p
+// poker-darwin`.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use poker_darwin::cfr::{CfrVariant, Solver, SolverConfig};
+use poker_darwin::exploit::exploitability;
+use poker_darwin::games::{KuhnPoker, LeducHoldem};
+
+fn bench_cfr_iterations(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cfr_iterations");
+    for &(name, variant) in &[
+        ("vanilla", CfrVariant::Vanilla),
+        ("cfr+", CfrVariant::CfrPlus),
+        (
+            "dcfr",
+            CfrVariant::Dcfr {
+                alpha: 1.5,
+                beta: 0.0,
+                gamma: 2.0,
+            },
+        ),
+    ] {
+        group.bench_function(format!("kuhn/{name}/100it"), |b| {
+            b.iter_batched(
+                || Solver::new(KuhnPoker::new(), SolverConfig::new(variant)),
+                |mut s| s.train(100),
+                BatchSize::SmallInput,
+            )
+        });
+        group.bench_function(format!("leduc/{name}/20it"), |b| {
+            b.iter_batched(
+                || Solver::new(LeducHoldem::new(), SolverConfig::new(variant)),
+                |mut s| s.train(20),
+                BatchSize::SmallInput,
+            )
+        });
+    }
+    group.finish();
+}
+
+fn bench_exploitability(c: &mut Criterion) {
+    let mut group = c.benchmark_group("exploitability");
+
+    let mut kuhn = Solver::new(KuhnPoker::new(), SolverConfig::default());
+    kuhn.train(500);
+    let kuhn_avg = kuhn.average_strategy();
+    group.bench_function("kuhn", |b| {
+        b.iter(|| exploitability(&KuhnPoker::new(), &kuhn_avg))
+    });
+
+    let mut leduc = Solver::new(LeducHoldem::new(), SolverConfig::default());
+    leduc.train(100);
+    let leduc_avg = leduc.average_strategy();
+    group.bench_function("leduc", |b| {
+        b.iter(|| exploitability(&LeducHoldem::new(), &leduc_avg))
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_cfr_iterations, bench_exploitability);
+criterion_main!(benches);

--- a/crates/poker-darwin/src/abstraction.rs
+++ b/crates/poker-darwin/src/abstraction.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: MIT
+//
+// Information-set abstraction via ruvnet/ruvector (feature `ruvector`).
+//
+// Real poker has too many information sets to solve directly, so solvers group
+// strategically-similar situations into "buckets" and solve the abstraction.
+// This module featurizes each information set into a small vector and uses
+// `ruvector-core`'s vector database (HNSW nearest-neighbour) to (a) retrieve the
+// most similar information sets and (b) greedily cluster them into buckets,
+// reporting the compression ratio. The same vector store doubles as an episodic
+// memory of game situations (ruvector's stated use case).
+
+use crate::cfr::{Solver, SolverConfig};
+use crate::features::featurize;
+use crate::games::LeducHoldem;
+use ruvector_core::types::{DbOptions, DistanceMetric, SearchQuery, VectorEntry};
+use ruvector_core::VectorDB;
+
+/// A vector-DB-backed store of information sets for retrieval and clustering.
+pub struct InfosetAbstractor {
+    db: VectorDB,
+    dim: usize,
+    count: usize,
+}
+
+impl InfosetAbstractor {
+    pub fn new(dim: usize) -> Result<Self, String> {
+        let opts = DbOptions {
+            dimensions: dim,
+            distance_metric: DistanceMetric::Euclidean,
+            ..Default::default()
+        };
+        let db = VectorDB::new(opts).map_err(|e| format!("ruvector init: {e:?}"))?;
+        Ok(InfosetAbstractor { db, dim, count: 0 })
+    }
+
+    /// Store an information set under its key.
+    pub fn insert(&mut self, key: &str, feat: &[f32]) -> Result<(), String> {
+        assert_eq!(feat.len(), self.dim);
+        self.db
+            .insert(VectorEntry {
+                id: Some(key.to_string()),
+                vector: feat.to_vec(),
+                metadata: None,
+            })
+            .map_err(|e| format!("ruvector insert: {e:?}"))?;
+        self.count += 1;
+        Ok(())
+    }
+
+    /// Return up to `k` nearest stored information sets as `(key, distance)`,
+    /// nearest first (distance 0 = identical features).
+    pub fn nearest(&self, feat: &[f32], k: usize) -> Result<Vec<(String, f32)>, String> {
+        let res = self
+            .db
+            .search(SearchQuery {
+                vector: feat.to_vec(),
+                k,
+                filter: None,
+                ef_search: None,
+            })
+            .map_err(|e| format!("ruvector search: {e:?}"))?;
+        Ok(res.into_iter().map(|r| (r.id, r.score)).collect())
+    }
+
+    pub fn len(&self) -> usize {
+        self.count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.count == 0
+    }
+}
+
+/// Greedily cluster `(key, feature)` pairs into buckets: a key joins the nearest
+/// existing bucket centroid within `threshold`, else it starts a new bucket.
+/// Returns `(num_buckets, assignments)`.
+pub fn greedy_bucket(
+    items: &[(String, Vec<f32>)],
+    dim: usize,
+    threshold: f32,
+) -> Result<(usize, Vec<usize>), String> {
+    let mut centroids = InfosetAbstractor::new(dim)?;
+    let mut bucket_of: Vec<usize> = Vec::with_capacity(items.len());
+    let mut next_bucket = 0usize;
+    for (key, feat) in items {
+        let nearest = centroids.nearest(feat, 1)?;
+        match nearest.first() {
+            Some((bkey, dist)) if *dist <= threshold => {
+                // Bucket id is encoded in the centroid's stored key suffix.
+                let id: usize = bkey
+                    .rsplit('#')
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .unwrap_or(0);
+                bucket_of.push(id);
+            }
+            _ => {
+                centroids.insert(&format!("{key}#{next_bucket}"), feat)?;
+                bucket_of.push(next_bucket);
+                next_bucket += 1;
+            }
+        }
+    }
+    Ok((next_bucket, bucket_of))
+}
+
+/// CLI demo: solve Leduc, store every information set in ruvector, show a
+/// nearest-neighbour retrieval, and report bucket compression.
+pub fn demo(iters: u64, target_buckets: usize) {
+    println!("== ruvector information-set abstraction (Leduc, {iters} CFR+ iters) ==");
+    let mut solver = Solver::new(LeducHoldem::new(), SolverConfig::default());
+    solver.train(iters);
+    let avg = solver.average_strategy();
+
+    let dim = 7;
+    let mut items: Vec<(String, Vec<f32>)> =
+        avg.keys().map(|k| (k.clone(), featurize(k))).collect();
+    items.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Build a retrieval index and demo a query.
+    let mut abs = InfosetAbstractor::new(dim).expect("init");
+    for (k, f) in &items {
+        abs.insert(k, f).expect("insert");
+    }
+    println!(
+        "stored {} information sets in ruvector (dim={dim})",
+        abs.len()
+    );
+
+    if let Some((qk, qf)) = items
+        .iter()
+        .find(|(k, _)| k.starts_with("K|cr|"))
+        .or_else(|| items.first())
+    {
+        println!("\nnearest neighbours of infoset {qk:?}:");
+        for (k, d) in abs.nearest(qf, 5).expect("search") {
+            println!("   dist {d:>7.3}  {k}");
+        }
+    }
+
+    // Greedy bucketing: find the smallest threshold reaching <= target buckets.
+    println!("\nbucket compression (target ~{target_buckets}):");
+    for thr in [0.0_f32, 0.5, 1.0, 1.5, 2.0, 3.0] {
+        let (n, _) = greedy_bucket(&items, dim, thr).expect("bucket");
+        let ratio = 100.0 * (1.0 - n as f64 / items.len() as f64);
+        println!("   threshold {thr:>4.1} -> {n:>3} buckets  ({ratio:>5.1}% compression)");
+        if n <= target_buckets {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn featurize_distinguishes_card_and_board() {
+        let a = featurize("J|cr|Q|c");
+        let b = featurize("J|cr|K|c");
+        assert_ne!(a, b, "different board ranks must differ");
+        assert_eq!(a[0], 0.0); // card J
+        assert_eq!(a[1], 1.0); // has board
+    }
+
+    #[test]
+    fn abstractor_retrieves_identical_first() {
+        let mut abs = InfosetAbstractor::new(7).unwrap();
+        abs.insert("K|cr|Q|c", &featurize("K|cr|Q|c")).unwrap();
+        abs.insert("J|c|-|", &featurize("J|c|-|")).unwrap();
+        let q = featurize("K|cr|Q|c");
+        let near = abs.nearest(&q, 1).unwrap();
+        assert_eq!(near[0].0, "K|cr|Q|c");
+        assert!(
+            near[0].1 < 1e-3,
+            "identical features should have ~0 distance"
+        );
+    }
+
+    #[test]
+    fn greedy_bucket_compresses() {
+        let items: Vec<(String, Vec<f32>)> = ["J|c|-|", "J|cc|-|", "K|cr|Q|c", "K|cr|Q|cc"]
+            .iter()
+            .map(|k| (k.to_string(), featurize(k)))
+            .collect();
+        let (n, assign) = greedy_bucket(&items, 7, 2.0).unwrap();
+        assert!(n <= items.len());
+        assert_eq!(assign.len(), items.len());
+    }
+}

--- a/crates/poker-darwin/src/bin/poker-darwin.rs
+++ b/crates/poker-darwin/src/bin/poker-darwin.rs
@@ -1,0 +1,340 @@
+// SPDX-License-Identifier: MIT
+//
+// poker-darwin CLI — the eval harness. Subcommands:
+//   solve   : train a CFR solver and print the exploitability convergence curve
+//   evolve  : run Darwin Mode (evolve the solver policy) and print the learning curve
+//   exploit : train and report final exploitability + game value
+//   equity  : (feature `realgames`) real Texas Hold'em equity via rs_poker
+//   abstract: (feature `ruvector`) information-set abstraction via ruvector
+//   neural  : (feature `neural`) Deep-CFR advantage network via candle
+
+use poker_darwin::cfr::{CfrVariant, Solver, SolverConfig};
+use poker_darwin::darwin::{evolve, DarwinConfig};
+use poker_darwin::exploit::{exploitability, profile_value};
+use poker_darwin::game::Game;
+use poker_darwin::games::{KuhnPoker, LeducHoldem};
+use std::collections::HashMap;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cmd = args.first().map(String::as_str).unwrap_or("help");
+    let rest = &args.get(1..).unwrap_or(&[]).to_vec();
+    let flags = parse_flags(rest);
+
+    match cmd {
+        "solve" => cmd_solve(&flags),
+        "exploit" => cmd_exploit(&flags),
+        "evolve" => cmd_evolve(&flags),
+        "info" => cmd_info(&flags),
+        "equity" => cmd_equity(rest, &flags),
+        "abstract" => cmd_abstract(&flags),
+        "neural" => cmd_neural(&flags),
+        "help" | "-h" | "--help" => print_help(),
+        other => {
+            eprintln!("unknown command: {other}\n");
+            print_help();
+            std::process::exit(2);
+        }
+    }
+}
+
+// ---- shared helpers -------------------------------------------------------
+
+#[derive(Default)]
+struct Flags(HashMap<String, String>);
+
+impl Flags {
+    fn get(&self, k: &str) -> Option<&str> {
+        self.0.get(k).map(String::as_str)
+    }
+    fn str_or<'a>(&'a self, k: &str, d: &'a str) -> &'a str {
+        self.get(k).unwrap_or(d)
+    }
+    fn u64_or(&self, k: &str, d: u64) -> u64 {
+        self.get(k).and_then(|v| v.parse().ok()).unwrap_or(d)
+    }
+    fn usize_or(&self, k: &str, d: usize) -> usize {
+        self.get(k).and_then(|v| v.parse().ok()).unwrap_or(d)
+    }
+}
+
+fn parse_flags(args: &[String]) -> Flags {
+    let mut m = HashMap::new();
+    let mut i = 0;
+    while i < args.len() {
+        if let Some(name) = args[i].strip_prefix("--") {
+            let val = args.get(i + 1).filter(|v| !v.starts_with("--")).cloned();
+            if let Some(v) = val {
+                m.insert(name.to_string(), v);
+                i += 2;
+            } else {
+                m.insert(name.to_string(), "true".to_string());
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    Flags(m)
+}
+
+fn parse_variant(s: &str) -> CfrVariant {
+    match s {
+        "vanilla" => CfrVariant::Vanilla,
+        "linear" => CfrVariant::Linear,
+        "dcfr" => CfrVariant::Dcfr {
+            alpha: 1.5,
+            beta: 0.0,
+            gamma: 2.0,
+        },
+        _ => CfrVariant::CfrPlus,
+    }
+}
+
+// ---- solve / exploit ------------------------------------------------------
+
+fn cmd_solve(flags: &Flags) {
+    let iters = flags.u64_or("iters", 1000);
+    let every = flags.u64_or("every", (iters / 10).max(1));
+    let variant = parse_variant(flags.str_or("variant", "cfr+"));
+    match flags.str_or("game", "kuhn") {
+        "leduc" => solve_curve(LeducHoldem::new(), variant, iters, every),
+        _ => solve_curve(KuhnPoker::new(), variant, iters, every),
+    }
+}
+
+fn solve_curve<G: Game>(game: G, variant: CfrVariant, iters: u64, every: u64) {
+    println!(
+        "== solve {} | variant={} | {iters} iterations ==",
+        game.name(),
+        variant.tag()
+    );
+    println!(
+        "{:>10}  {:>14}  {:>14}",
+        "iters", "exploitability", "game value(p0)"
+    );
+    let mut solver = Solver::new(game, SolverConfig::new(variant));
+    let mut done = 0u64;
+    while done < iters {
+        let step = every.min(iters - done);
+        solver.train(step);
+        done += step;
+        let avg = solver.average_strategy();
+        let e = exploitability(solver.game(), &avg);
+        let v = profile_value(solver.game(), &avg);
+        println!("{done:>10}  {e:>14.6}  {v:>14.6}");
+    }
+    println!("infosets: {}", solver.num_infosets());
+}
+
+fn cmd_exploit(flags: &Flags) {
+    let iters = flags.u64_or("iters", 2000);
+    let variant = parse_variant(flags.str_or("variant", "cfr+"));
+    match flags.str_or("game", "kuhn") {
+        "leduc" => report_final(LeducHoldem::new(), variant, iters),
+        _ => report_final(KuhnPoker::new(), variant, iters),
+    }
+}
+
+fn report_final<G: Game>(game: G, variant: CfrVariant, iters: u64) {
+    let mut solver = Solver::new(game, SolverConfig::new(variant));
+    solver.train(iters);
+    let avg = solver.average_strategy();
+    println!(
+        "game={} variant={} iters={iters}",
+        solver.game().name(),
+        variant.tag()
+    );
+    println!(
+        "exploitability = {:.6}",
+        exploitability(solver.game(), &avg)
+    );
+    println!(
+        "game value (p0) = {:.6}",
+        profile_value(solver.game(), &avg)
+    );
+}
+
+// ---- info (environment / tree size) --------------------------------------
+
+fn cmd_info(flags: &Flags) {
+    match flags.str_or("game", "kuhn") {
+        "leduc" => print_info(LeducHoldem::new()),
+        "kuhn" => print_info(KuhnPoker::new()),
+        "all" => {
+            print_info(KuhnPoker::new());
+            println!();
+            print_info(LeducHoldem::new());
+        }
+        other => {
+            eprintln!("unknown game: {other} (use kuhn|leduc|all)");
+            std::process::exit(2);
+        }
+    }
+}
+
+fn print_info<G: Game>(game: G) {
+    let st = poker_darwin::game::tree_stats(&game);
+    println!("== environment: {} ==", game.name());
+    println!("  information sets : {}", st.infosets);
+    println!("  decision nodes   : {}", st.decision_nodes);
+    println!("  chance nodes     : {}", st.chance_nodes);
+    println!("  terminal leaves  : {}", st.terminal_nodes);
+    println!(
+        "  total histories  : {}",
+        st.decision_nodes + st.chance_nodes + st.terminal_nodes
+    );
+    println!("  max depth        : {}", st.max_depth);
+    println!("  utility unit     : chips (1 ante); exploitability reported in the same unit");
+}
+
+// ---- evolve (Darwin self-learning) ---------------------------------------
+
+fn cmd_evolve(flags: &Flags) {
+    let cfg = DarwinConfig {
+        population: flags.usize_or("population", 12),
+        generations: flags.usize_or("generations", 8),
+        eval_iterations: flags.u64_or("eval-iters", 200),
+        seed: flags.u64_or("seed", 0xC0FFEE),
+        elite: flags.usize_or("elite", 3),
+    };
+    match flags.str_or("game", "kuhn") {
+        "leduc" => run_evolve(LeducHoldem::new(), cfg),
+        _ => run_evolve(KuhnPoker::new(), cfg),
+    }
+}
+
+fn run_evolve<G: Game + Clone>(game: G, cfg: DarwinConfig) {
+    println!(
+        "== Darwin evolve {} | pop={} gens={} eval_iters={} seed={:#x} ==",
+        game.name(),
+        cfg.population,
+        cfg.generations,
+        cfg.eval_iterations,
+        cfg.seed
+    );
+    let report = evolve(&game, &cfg);
+    let h = cfg.eval_iterations;
+    println!(
+        "baseline (vanilla CFR @ {h} it): exploitability = {:.6}\n",
+        report.baseline_exploitability
+    );
+    println!("{:>4}  {:>14}  {:>14}  champion", "gen", "champ_exploit", "mean_exploit");
+    for g in &report.generations {
+        println!(
+            "{:>4}  {:>14.6}  {:>14.6}  {}",
+            g.index,
+            g.champion_exploitability,
+            g.mean_exploitability,
+            g.champion.label()
+        );
+    }
+    let improvement = if report.baseline_exploitability > 0.0 {
+        100.0 * (report.baseline_exploitability - report.champion_exploitability)
+            / report.baseline_exploitability
+    } else {
+        0.0
+    };
+    let dyn_edge = if report.best_static_exploitability > 0.0 {
+        100.0 * (report.best_static_exploitability - report.best_dynamic_exploitability)
+            / report.best_static_exploitability
+    } else {
+        0.0
+    };
+    println!("\nchampion         : {}", report.champion.label());
+    println!("  dynamic?       : {}", report.champion.is_dynamic());
+    println!("champion exploit : {:.6}", report.champion_exploitability);
+    println!("baseline exploit : {:.6}", report.baseline_exploitability);
+    println!("improvement      : {improvement:.1}% lower exploitability than vanilla");
+    println!("\n-- SOTA lever: best static vs best non-stationary genome --");
+    println!(
+        "best STATIC      : {:.6}",
+        report.best_static_exploitability
+    );
+    println!(
+        "best DYNAMIC     : {:.6}",
+        report.best_dynamic_exploitability
+    );
+    println!("dynamic edge     : {dyn_edge:.1}% lower exploitability than best static");
+    println!("\n-- champion lineage (seed -> champion) --");
+    for step in &report.champion_ancestry {
+        println!("   {step}");
+    }
+    println!("\nevaluated genomes: {}", report.lineage.len());
+    println!("receipt (fnv1a)  : {}", report.receipt);
+}
+
+// ---- feature-gated subcommands -------------------------------------------
+
+#[cfg(feature = "realgames")]
+fn cmd_equity(rest: &[String], flags: &Flags) {
+    // Positional hands are the leading args before any `--flag`.
+    let hands: Vec<String> = rest
+        .iter()
+        .take_while(|a| !a.starts_with("--"))
+        .cloned()
+        .collect();
+    if hands.len() < 2 {
+        eprintln!("usage: poker-darwin equity <hand1> <hand2> [...] [--iters N]");
+        eprintln!("example: poker-darwin equity AsKs QdQh --iters 100000");
+        std::process::exit(2);
+    }
+    let iters = flags.usize_or("iters", 100_000);
+    match poker_darwin::realgames::equity(&hands, iters) {
+        Ok(eq) => {
+            println!("== Texas Hold'em equity ({iters} Monte Carlo rollouts, rs_poker) ==");
+            for (h, e) in hands.iter().zip(eq) {
+                println!("  {h:>8} : {:.2}%", e * 100.0);
+            }
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[cfg(not(feature = "realgames"))]
+fn cmd_equity(_rest: &[String], _flags: &Flags) {
+    eprintln!("`equity` needs the `realgames` feature: cargo run -p poker-darwin --features realgames -- equity ...");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "ruvector")]
+fn cmd_abstract(flags: &Flags) {
+    let iters = flags.u64_or("iters", 1000);
+    let buckets = flags.usize_or("buckets", 8);
+    poker_darwin::abstraction::demo(iters, buckets);
+}
+
+#[cfg(not(feature = "ruvector"))]
+fn cmd_abstract(_flags: &Flags) {
+    eprintln!("`abstract` needs the `ruvector` feature: cargo run -p poker-darwin --features ruvector -- abstract ...");
+    std::process::exit(2);
+}
+
+#[cfg(feature = "neural")]
+fn cmd_neural(flags: &Flags) {
+    let epochs = flags.usize_or("epochs", 200);
+    poker_darwin::neural::demo(epochs);
+}
+
+#[cfg(not(feature = "neural"))]
+fn cmd_neural(_flags: &Flags) {
+    eprintln!("`neural` needs the `neural` feature: cargo run -p poker-darwin --features neural -- neural ...");
+    std::process::exit(2);
+}
+
+fn print_help() {
+    println!(
+        "poker-darwin — CFR poker solver + Darwin self-learning\n\n\
+         USAGE:\n\
+         \x20 poker-darwin info     --game <kuhn|leduc|all>                     (environment / tree size)\n\
+         \x20 poker-darwin solve    --game <kuhn|leduc> --iters N [--variant cfr+|vanilla|linear|dcfr] [--every K]\n\
+         \x20 poker-darwin exploit  --game <kuhn|leduc> --iters N [--variant ...]\n\
+         \x20 poker-darwin evolve   --game <kuhn|leduc> [--generations G --population P --eval-iters N --seed S]\n\
+         \x20 poker-darwin equity   <hand1> <hand2> [--iters N]            (needs --features realgames)\n\
+         \x20 poker-darwin abstract --game <kuhn|leduc> [--buckets B]      (needs --features ruvector)\n\
+         \x20 poker-darwin neural   [--epochs E]                           (needs --features neural)\n"
+    );
+}

--- a/crates/poker-darwin/src/cfr.rs
+++ b/crates/poker-darwin/src/cfr.rs
@@ -1,0 +1,604 @@
+// SPDX-License-Identifier: MIT
+//
+// Counterfactual Regret Minimization — the engine that actually *solves* poker.
+// Repeatedly traversing the game tree and minimizing per-information-set regret
+// drives the time-averaged strategy to a Nash equilibrium of a two-player
+// zero-sum game.
+//
+// This solver is deliberately *non-stationary*: its hyperparameters can vary
+// over the course of a solve, which is the lever Darwin uses to push past the
+// best static configuration (see ADR-187). It covers:
+//
+//   * Vanilla CFR / CFR+ / Linear CFR / static Discounted-CFR — the classics.
+//   * Time-variant DCFR schedules — α and β anneal from a `start` to an `end`
+//     exponent over the run, so the solver can blast through the early tree
+//     aggressively and stabilize near equilibrium.
+//   * Predictive (optimistic) regret matching — a momentum term ω extrapolates
+//     each information set's regret trend before choosing the next strategy,
+//     "skating to where the puck is going."
+//   * Regret-based pruning — actions whose cumulative regret falls below a
+//     threshold P (and carry zero probability) are skipped, trading a little
+//     exploitability-per-iteration for a lot of exploitability-per-second.
+//
+// IMPORTANT invariant: the strategy of an information set is computed **once per
+// iteration** and reused for every history that reaches it that iteration.
+// Recomputing it per-history silently corrupts convergence (it wrecks Leduc and
+// CFR+'s flooring amplifies it). The `cur_iter` cache enforces this.
+//
+// Chance and opponent reach are integrated *exactly* (no sampling), so the
+// average strategy this produces can be scored by the exact exploitability
+// oracle in `crate::exploit` — the convergence the tests assert is real.
+
+use crate::game::{regret_matching, Game};
+use std::collections::HashMap;
+
+/// Which regret/averaging scheme to run.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CfrVariant {
+    Vanilla,
+    CfrPlus,
+    Linear,
+    /// Discounted CFR with regret exponents (α, β) and strategy exponent γ.
+    Dcfr {
+        alpha: f64,
+        beta: f64,
+        gamma: f64,
+    },
+}
+
+impl CfrVariant {
+    /// A short tag for reports / receipts.
+    pub fn tag(&self) -> String {
+        match self {
+            CfrVariant::Vanilla => "vanilla".into(),
+            CfrVariant::CfrPlus => "cfr+".into(),
+            CfrVariant::Linear => "linear".into(),
+            CfrVariant::Dcfr { alpha, beta, gamma } => {
+                format!("dcfr(a={alpha:.2},b={beta:.2},g={gamma:.2})")
+            }
+        }
+    }
+}
+
+/// Maximum Chebyshev order a schedule can carry (≤ 8 is plenty for smooth,
+/// non-stationary trajectories — cyclic, warming, decaying, or volatile).
+pub const MAX_CHEB: usize = 8;
+
+/// A functional hyperparameter trajectory over the solve, represented as a
+/// shifted Chebyshev polynomial of the first kind. Normalized time
+/// `t̂ = 2·progress − 1 ∈ [−1, 1]` is fed to `Σ cᵢ·Tᵢ(t̂)`, evaluated with
+/// **Clenshaw's recurrence** (numerically stable — no `xⁿ` catastrophic
+/// cancellation) and clamped to `[lo, hi]` so mutation can never produce
+/// explosive values. Fixed-array storage keeps it `Copy` and zero-alloc.
+///
+/// Why Chebyshev over step-decay / piecewise-constant: a mutation of one
+/// coefficient yields a *smooth, global-or-localized* deformation of the curve
+/// rather than a discontinuous spike, so the evolutionary search moves through a
+/// well-behaved trajectory space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Schedule {
+    coeffs: [f64; MAX_CHEB],
+    n: usize,
+    lo: f64,
+    hi: f64,
+}
+
+impl Schedule {
+    /// A constant trajectory (unbounded).
+    pub fn constant(v: f64) -> Self {
+        let mut coeffs = [0.0; MAX_CHEB];
+        coeffs[0] = v;
+        Schedule {
+            coeffs,
+            n: 1,
+            lo: f64::NEG_INFINITY,
+            hi: f64::INFINITY,
+        }
+    }
+
+    /// A linear ramp from `start` (t=0) to `end` (t=horizon), as the order-1
+    /// Chebyshev `a₀ + a₁·t̂`.
+    pub fn linear(start: f64, end: f64) -> Self {
+        let mut coeffs = [0.0; MAX_CHEB];
+        coeffs[0] = 0.5 * (start + end);
+        coeffs[1] = 0.5 * (end - start);
+        Schedule {
+            coeffs,
+            n: 2,
+            lo: start.min(end),
+            hi: start.max(end),
+        }
+    }
+
+    /// An arbitrary Chebyshev trajectory with output clamped to `[lo, hi]`.
+    pub fn chebyshev(coeffs: &[f64], lo: f64, hi: f64) -> Self {
+        let mut c = [0.0; MAX_CHEB];
+        let n = coeffs.len().min(MAX_CHEB);
+        c[..n].copy_from_slice(&coeffs[..n]);
+        Schedule {
+            coeffs: c,
+            n: n.max(1),
+            lo,
+            hi,
+        }
+    }
+
+    /// Clenshaw's recurrence for `Σ cᵢ·Tᵢ(x)`.
+    #[inline]
+    fn clenshaw(&self, x: f64) -> f64 {
+        let c = &self.coeffs[..self.n];
+        if c.len() == 1 {
+            return c[0];
+        }
+        let x2 = 2.0 * x;
+        let (mut b2, mut b1) = (0.0, 0.0);
+        for &ci in c.iter().skip(1).rev() {
+            let b = ci + x2 * b1 - b2;
+            b2 = b1;
+            b1 = b;
+        }
+        c[0] + x * b1 - b2
+    }
+
+    /// Value at iteration `t` of `horizon` total, clamped to `[lo, hi]`.
+    /// `horizon == 0` ⇒ value at the start of the trajectory.
+    #[inline]
+    pub fn at(&self, t: u64, horizon: u64) -> f64 {
+        let progress = if horizon == 0 {
+            0.0
+        } else {
+            (t as f64 / horizon as f64).min(1.0)
+        };
+        let x = 2.0 * progress - 1.0;
+        self.clenshaw(x).clamp(self.lo, self.hi)
+    }
+}
+
+/// Solver configuration — the tunable surface Darwin mutates. The classic
+/// variants leave the dynamic levers off; the non-stationary "dynamic DCFR"
+/// genome turns them on.
+#[derive(Clone, Copy, Debug)]
+pub struct SolverConfig {
+    pub variant: CfrVariant,
+    /// Time-variant schedule for the DCFR α exponent (overrides the static α
+    /// in `variant` when `Some` and `variant` is `Dcfr`).
+    pub alpha_schedule: Option<Schedule>,
+    /// Time-variant schedule for the DCFR β exponent.
+    pub beta_schedule: Option<Schedule>,
+    /// Predictive-regret momentum (0 = off): strategy uses
+    /// `regret + omega * last_instant_regret`. Scalar fallback for `omega_schedule`.
+    pub omega: f64,
+    /// Time-variant momentum trajectory (overrides `omega` when `Some`).
+    pub omega_schedule: Option<Schedule>,
+    /// Regret-pruning threshold (NEG_INFINITY = off): zero-probability actions
+    /// with cumulative regret below this are skipped. Scalar fallback for
+    /// `prune_schedule`.
+    pub prune: f64,
+    /// Time-variant pruning-threshold trajectory (overrides `prune` when `Some`).
+    pub prune_schedule: Option<Schedule>,
+    /// Planned total iterations, used to position the schedules.
+    pub horizon: u64,
+}
+
+impl SolverConfig {
+    pub fn new(variant: CfrVariant) -> Self {
+        SolverConfig {
+            variant,
+            alpha_schedule: None,
+            beta_schedule: None,
+            omega: 0.0,
+            omega_schedule: None,
+            prune: f64::NEG_INFINITY,
+            prune_schedule: None,
+            horizon: 0,
+        }
+    }
+
+    /// Effective momentum weight at iteration `t`.
+    #[inline]
+    pub fn omega_at(&self, t: u64) -> f64 {
+        self.omega_schedule
+            .map(|s| s.at(t, self.horizon))
+            .unwrap_or(self.omega)
+    }
+
+    /// Effective pruning threshold at iteration `t`.
+    #[inline]
+    pub fn prune_at(&self, t: u64) -> f64 {
+        self.prune_schedule
+            .map(|s| s.at(t, self.horizon))
+            .unwrap_or(self.prune)
+    }
+
+    /// Whether this config ever uses predictive momentum.
+    #[inline]
+    pub fn uses_momentum(&self) -> bool {
+        self.omega != 0.0 || self.omega_schedule.is_some()
+    }
+
+    /// True if any non-stationary lever is engaged.
+    pub fn is_dynamic(&self) -> bool {
+        self.alpha_schedule.is_some()
+            || self.beta_schedule.is_some()
+            || self.uses_momentum()
+            || self.prune.is_finite()
+            || self.prune_schedule.is_some()
+    }
+}
+
+impl Default for SolverConfig {
+    fn default() -> Self {
+        // CFR+ is the sensible, fast default.
+        SolverConfig::new(CfrVariant::CfrPlus)
+    }
+}
+
+/// Per-solve compute accounting (for exploitability-per-second comparisons).
+#[derive(Default, Clone, Copy, Debug)]
+pub struct SolveStats {
+    pub action_visits: u64,
+    pub pruned_visits: u64,
+}
+
+impl SolveStats {
+    pub fn prune_rate(&self) -> f64 {
+        if self.action_visits == 0 {
+            0.0
+        } else {
+            self.pruned_visits as f64 / self.action_visits as f64
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Node {
+    regret_sum: Vec<f64>,
+    strategy_sum: Vec<f64>,
+    /// Strategy for the current iteration (computed once, reused per history).
+    cur_strategy: Vec<f64>,
+    /// This iteration's accumulated instantaneous regret (momentum source).
+    this_instant: Vec<f64>,
+    /// Previous iteration's instantaneous regret (the prediction).
+    last_instant: Vec<f64>,
+    /// Iteration `cur_strategy` was computed for; gates per-iteration work.
+    cur_iter: u64,
+}
+
+impl Node {
+    fn new(n: usize) -> Self {
+        Node {
+            regret_sum: vec![0.0; n],
+            strategy_sum: vec![0.0; n],
+            cur_strategy: vec![1.0 / n as f64; n],
+            this_instant: vec![0.0; n],
+            last_instant: vec![0.0; n],
+            cur_iter: 0,
+        }
+    }
+}
+
+/// A trained (or in-training) CFR solver over a specific game.
+pub struct Solver<G: Game> {
+    game: G,
+    config: SolverConfig,
+    table: HashMap<String, Node>,
+    iterations: u64,
+    stats: SolveStats,
+}
+
+impl<G: Game> Solver<G> {
+    pub fn new(game: G, config: SolverConfig) -> Self {
+        Solver {
+            game,
+            config,
+            table: HashMap::new(),
+            iterations: 0,
+            stats: SolveStats::default(),
+        }
+    }
+
+    pub fn game(&self) -> &G {
+        &self.game
+    }
+
+    pub fn iterations(&self) -> u64 {
+        self.iterations
+    }
+
+    pub fn stats(&self) -> SolveStats {
+        self.stats
+    }
+
+    /// Run `iters` CFR iterations (each iteration traverses the tree once per
+    /// player — alternating updates). Can be called repeatedly to continue.
+    pub fn train(&mut self, iters: u64) {
+        let root = self.game.root();
+        for _ in 0..iters {
+            self.iterations += 1;
+            let t = self.iterations;
+            for traverser in 0..2usize {
+                cfr_rec(
+                    &self.game,
+                    &mut self.table,
+                    &self.config,
+                    &mut self.stats,
+                    &root,
+                    [1.0, 1.0, 1.0],
+                    traverser,
+                    t,
+                );
+            }
+        }
+    }
+
+    /// The time-averaged strategy (the object that converges to Nash):
+    /// `infoset_key -> probability per legal action`.
+    pub fn average_strategy(&self) -> HashMap<String, Vec<f64>> {
+        let mut out = HashMap::with_capacity(self.table.len());
+        for (k, node) in &self.table {
+            let sum: f64 = node.strategy_sum.iter().sum();
+            let probs = if sum > 0.0 {
+                node.strategy_sum.iter().map(|x| x / sum).collect()
+            } else {
+                vec![1.0 / node.strategy_sum.len() as f64; node.strategy_sum.len()]
+            };
+            out.insert(k.clone(), probs);
+        }
+        out
+    }
+
+    /// Number of information sets discovered.
+    pub fn num_infosets(&self) -> usize {
+        self.table.len()
+    }
+}
+
+/// Once-per-iteration node preparation: roll the momentum window, apply the
+/// (possibly time-variant) DCFR discount, then compute this iteration's
+/// strategy with predictive momentum. Idempotent within an iteration.
+fn prepare_node(node: &mut Node, cfg: &SolverConfig, t: u64) {
+    if node.cur_iter == t {
+        return;
+    }
+    let momentum = cfg.uses_momentum();
+    // Roll momentum: last iteration's instantaneous regret becomes the prediction.
+    if momentum {
+        node.last_instant.copy_from_slice(&node.this_instant);
+    }
+    for v in &mut node.this_instant {
+        *v = 0.0;
+    }
+
+    if let CfrVariant::Dcfr { alpha, beta, gamma } = cfg.variant {
+        let tf = t as f64;
+        // Effective exponents: scheduled if present, else the static value.
+        let a = cfg
+            .alpha_schedule
+            .map(|s| s.at(t, cfg.horizon))
+            .unwrap_or(alpha);
+        let b = cfg
+            .beta_schedule
+            .map(|s| s.at(t, cfg.horizon))
+            .unwrap_or(beta);
+        let pos = tf.powf(a) / (tf.powf(a) + 1.0);
+        let neg = tf.powf(b) / (tf.powf(b) + 1.0);
+        for r in &mut node.regret_sum {
+            *r *= if *r > 0.0 { pos } else { neg };
+        }
+        if t > 1 {
+            let sfac = ((tf - 1.0) / tf).powf(gamma);
+            for s in &mut node.strategy_sum {
+                *s *= sfac;
+            }
+        }
+    }
+
+    // Predictive (optimistic) regret matching: extrapolate the regret trend.
+    if momentum {
+        let omega = cfg.omega_at(t);
+        let predicted: Vec<f64> = node
+            .regret_sum
+            .iter()
+            .zip(&node.last_instant)
+            .map(|(r, d)| r + omega * d)
+            .collect();
+        regret_matching(&predicted, &mut node.cur_strategy);
+    } else {
+        regret_matching(&node.regret_sum, &mut node.cur_strategy);
+    }
+    node.cur_iter = t;
+}
+
+#[inline]
+fn regret_contrib_weight(cfg: &SolverConfig, t: u64) -> f64 {
+    match cfg.variant {
+        CfrVariant::Linear => t as f64,
+        _ => 1.0,
+    }
+}
+
+#[inline]
+fn strategy_contrib_weight(cfg: &SolverConfig, t: u64) -> f64 {
+    match cfg.variant {
+        CfrVariant::CfrPlus | CfrVariant::Linear => t as f64,
+        _ => 1.0,
+    }
+}
+
+/// The CFR recursion. `reach = [reach_p0, reach_p1, reach_chance]`. Returns the
+/// expected utility of the subtree to `traverser`.
+#[allow(clippy::too_many_arguments)]
+fn cfr_rec<G: Game>(
+    game: &G,
+    table: &mut HashMap<String, Node>,
+    cfg: &SolverConfig,
+    stats: &mut SolveStats,
+    s: &G::State,
+    reach: [f64; 3],
+    traverser: usize,
+    t: u64,
+) -> f64 {
+    if game.is_terminal(s) {
+        return game.payoff(s, traverser);
+    }
+    if game.is_chance(s) {
+        let mut v = 0.0;
+        for (a, p) in game.chance_outcomes(s) {
+            let child = game.apply(s, a);
+            let mut r = reach;
+            r[2] *= p;
+            v += p * cfr_rec(game, table, cfg, stats, &child, r, traverser, t);
+        }
+        return v;
+    }
+
+    let player = game.current_player(s);
+    let actions = game.legal_actions(s);
+    let n = actions.len();
+    let key = game.infoset_key(s);
+
+    // Fetch/prepare the node: exactly one strategy per infoset per iteration.
+    let (sigma, regret_snapshot) = {
+        let node = table.entry(key.clone()).or_insert_with(|| Node::new(n));
+        debug_assert_eq!(node.regret_sum.len(), n, "infoset {key} action-count drift");
+        prepare_node(node, cfg, t);
+        (node.cur_strategy.clone(), node.regret_sum.clone())
+    };
+
+    if player == traverser {
+        let prune_thresh = cfg.prune_at(t);
+        let prune_on = prune_thresh.is_finite();
+        let mut util = vec![0.0; n];
+        let mut pruned = vec![false; n];
+        let mut node_util = 0.0;
+        for (i, &a) in actions.iter().enumerate() {
+            stats.action_visits += 1;
+            // Regret-based pruning: skip zero-probability, deeply-negative actions.
+            if prune_on && sigma[i] == 0.0 && regret_snapshot[i] < prune_thresh {
+                pruned[i] = true;
+                stats.pruned_visits += 1;
+                continue;
+            }
+            let child = game.apply(s, a);
+            let mut r = reach;
+            r[player] *= sigma[i];
+            util[i] = cfr_rec(game, table, cfg, stats, &child, r, traverser, t);
+            node_util += sigma[i] * util[i];
+        }
+        // Counterfactual reach = everyone *but* the traverser (opponent × chance).
+        let cf = reach[1 - player] * reach[2];
+        let rc = regret_contrib_weight(cfg, t);
+        let sc = strategy_contrib_weight(cfg, t);
+        let own_reach = reach[player];
+        let floor = matches!(cfg.variant, CfrVariant::CfrPlus);
+        let momentum = cfg.uses_momentum();
+
+        let node = table.get_mut(&key).expect("node present");
+        for i in 0..n {
+            if pruned[i] {
+                continue; // leave regret unchanged so it can re-enter later
+            }
+            let inc = rc * cf * (util[i] - node_util);
+            node.regret_sum[i] += inc;
+            if floor && node.regret_sum[i] < 0.0 {
+                node.regret_sum[i] = 0.0; // regret-matching+ : floor on every update
+            }
+            if momentum {
+                node.this_instant[i] += inc;
+            }
+            node.strategy_sum[i] += sc * own_reach * sigma[i];
+        }
+        node_util
+    } else {
+        // Opponent node: weight children by the opponent's current strategy.
+        let mut node_util = 0.0;
+        for (i, &a) in actions.iter().enumerate() {
+            let child = game.apply(s, a);
+            let mut r = reach;
+            r[player] *= sigma[i];
+            node_util += sigma[i] * cfr_rec(game, table, cfg, stats, &child, r, traverser, t);
+        }
+        node_util
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::games::KuhnPoker;
+
+    #[test]
+    fn average_strategy_rows_are_distributions() {
+        let mut solver = Solver::new(KuhnPoker::new(), SolverConfig::default());
+        solver.train(200);
+        let avg = solver.average_strategy();
+        assert_eq!(avg.len(), 12); // Kuhn has 12 infosets
+        for (k, probs) in avg {
+            let s: f64 = probs.iter().sum();
+            assert!((s - 1.0).abs() < 1e-9, "{k} not normalised: {probs:?}");
+            assert!(probs.iter().all(|&p| p >= 0.0));
+        }
+    }
+
+    #[test]
+    fn linear_schedule_anneals_start_to_end() {
+        let s = Schedule::linear(4.0, 1.0);
+        assert!((s.at(0, 100) - 4.0).abs() < 1e-9);
+        assert!((s.at(100, 100) - 1.0).abs() < 1e-9);
+        let mid = s.at(50, 100);
+        assert!(
+            (mid - 2.5).abs() < 1e-9,
+            "linear midpoint should be 2.5, got {mid}"
+        );
+    }
+
+    #[test]
+    fn clenshaw_matches_explicit_chebyshev() {
+        // T0=1, T1=x, T2=2x²−1, T3=4x³−3x. Check Σ cᵢTᵢ at a few points.
+        let c = [0.3, -0.5, 0.2, 0.1];
+        let s = Schedule::chebyshev(&c, f64::NEG_INFINITY, f64::INFINITY);
+        for &x in &[-1.0, -0.4, 0.0, 0.7, 1.0] {
+            let t0 = 1.0;
+            let t1 = x;
+            let t2 = 2.0 * x * x - 1.0;
+            let t3 = 4.0 * x * x * x - 3.0 * x;
+            let expected = c[0] * t0 + c[1] * t1 + c[2] * t2 + c[3] * t3;
+            // map x back into at(): x = 2p-1 => p=(x+1)/2 => t = p*horizon
+            let horizon = 1000u64;
+            let t = (((x + 1.0) / 2.0) * horizon as f64).round() as u64;
+            let got = s.at(t, horizon);
+            assert!(
+                (got - expected).abs() < 1e-6,
+                "x={x}: clenshaw {got} vs explicit {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn schedule_clamps_to_bounds() {
+        let s = Schedule::chebyshev(&[0.0, 100.0], 1.0, 4.0); // huge slope, tight bounds
+        assert_eq!(s.at(1000, 1000), 4.0);
+        assert_eq!(s.at(0, 1000), 1.0);
+    }
+
+    #[test]
+    fn momentum_and_pruning_schedules_keep_convergence() {
+        // A fully dynamic config (scheduled α/ω/P) must still reduce exploitability.
+        let mut cfg = SolverConfig::new(CfrVariant::Dcfr {
+            alpha: 2.0,
+            beta: 0.0,
+            gamma: 2.0,
+        });
+        cfg.alpha_schedule = Some(Schedule::chebyshev(&[2.5, -1.0], 1.0, 4.0));
+        cfg.omega_schedule = Some(Schedule::chebyshev(&[0.5], 0.0, 2.0));
+        cfg.prune_schedule = Some(Schedule::chebyshev(&[-10.0], -30.0, -1.0));
+        cfg.horizon = 500;
+        let mut solver = Solver::new(KuhnPoker::new(), cfg);
+        solver.train(500);
+        let e = crate::exploit::exploitability(solver.game(), &solver.average_strategy());
+        assert!(
+            e < 0.02,
+            "dynamic (Chebyshev) solver should converge on Kuhn: {e}"
+        );
+    }
+}

--- a/crates/poker-darwin/src/darwin.rs
+++ b/crates/poker-darwin/src/darwin.rs
@@ -1,0 +1,682 @@
+// SPDX-License-Identifier: MIT
+//
+// Darwin Mode for poker solving. This mirrors the @metaharness/projects
+// `discovery-evolve` pattern (ADR-119/137/165): evolve a *structured policy
+// genome*, never a prompt. Here the genome is the CFR solver's configuration.
+//
+// ADR-187 pushes this past the best *static* configuration by giving Darwin the
+// architectural levers to build a NON-STATIONARY solver — the genome can emit
+// functional schedules, not just scalars:
+//
+//   * Time-variant DCFR schedules (α/β anneal start → end with a decay rate).
+//   * Predictive-regret momentum ω (optimistic regret matching).
+//   * Regret-pruning threshold P (skip dominated branches; speed lever).
+//
+// The CFR algorithm stays frozen; the *harness around it* learns, from its own
+// measured exploitability, a dynamic solver schedule that beats any fixed one.
+
+use crate::cfr::{CfrVariant, Schedule, Solver, SolverConfig};
+use crate::exploit::exploitability;
+use crate::game::Game;
+use crate::rng::Rng;
+use std::collections::HashMap;
+
+/// The evolvable policy genome. `kind` selects the family; the remaining genes
+/// are the static DCFR exponents, the dynamic α/β schedule endpoints + decay,
+/// the momentum weight, and the pruning threshold. Genes not used by a given
+/// `kind` are still carried so mutation can switch family with sane values.
+/// Order of the Chebyshev trajectories evolved by the kind-5 genome.
+pub const CHEB_ORDER: usize = 4;
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Genome {
+    /// 0 Vanilla, 1 CFR+, 2 Linear, 3 static DCFR, 4 linear-dynamic DCFR,
+    /// 5 Chebyshev-dynamic DCFR (the SOTA functional-schedule family).
+    pub kind: u8,
+    // Static DCFR exponents (and the strategy exponent γ, shared by dynamic).
+    pub alpha: f64,
+    pub beta: f64,
+    pub gamma: f64,
+    // Linear-dynamic α/β annealing schedule (kind 4).
+    pub alpha_start: f64,
+    pub alpha_end: f64,
+    pub beta_start: f64,
+    pub beta_end: f64,
+    pub decay: f64,
+    // Predictive momentum + pruning scalars (kind 4).
+    pub omega: f64,
+    pub prune: f64,
+    // Chebyshev trajectory coefficients (kind 5): the value (α), momentum (ω),
+    // and pruning (P) curves. β stays the scalar `beta`, γ the scalar `gamma`.
+    pub alpha_cheb: [f64; CHEB_ORDER],
+    pub omega_cheb: [f64; CHEB_ORDER],
+    pub prune_cheb: [f64; CHEB_ORDER],
+}
+
+const KINDS: u8 = 6;
+// Output bounds for the Chebyshev curves (mutation can never exceed these).
+const ALPHA_BOUNDS: (f64, f64) = (0.5, 5.0);
+const OMEGA_BOUNDS: (f64, f64) = (0.0, 2.5);
+const PRUNE_BOUNDS: (f64, f64) = (-30.0, -1.0);
+
+impl Default for Genome {
+    fn default() -> Self {
+        // CFR+ with canonical DCFR seeds ready for mutation.
+        Genome {
+            kind: 1,
+            alpha: 1.5,
+            beta: 0.0,
+            gamma: 2.0,
+            alpha_start: 4.0,
+            alpha_end: 1.0,
+            beta_start: 0.0,
+            beta_end: -1.0,
+            decay: 4.0,
+            omega: 0.5,
+            prune: -12.0,
+            // α: ~ linear 4→1 (a₀=2.5, a₁=−1.5); ω: constant 0.6; P: constant −12.
+            alpha_cheb: [2.5, -1.5, 0.0, 0.0],
+            omega_cheb: [0.6, 0.0, 0.0, 0.0],
+            prune_cheb: [-12.0, 0.0, 0.0, 0.0],
+        }
+    }
+}
+
+fn clamp(x: f64, lo: f64, hi: f64) -> f64 {
+    x.max(lo).min(hi)
+}
+
+impl Genome {
+    /// The naive baseline: vanilla CFR.
+    pub fn vanilla() -> Self {
+        Genome {
+            kind: 0,
+            ..Genome::default()
+        }
+    }
+
+    /// A strong static DCFR seed (near the previously-evolved static champion).
+    pub fn static_dcfr() -> Self {
+        Genome {
+            kind: 3,
+            alpha: 2.75,
+            beta: -0.48,
+            gamma: 2.0,
+            ..Genome::default()
+        }
+    }
+
+    /// A linear-dynamic-DCFR seed: aggressive early α annealing toward CFR+
+    /// levels, modest momentum, light pruning — the ADR-187 hypothesis.
+    pub fn dynamic_seed() -> Self {
+        Genome {
+            kind: 4,
+            ..Genome::default()
+        }
+    }
+
+    /// A Chebyshev-dynamic seed: the SOTA functional-schedule family (ADR-188).
+    pub fn cheb_seed() -> Self {
+        Genome {
+            kind: 5,
+            ..Genome::default()
+        }
+    }
+
+    /// A random genome (seeds population diversity).
+    pub fn random(rng: &mut Rng) -> Self {
+        let cheb = |lo: f64, hi: f64, rng: &mut Rng| {
+            // First coefficient near the band centre, higher orders small.
+            let mut c = [0.0; CHEB_ORDER];
+            c[0] = rng.range_f64(lo, hi);
+            for ci in c.iter_mut().skip(1) {
+                *ci = rng.range_f64(-0.8, 0.8);
+            }
+            c
+        };
+        Genome {
+            kind: rng.below(KINDS as usize) as u8,
+            alpha: rng.range_f64(0.0, 3.0),
+            beta: rng.range_f64(-3.0, 3.0),
+            gamma: rng.range_f64(0.0, 4.0),
+            alpha_start: rng.range_f64(1.0, 5.0),
+            alpha_end: rng.range_f64(0.5, 2.0),
+            beta_start: rng.range_f64(-2.0, 2.0),
+            beta_end: rng.range_f64(-3.0, 1.0),
+            decay: rng.range_f64(0.5, 8.0),
+            omega: rng.range_f64(0.0, 2.0),
+            prune: rng.range_f64(-25.0, -2.0),
+            alpha_cheb: cheb(1.0, 4.0, rng),
+            omega_cheb: cheb(0.0, 1.5, rng),
+            prune_cheb: cheb(-20.0, -4.0, rng),
+        }
+    }
+
+    /// True if this genome engages any non-stationary lever (kinds 4 and 5).
+    pub fn is_dynamic(&self) -> bool {
+        matches!(self.kind % KINDS, 4 | 5)
+    }
+
+    /// Translate to a concrete solver configuration for a run of `horizon`
+    /// iterations (the schedules anneal over that horizon).
+    pub fn to_config(&self, horizon: u64) -> SolverConfig {
+        match self.kind % KINDS {
+            0 => SolverConfig::new(CfrVariant::Vanilla),
+            1 => SolverConfig::new(CfrVariant::CfrPlus),
+            2 => SolverConfig::new(CfrVariant::Linear),
+            3 => SolverConfig::new(CfrVariant::Dcfr {
+                alpha: self.alpha,
+                beta: self.beta,
+                gamma: self.gamma,
+            }),
+            4 => {
+                // Linear-dynamic: α and β ramp from start to end over the run.
+                let mut c = SolverConfig::new(CfrVariant::Dcfr {
+                    alpha: self.alpha_start,
+                    beta: self.beta_start,
+                    gamma: self.gamma,
+                });
+                c.alpha_schedule = Some(Schedule::linear(self.alpha_start, self.alpha_end));
+                c.beta_schedule = Some(Schedule::linear(self.beta_start, self.beta_end));
+                c.omega = self.omega;
+                c.prune = self.prune;
+                c.horizon = horizon;
+                c
+            }
+            _ => {
+                // Chebyshev-dynamic: arbitrary smooth α / ω / P trajectories.
+                let mut c = SolverConfig::new(CfrVariant::Dcfr {
+                    alpha: 1.5,
+                    beta: self.beta,
+                    gamma: self.gamma,
+                });
+                c.alpha_schedule = Some(Schedule::chebyshev(
+                    &self.alpha_cheb,
+                    ALPHA_BOUNDS.0,
+                    ALPHA_BOUNDS.1,
+                ));
+                c.beta_schedule = Some(Schedule::linear(self.beta_start, self.beta_end));
+                c.omega_schedule = Some(Schedule::chebyshev(
+                    &self.omega_cheb,
+                    OMEGA_BOUNDS.0,
+                    OMEGA_BOUNDS.1,
+                ));
+                c.prune_schedule = Some(Schedule::chebyshev(
+                    &self.prune_cheb,
+                    PRUNE_BOUNDS.0,
+                    PRUNE_BOUNDS.1,
+                ));
+                c.horizon = horizon;
+                c
+            }
+        }
+    }
+
+    /// A stable behaviour key for caching evaluations.
+    pub fn key(&self) -> String {
+        let fmt = |a: &[f64; CHEB_ORDER]| {
+            a.iter()
+                .map(|v| format!("{v:.2}"))
+                .collect::<Vec<_>>()
+                .join(",")
+        };
+        match self.kind % KINDS {
+            0..=3 => self.to_config(0).variant.tag(),
+            4 => format!(
+                "lin(a={:.2}->{:.2},b={:.2}->{:.2},g={:.2},w={:.2},p={:.1})",
+                self.alpha_start,
+                self.alpha_end,
+                self.beta_start,
+                self.beta_end,
+                self.gamma,
+                self.omega,
+                self.prune
+            ),
+            _ => format!(
+                "cheb(a=[{}],w=[{}],p=[{}],b={:.2}->{:.2},g={:.2})",
+                fmt(&self.alpha_cheb),
+                fmt(&self.omega_cheb),
+                fmt(&self.prune_cheb),
+                self.beta_start,
+                self.beta_end,
+                self.gamma
+            ),
+        }
+    }
+
+    /// A human label for reports.
+    pub fn label(&self) -> String {
+        self.key()
+    }
+
+    /// Mutate exactly one gene (or switch family). One-knob-at-a-time keeps the
+    /// search interpretable.
+    pub fn mutate(&self, rng: &mut Rng) -> Genome {
+        let mut g = *self;
+        if rng.chance(0.30) {
+            let mut k = rng.below(KINDS as usize) as u8;
+            if k == g.kind {
+                k = (k + 1) % KINDS;
+            }
+            g.kind = k;
+            return g;
+        }
+        match rng.below(10 + 3 * CHEB_ORDER) {
+            0 => g.alpha = clamp(g.alpha + rng.range_f64(-0.6, 0.6), 0.0, 3.0),
+            1 => g.beta = clamp(g.beta + rng.range_f64(-0.6, 0.6), -3.0, 3.0),
+            2 => g.gamma = clamp(g.gamma + rng.range_f64(-0.6, 0.6), 0.0, 4.0),
+            3 => g.alpha_start = clamp(g.alpha_start + rng.range_f64(-0.8, 0.8), 0.5, 5.0),
+            4 => g.alpha_end = clamp(g.alpha_end + rng.range_f64(-0.5, 0.5), 0.3, 2.5),
+            5 => g.beta_start = clamp(g.beta_start + rng.range_f64(-0.8, 0.8), -3.0, 3.0),
+            6 => g.beta_end = clamp(g.beta_end + rng.range_f64(-0.8, 0.8), -3.5, 1.5),
+            7 => g.decay = clamp(g.decay + rng.range_f64(-1.5, 1.5), 0.3, 9.0),
+            8 => g.omega = clamp(g.omega + rng.range_f64(-0.5, 0.5), 0.0, 2.5),
+            9 => g.prune = clamp(g.prune + rng.range_f64(-5.0, 5.0), -30.0, -1.0),
+            // Chebyshev coefficient jitters (kind 5). Higher-order coefficients
+            // get smaller perturbations so curves stay smooth.
+            i => {
+                let i = i - 10;
+                let (arr, which) = (i / CHEB_ORDER, i % CHEB_ORDER);
+                let step = if which == 0 { 0.6 } else { 0.3 };
+                let target = match arr {
+                    0 => &mut g.alpha_cheb,
+                    1 => &mut g.omega_cheb,
+                    _ => &mut g.prune_cheb,
+                };
+                target[which] += rng.range_f64(-step, step);
+            }
+        }
+        g
+    }
+}
+
+/// Knobs for the evolutionary run.
+#[derive(Clone, Copy, Debug)]
+pub struct DarwinConfig {
+    pub population: usize,
+    pub generations: usize,
+    /// CFR iterations used to score each candidate (also the schedule horizon).
+    pub eval_iterations: u64,
+    pub seed: u64,
+    /// How many top genomes survive unchanged into the next generation.
+    pub elite: usize,
+}
+
+impl Default for DarwinConfig {
+    fn default() -> Self {
+        DarwinConfig {
+            population: 14,
+            generations: 8,
+            eval_iterations: 300,
+            seed: 0xC0FFEE,
+            elite: 4,
+        }
+    }
+}
+
+/// One generation's record, for plotting / receipts.
+#[derive(Clone, Debug)]
+pub struct Generation {
+    pub index: usize,
+    pub champion: Genome,
+    pub champion_exploitability: f64,
+    /// Best-so-far fitness (monotone non-decreasing): `-exploitability`.
+    pub champion_fitness: f64,
+    pub mean_exploitability: f64,
+}
+
+/// Result of an evolutionary run.
+#[derive(Clone, Debug)]
+pub struct DarwinReport {
+    pub game: String,
+    pub champion: Genome,
+    pub champion_exploitability: f64,
+    pub champion_fitness: f64,
+    pub baseline_exploitability: f64,
+    pub improved_over_baseline: bool,
+    /// Best exploitability achieved by any *static* (stationary) genome.
+    pub best_static_exploitability: f64,
+    /// Best exploitability achieved by any *dynamic* (non-stationary) genome.
+    pub best_dynamic_exploitability: f64,
+    /// Champion fitness per generation (monotone non-decreasing).
+    pub history: Vec<f64>,
+    pub generations: Vec<Generation>,
+    /// Full evolutionary family tree (every evaluated individual).
+    pub lineage: Vec<LineageNode>,
+    /// Genome keys from seed → … → champion (the winning lineage).
+    pub champion_ancestry: Vec<String>,
+    pub eval_iterations: u64,
+    pub seed: u64,
+    /// Deterministic content hash of the outcome (reproducibility receipt).
+    pub receipt: String,
+}
+
+/// A population member with stable identity for lineage tracking.
+#[derive(Clone, Copy, Debug)]
+struct Indiv {
+    genome: Genome,
+    id: u64,
+    parent: Option<u64>,
+}
+
+/// One node in the evolutionary family tree.
+#[derive(Clone, Debug)]
+pub struct LineageNode {
+    pub id: u64,
+    pub parent: Option<u64>,
+    pub generation: usize,
+    pub genome_key: String,
+    pub exploitability: f64,
+    pub dynamic: bool,
+}
+
+/// Walk parent links from `id` back to its seed, returning the chain of genome
+/// keys root → … → champion.
+fn trace_ancestry(lineage: &[LineageNode], id: u64) -> Vec<String> {
+    let mut by_id: HashMap<u64, &LineageNode> = HashMap::new();
+    for node in lineage {
+        // Keep the earliest record of each id (its birth generation).
+        by_id.entry(node.id).or_insert(node);
+    }
+    let mut chain = Vec::new();
+    let mut cur = Some(id);
+    while let Some(cid) = cur {
+        if let Some(node) = by_id.get(&cid) {
+            chain.push(format!("g{}:{}", node.generation, node.genome_key));
+            cur = node.parent;
+        } else {
+            break;
+        }
+    }
+    chain.reverse();
+    chain
+}
+
+/// Score a genome: train a fresh solver for the eval budget and return its exact
+/// exploitability (lower is better). Memoized via `cache` on the genome key.
+fn score<G: Game + Clone>(
+    game: &G,
+    genome: &Genome,
+    iters: u64,
+    cache: &mut HashMap<String, f64>,
+) -> f64 {
+    let key = format!("{}|{iters}", genome.key());
+    if let Some(&v) = cache.get(&key) {
+        return v;
+    }
+    let mut solver = Solver::new(game.clone(), genome.to_config(iters));
+    solver.train(iters);
+    let e = exploitability(game, &solver.average_strategy());
+    cache.insert(key, e);
+    e
+}
+
+/// FNV-1a 64-bit — a tiny, dependency-free, deterministic hash for the receipt.
+fn fnv1a(s: &str) -> String {
+    let mut h: u64 = 0xcbf29ce484222325;
+    for b in s.bytes() {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x100000001b3);
+    }
+    format!("{h:016x}")
+}
+
+/// Evolve a CFR policy genome for `game`. Returns the champion and a monotone
+/// learning curve. Fully deterministic given `cfg.seed`.
+pub fn evolve<G: Game + Clone>(game: &G, cfg: &DarwinConfig) -> DarwinReport {
+    let mut rng = Rng::new(cfg.seed);
+    let mut cache: HashMap<String, f64> = HashMap::new();
+    let horizon = cfg.eval_iterations;
+
+    let baseline_e = score(game, &Genome::vanilla(), horizon, &mut cache);
+
+    // Seed population: strong known configs across the static/dynamic spectrum.
+    let seeds = vec![
+        Genome::default(),
+        Genome::vanilla(),
+        Genome::static_dcfr(),
+        Genome::dynamic_seed(),
+        Genome::cheb_seed(),
+    ];
+    let mut next_id: u64 = 0;
+    let mut lineage: Vec<LineageNode> = Vec::new();
+    let mut pop: Vec<Indiv> = Vec::with_capacity(cfg.population);
+    for g in seeds {
+        if pop.len() >= cfg.population {
+            break;
+        }
+        pop.push(Indiv {
+            genome: g,
+            id: next_id,
+            parent: None,
+        });
+        next_id += 1;
+    }
+    while pop.len() < cfg.population {
+        pop.push(Indiv {
+            genome: Genome::random(&mut rng),
+            id: next_id,
+            parent: None,
+        });
+        next_id += 1;
+    }
+
+    let mut best: Option<(Indiv, f64)> = None;
+    let mut best_static = f64::INFINITY;
+    let mut best_dynamic = f64::INFINITY;
+    let mut history = Vec::with_capacity(cfg.generations);
+    let mut generations = Vec::with_capacity(cfg.generations);
+
+    for gen in 0..cfg.generations {
+        let mut scored: Vec<(Indiv, f64)> = pop
+            .iter()
+            .map(|ind| (*ind, score(game, &ind.genome, horizon, &mut cache)))
+            .collect();
+        scored.sort_by(|a, b| {
+            a.1.partial_cmp(&b.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.genome.key().cmp(&b.0.genome.key()))
+        });
+
+        // Record this generation's lineage and track per-class bests.
+        for (ind, e) in &scored {
+            lineage.push(LineageNode {
+                id: ind.id,
+                parent: ind.parent,
+                generation: gen,
+                genome_key: ind.genome.key(),
+                exploitability: *e,
+                dynamic: ind.genome.is_dynamic(),
+            });
+            if ind.genome.is_dynamic() {
+                best_dynamic = best_dynamic.min(*e);
+            } else {
+                best_static = best_static.min(*e);
+            }
+        }
+
+        let mean_e = scored.iter().map(|x| x.1).sum::<f64>() / scored.len() as f64;
+        let (gen_best_ind, gen_best_e) = scored[0];
+
+        let improved = best.map(|(_, e)| gen_best_e < e).unwrap_or(true);
+        if improved {
+            best = Some((gen_best_ind, gen_best_e));
+        }
+        let (champ_ind, champ_e) = best.unwrap();
+        let champ_fitness = -champ_e;
+        history.push(champ_fitness);
+        generations.push(Generation {
+            index: gen,
+            champion: champ_ind.genome,
+            champion_exploitability: champ_e,
+            champion_fitness: champ_fitness,
+            mean_exploitability: mean_e,
+        });
+
+        // Next generation: elites carried over (identity preserved), the rest
+        // mutated from tournament survivors (child records its parent's id).
+        let elite = cfg.elite.min(scored.len());
+        let mut next: Vec<Indiv> = scored.iter().take(elite).map(|x| x.0).collect();
+        let survivors: Vec<Indiv> = scored
+            .iter()
+            .take(scored.len() / 2 + 1)
+            .map(|x| x.0)
+            .collect();
+        while next.len() < cfg.population {
+            let parent = survivors[rng.below(survivors.len())];
+            next.push(Indiv {
+                genome: parent.genome.mutate(&mut rng),
+                id: next_id,
+                parent: Some(parent.id),
+            });
+            next_id += 1;
+        }
+        pop = next;
+    }
+
+    let (champion_ind, champion_exploitability) = best.expect("at least one generation");
+    let champion = champion_ind.genome;
+    // Walk the champion's ancestry from seed to champion (deterministic).
+    let champion_ancestry = trace_ancestry(&lineage, champion_ind.id);
+    let receipt = {
+        let hist: Vec<String> = history.iter().map(|f| format!("{f:.6}")).collect();
+        fnv1a(&format!(
+            "game={};champ={};e={:.6};hist=[{}]",
+            game.name(),
+            champion.key(),
+            champion_exploitability,
+            hist.join(",")
+        ))
+    };
+
+    DarwinReport {
+        game: game.name().to_string(),
+        champion,
+        champion_exploitability,
+        champion_fitness: -champion_exploitability,
+        baseline_exploitability: baseline_e,
+        improved_over_baseline: champion_exploitability < baseline_e,
+        best_static_exploitability: best_static,
+        best_dynamic_exploitability: best_dynamic,
+        history,
+        generations,
+        lineage,
+        champion_ancestry,
+        eval_iterations: cfg.eval_iterations,
+        seed: cfg.seed,
+        receipt,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::games::KuhnPoker;
+
+    #[test]
+    fn history_is_monotone_non_decreasing() {
+        let report = evolve(
+            &KuhnPoker::new(),
+            &DarwinConfig {
+                generations: 6,
+                population: 10,
+                ..Default::default()
+            },
+        );
+        for w in report.history.windows(2) {
+            assert!(
+                w[1] >= w[0] - 1e-12,
+                "fitness regressed: {:?}",
+                report.history
+            );
+        }
+    }
+
+    #[test]
+    fn champion_at_least_matches_baseline() {
+        let report = evolve(&KuhnPoker::new(), &DarwinConfig::default());
+        assert!(
+            report.champion_exploitability <= report.baseline_exploitability + 1e-9,
+            "champion {} worse than baseline {}",
+            report.champion_exploitability,
+            report.baseline_exploitability
+        );
+    }
+
+    #[test]
+    fn deterministic_receipt() {
+        let a = evolve(&KuhnPoker::new(), &DarwinConfig::default());
+        let b = evolve(&KuhnPoker::new(), &DarwinConfig::default());
+        assert_eq!(a.receipt, b.receipt);
+        assert_eq!(a.champion, b.champion);
+    }
+
+    #[test]
+    fn dynamic_genome_is_distinct_config() {
+        let g = Genome::dynamic_seed();
+        let cfg = g.to_config(1000);
+        assert!(cfg.is_dynamic());
+        assert!(cfg.alpha_schedule.is_some());
+    }
+
+    #[test]
+    fn chebyshev_genome_engages_all_levers() {
+        let cfg = Genome::cheb_seed().to_config(1000);
+        assert!(cfg.alpha_schedule.is_some());
+        assert!(cfg.omega_schedule.is_some());
+        assert!(cfg.prune_schedule.is_some());
+        assert!(cfg.uses_momentum());
+    }
+
+    #[test]
+    fn lineage_and_ancestry_are_populated() {
+        let report = evolve(
+            &KuhnPoker::new(),
+            &DarwinConfig {
+                generations: 5,
+                population: 10,
+                ..Default::default()
+            },
+        );
+        assert!(
+            !report.lineage.is_empty(),
+            "lineage should record evaluated genomes"
+        );
+        assert!(
+            !report.champion_ancestry.is_empty(),
+            "champion should have an ancestry chain"
+        );
+        // The ancestry chain must reference real generations in order.
+        let gens: Vec<&str> = report
+            .champion_ancestry
+            .iter()
+            .map(|s| s.as_str())
+            .collect();
+        assert!(
+            gens[0].starts_with("g0:") || gens.iter().any(|s| s.starts_with("g")),
+            "ancestry tagged by generation"
+        );
+    }
+
+    #[test]
+    fn dynamic_can_match_or_beat_best_static_on_leduc() {
+        use crate::games::LeducHoldem;
+        let report = evolve(
+            &LeducHoldem::new(),
+            &DarwinConfig {
+                population: 16,
+                generations: 8,
+                eval_iterations: 400,
+                seed: 7,
+                elite: 4,
+            },
+        );
+        // The non-stationary family should not be worse than the best static one.
+        assert!(
+            report.best_dynamic_exploitability <= report.best_static_exploitability + 1e-9,
+            "dynamic {} should be <= static {}",
+            report.best_dynamic_exploitability,
+            report.best_static_exploitability
+        );
+    }
+}

--- a/crates/poker-darwin/src/exploit.rs
+++ b/crates/poker-darwin/src/exploit.rs
@@ -1,0 +1,262 @@
+// SPDX-License-Identifier: MIT
+//
+// Exact best response and exploitability — the *ground truth* metric for a
+// poker solver. Exploitability measures how much a worst-case adversary can
+// beat a strategy by; a Nash equilibrium has exploitability 0. Because the
+// games here are small, we compute the best response exactly (full tree, exact
+// integration over chance), so "exploitability → 0" in the tests is a proof of
+// convergence, not a sampled approximation.
+//
+// Best response over imperfect information is subtler than plain expectimax:
+// the responder must commit to one action per *information set*, not per
+// history. We compute it in two passes:
+//   1. `collect` walks the tree accumulating, for every responder information
+//      set, the histories in it and their opponent+chance reach probability
+//      (the responder's own reach is excluded — it can't influence it).
+//   2. Information sets are resolved deepest-first; each picks the action
+//      maximizing summed counterfactual value. Subtrees below are already
+//      resolved, so a memoized value function `V` is well-defined.
+
+use crate::game::Game;
+use std::collections::HashMap;
+
+struct BrCtx<G: Game> {
+    // responder infoset -> histories in it: (state, opp+chance reach, depth)
+    states: HashMap<String, Vec<(G::State, f64, usize)>>,
+}
+
+fn collect<G: Game>(
+    game: &G,
+    avg: &HashMap<String, Vec<f64>>,
+    br_player: usize,
+    s: &G::State,
+    reach: f64,
+    depth: usize,
+    ctx: &mut BrCtx<G>,
+) {
+    if game.is_terminal(s) {
+        return;
+    }
+    if game.is_chance(s) {
+        for (a, p) in game.chance_outcomes(s) {
+            collect(
+                game,
+                avg,
+                br_player,
+                &game.apply(s, a),
+                reach * p,
+                depth + 1,
+                ctx,
+            );
+        }
+        return;
+    }
+    let player = game.current_player(s);
+    let actions = game.legal_actions(s);
+    if player == br_player {
+        ctx.states
+            .entry(game.infoset_key(s))
+            .or_default()
+            .push((s.clone(), reach, depth));
+        // Responder reach contributes a factor of 1 (it is being optimized).
+        for &a in &actions {
+            collect(
+                game,
+                avg,
+                br_player,
+                &game.apply(s, a),
+                reach,
+                depth + 1,
+                ctx,
+            );
+        }
+    } else {
+        let sigma = strategy_for(avg, &game.infoset_key(s), actions.len());
+        for (i, &a) in actions.iter().enumerate() {
+            collect(
+                game,
+                avg,
+                br_player,
+                &game.apply(s, a),
+                reach * sigma[i],
+                depth + 1,
+                ctx,
+            );
+        }
+    }
+}
+
+/// Look up an information set's strategy, defaulting to uniform when the solver
+/// never visited it (e.g. an off-path infoset with zero training mass).
+fn strategy_for(avg: &HashMap<String, Vec<f64>>, key: &str, n: usize) -> Vec<f64> {
+    match avg.get(key) {
+        Some(v) if v.len() == n => v.clone(),
+        _ => vec![1.0 / n as f64; n],
+    }
+}
+
+/// Value of the subtree to the responder, given the responder follows `policy`
+/// (action index per infoset) and the opponent follows `avg`. Memoized on the
+/// full state key.
+fn value<G: Game>(
+    game: &G,
+    avg: &HashMap<String, Vec<f64>>,
+    br_player: usize,
+    policy: &HashMap<String, usize>,
+    s: &G::State,
+    memo: &mut HashMap<String, f64>,
+) -> f64 {
+    if game.is_terminal(s) {
+        return game.payoff(s, br_player);
+    }
+    let sk = game.state_key(s);
+    if let Some(&v) = memo.get(&sk) {
+        return v;
+    }
+    let v = if game.is_chance(s) {
+        game.chance_outcomes(s)
+            .into_iter()
+            .map(|(a, p)| p * value(game, avg, br_player, policy, &game.apply(s, a), memo))
+            .sum()
+    } else {
+        let player = game.current_player(s);
+        let actions = game.legal_actions(s);
+        if player == br_player {
+            let idx = *policy
+                .get(&game.infoset_key(s))
+                .expect("policy resolved for reachable infoset");
+            value(
+                game,
+                avg,
+                br_player,
+                policy,
+                &game.apply(s, actions[idx]),
+                memo,
+            )
+        } else {
+            let sigma = strategy_for(avg, &game.infoset_key(s), actions.len());
+            actions
+                .iter()
+                .enumerate()
+                .map(|(i, &a)| {
+                    sigma[i] * value(game, avg, br_player, policy, &game.apply(s, a), memo)
+                })
+                .sum()
+        }
+    };
+    memo.insert(sk, v);
+    v
+}
+
+/// Value to `br_player` when `br_player` plays an exact best response to the
+/// opponent's average strategy `avg`.
+pub fn best_response_value<G: Game>(
+    game: &G,
+    avg: &HashMap<String, Vec<f64>>,
+    br_player: usize,
+) -> f64 {
+    let mut ctx = BrCtx::<G> {
+        states: HashMap::new(),
+    };
+    collect(game, avg, br_player, &game.root(), 1.0, 0, &mut ctx);
+
+    // Resolve infosets deepest-first so every subtree referenced by `value`
+    // is already decided.
+    let mut order: Vec<(String, usize)> = ctx
+        .states
+        .iter()
+        .map(|(k, v)| (k.clone(), v.iter().map(|x| x.2).max().unwrap_or(0)))
+        .collect();
+    order.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+
+    let mut policy: HashMap<String, usize> = HashMap::new();
+    let mut memo: HashMap<String, f64> = HashMap::new();
+    for (infoset, _) in &order {
+        let entries = &ctx.states[infoset];
+        let actions = game.legal_actions(&entries[0].0);
+        let n = actions.len();
+        let mut best_idx = 0;
+        let mut best_val = f64::NEG_INFINITY;
+        #[allow(clippy::needless_range_loop)] // index needed to record best_idx
+        for i in 0..n {
+            let mut av = 0.0;
+            for (state, reach, _) in entries {
+                let child = game.apply(state, actions[i]);
+                av += reach * value(game, avg, br_player, &policy, &child, &mut memo);
+            }
+            if av > best_val {
+                best_val = av;
+                best_idx = i;
+            }
+        }
+        policy.insert(infoset.clone(), best_idx);
+        // No memo invalidation needed: infosets resolve deepest-first, and a
+        // responder node's value is only ever computed *after* its (deeper)
+        // infoset is decided, so every memoized entry is already final.
+    }
+
+    value(game, avg, br_player, &policy, &game.root(), &mut memo)
+}
+
+/// Exploitability of `avg`: the average of how much each player gains by
+/// best-responding. Zero exactly at a Nash equilibrium; reported in the game's
+/// own utility units (chips). Always ≥ 0 up to floating point.
+pub fn exploitability<G: Game>(game: &G, avg: &HashMap<String, Vec<f64>>) -> f64 {
+    let v0 = best_response_value(game, avg, 0);
+    let v1 = best_response_value(game, avg, 1);
+    (v0 + v1) / 2.0
+}
+
+/// Expected value to player 0 when *both* players follow `avg` (the value of the
+/// strategy profile). At convergence this approaches the game value.
+pub fn profile_value<G: Game>(game: &G, avg: &HashMap<String, Vec<f64>>) -> f64 {
+    fn rec<G: Game>(game: &G, avg: &HashMap<String, Vec<f64>>, s: &G::State) -> f64 {
+        if game.is_terminal(s) {
+            return game.payoff(s, 0);
+        }
+        if game.is_chance(s) {
+            return game
+                .chance_outcomes(s)
+                .into_iter()
+                .map(|(a, p)| p * rec(game, avg, &game.apply(s, a)))
+                .sum();
+        }
+        let actions = game.legal_actions(s);
+        let sigma = strategy_for(avg, &game.infoset_key(s), actions.len());
+        actions
+            .iter()
+            .enumerate()
+            .map(|(i, &a)| sigma[i] * rec(game, avg, &game.apply(s, a)))
+            .sum()
+    }
+    rec(game, avg, &game.root())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cfr::{Solver, SolverConfig};
+    use crate::games::KuhnPoker;
+
+    #[test]
+    fn uniform_strategy_is_exploitable() {
+        // The empty (all-uniform) strategy should be measurably exploitable.
+        let g = KuhnPoker::new();
+        let empty = HashMap::new();
+        let e = exploitability(&g, &empty);
+        assert!(e > 0.05, "uniform play should be exploitable, got {e}");
+    }
+
+    #[test]
+    fn cfr_reduces_exploitability_below_uniform() {
+        let g = KuhnPoker::new();
+        let uniform_e = exploitability(&g, &HashMap::new());
+        let mut solver = Solver::new(KuhnPoker::new(), SolverConfig::default());
+        solver.train(500);
+        let trained_e = exploitability(&g, &solver.average_strategy());
+        assert!(
+            trained_e < uniform_e * 0.25,
+            "CFR should cut exploitability: {uniform_e} -> {trained_e}"
+        );
+    }
+}

--- a/crates/poker-darwin/src/features.rs
+++ b/crates/poker-darwin/src/features.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+//
+// Interpretable featurization of information-set keys, shared by the ruvector
+// abstraction and the candle policy net. Keeping it dependency-free and always
+// compiled means both integrations consume identical features (so an abstraction
+// bucket and a network prediction are directly comparable).
+
+/// Featurize a canonical information-set key into an interpretable vector.
+/// Works for both Kuhn ("J:pb") and Leduc ("J|cr|Q|c") keys:
+///   [own card, has board, board rank, #bets/raises, #calls/checks, #folds, len]
+pub fn featurize(key: &str) -> Vec<f32> {
+    let rank = |c: char| match c {
+        'J' => Some(0.0),
+        'Q' => Some(1.0),
+        'K' => Some(2.0),
+        _ => None,
+    };
+    let mut card = 0.0;
+    let mut board = 0.0;
+    let mut has_board = 0.0;
+    let mut seen_card = false;
+    let (mut bets, mut calls, mut folds, mut len) = (0.0f32, 0.0f32, 0.0f32, 0.0f32);
+    for ch in key.chars() {
+        if let Some(r) = rank(ch) {
+            if !seen_card {
+                card = r;
+                seen_card = true;
+            } else {
+                board = r;
+                has_board = 1.0;
+            }
+            continue;
+        }
+        match ch {
+            'b' | 'r' => {
+                bets += 1.0;
+                len += 1.0;
+            }
+            'c' | 'p' => {
+                calls += 1.0;
+                len += 1.0;
+            }
+            'f' => {
+                folds += 1.0;
+                len += 1.0;
+            }
+            _ => {}
+        }
+    }
+    vec![card, has_board, board, bets, calls, folds, len]
+}
+
+/// Dimensionality of [`featurize`] output.
+pub const FEATURE_DIM: usize = 7;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinguishes_card_and_board() {
+        let a = featurize("J|cr|Q|c");
+        let b = featurize("J|cr|K|c");
+        assert_ne!(a, b);
+        assert_eq!(a.len(), FEATURE_DIM);
+        assert_eq!(a[0], 0.0); // card J
+        assert_eq!(a[1], 1.0); // has board
+    }
+
+    #[test]
+    fn kuhn_key_has_no_board() {
+        let f = featurize("K:pb");
+        assert_eq!(f[1], 0.0, "Kuhn keys have no board card");
+        assert_eq!(f[0], 2.0); // card K
+    }
+}

--- a/crates/poker-darwin/src/game.rs
+++ b/crates/poker-darwin/src/game.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: MIT
+//
+// The extensive-form game abstraction. Everything in the crate — the CFR
+// solver, the exact best-response / exploitability oracle, the Darwin fitness
+// function — is generic over this trait, so a new poker variant only has to
+// describe its tree once.
+//
+// Conventions (two-player zero-sum, perfect recall):
+//   * Players are `0` and `1`. Utilities satisfy `payoff(s,0) == -payoff(s,1)`.
+//   * Chance (the deal) is its own node kind with an explicit outcome
+//     distribution, so CFR and best-response can integrate over it *exactly*
+//     rather than sampling — that is what makes the exploitability numbers
+//     ground-truth instead of estimates.
+//   * `infoset_key` is what a player can observe (their card + public history);
+//     all states sharing a key share a strategy. `state_key` is the full,
+//     globally-unique node id (both private cards + history) used for
+//     memoization in the best-response pass.
+
+/// A perfect-recall, two-player zero-sum extensive-form game.
+pub trait Game {
+    /// A node in the game tree (public history + both players' private state).
+    type State: Clone;
+    /// A move: a player action or a chance outcome.
+    type Action: Copy + Clone + Eq + std::fmt::Debug;
+
+    /// Human-readable game name (used in reports / benchmarks).
+    fn name(&self) -> &'static str;
+
+    /// The root node, *before* the chance deal.
+    fn root(&self) -> Self::State;
+
+    /// Is this a terminal (showdown / fold) node?
+    fn is_terminal(&self, s: &Self::State) -> bool;
+
+    /// Is this a chance node (a deal)?
+    fn is_chance(&self, s: &Self::State) -> bool;
+
+    /// The player (0 or 1) to act at a decision node.
+    /// Only meaningful when the node is neither terminal nor chance.
+    fn current_player(&self, s: &Self::State) -> usize;
+
+    /// Chance outcomes `(action, probability)` at a chance node.
+    /// Probabilities must sum to 1.
+    fn chance_outcomes(&self, s: &Self::State) -> Vec<(Self::Action, f64)>;
+
+    /// Legal actions at a decision node, in a **stable order** that is
+    /// identical for every state sharing an information set.
+    fn legal_actions(&self, s: &Self::State) -> Vec<Self::Action>;
+
+    /// Apply an action (player or chance) and return the child node.
+    fn apply(&self, s: &Self::State, a: Self::Action) -> Self::State;
+
+    /// The acting player's information-set key (perfect recall).
+    fn infoset_key(&self, s: &Self::State) -> String;
+
+    /// A globally-unique key for the full node (used for best-response memo).
+    fn state_key(&self, s: &Self::State) -> String;
+
+    /// Terminal utility for `player`. Zero-sum: `payoff(s,0) == -payoff(s,1)`.
+    fn payoff(&self, s: &Self::State, player: usize) -> f64;
+
+    /// Render an action for display (defaults to `Debug`).
+    fn action_label(&self, a: Self::Action) -> String {
+        format!("{a:?}")
+    }
+}
+
+/// Size statistics for a game tree (the "environment" a solver is run on).
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct TreeStats {
+    /// Player decision nodes (histories where someone acts).
+    pub decision_nodes: usize,
+    /// Terminal (showdown / fold) leaves.
+    pub terminal_nodes: usize,
+    /// Chance (deal) nodes.
+    pub chance_nodes: usize,
+    /// Distinct information sets (the size of the strategy table).
+    pub infosets: usize,
+    /// Maximum tree depth (actions from root to a leaf).
+    pub max_depth: usize,
+}
+
+/// Walk a game's full tree and tally its size — used to characterize the exact
+/// environment exploitability is measured on (tree size matters: a `1e-3`
+/// exploitability means different things on a 12-infoset vs a 288-infoset game).
+pub fn tree_stats<G: Game>(game: &G) -> TreeStats {
+    use std::collections::BTreeSet;
+    let mut st = TreeStats::default();
+    let mut infosets = BTreeSet::new();
+    let mut stack = vec![(game.root(), 0usize)];
+    while let Some((s, depth)) = stack.pop() {
+        st.max_depth = st.max_depth.max(depth);
+        if game.is_terminal(&s) {
+            st.terminal_nodes += 1;
+            continue;
+        }
+        if game.is_chance(&s) {
+            st.chance_nodes += 1;
+            for (a, _) in game.chance_outcomes(&s) {
+                stack.push((game.apply(&s, a), depth + 1));
+            }
+        } else {
+            st.decision_nodes += 1;
+            infosets.insert(game.infoset_key(&s));
+            for a in game.legal_actions(&s) {
+                stack.push((game.apply(&s, a), depth + 1));
+            }
+        }
+    }
+    st.infosets = infosets.len();
+    st
+}
+
+/// Regret-matching: turn a regret vector into a strategy (probability
+/// distribution). Positive regrets are normalised; an all-non-positive vector
+/// falls back to the uniform strategy. This is the shared kernel of vanilla
+/// CFR and CFR+ (which additionally floors regrets at zero on update).
+pub fn regret_matching(regrets: &[f64], out: &mut [f64]) {
+    debug_assert_eq!(regrets.len(), out.len());
+    let mut sum = 0.0;
+    for (o, &r) in out.iter_mut().zip(regrets) {
+        let pos = if r > 0.0 { r } else { 0.0 };
+        *o = pos;
+        sum += pos;
+    }
+    if sum > 0.0 {
+        for o in out.iter_mut() {
+            *o /= sum;
+        }
+    } else {
+        let u = 1.0 / out.len() as f64;
+        for o in out.iter_mut() {
+            *o = u;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::regret_matching;
+
+    #[test]
+    fn positive_regrets_normalised() {
+        let mut out = [0.0; 3];
+        regret_matching(&[3.0, 1.0, 0.0], &mut out);
+        assert!((out[0] - 0.75).abs() < 1e-12);
+        assert!((out[1] - 0.25).abs() < 1e-12);
+        assert_eq!(out[2], 0.0);
+        assert!((out.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn nonpositive_falls_back_to_uniform() {
+        let mut out = [0.0; 4];
+        regret_matching(&[-1.0, 0.0, -5.0, 0.0], &mut out);
+        for o in out {
+            assert!((o - 0.25).abs() < 1e-12);
+        }
+    }
+}

--- a/crates/poker-darwin/src/games/kuhn.rs
+++ b/crates/poker-darwin/src/games/kuhn.rs
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: MIT
+//
+// Kuhn Poker — the smallest non-trivial poker game and the classic CFR sanity
+// check. Three cards {J<Q<K}, one each to two players, a single betting round.
+// It has a *known closed-form* Nash equilibrium family and a known game value
+// of -1/18 to the first player, so a correct solver must drive exploitability
+// to ~0 and reproduce that value. That is exactly what the tests assert.
+//
+// Action encoding: `Pass` = check/fold, `Bet` = bet/call (the meaning depends
+// on context, as in the standard formulation).
+
+use crate::game::Game;
+
+/// J=0, Q=1, K=2.
+const RANKS: [&str; 3] = ["J", "Q", "K"];
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum KuhnAction {
+    /// Chance: deal (player-0 card, player-1 card).
+    Deal(u8, u8),
+    /// Check, or fold to a bet.
+    Pass,
+    /// Bet, or call a bet.
+    Bet,
+}
+
+#[derive(Clone, Debug)]
+pub struct KuhnState {
+    /// `None` before the deal; `Some((c0, c1))` after.
+    cards: Option<(u8, u8)>,
+    /// Player-action history (Pass/Bet only).
+    history: Vec<KuhnAction>,
+}
+
+fn hist_str(h: &[KuhnAction]) -> String {
+    h.iter()
+        .map(|a| match a {
+            KuhnAction::Pass => 'p',
+            KuhnAction::Bet => 'b',
+            KuhnAction::Deal(..) => '?',
+        })
+        .collect()
+}
+
+/// `true` for the betting sequences that end the hand.
+fn terminal_history(h: &[KuhnAction]) -> bool {
+    use KuhnAction::{Bet, Pass};
+    matches!(
+        h,
+        [Pass, Pass] | [Pass, Bet, Pass] | [Pass, Bet, Bet] | [Bet, Pass] | [Bet, Bet]
+    )
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct KuhnPoker;
+
+impl KuhnPoker {
+    pub fn new() -> Self {
+        KuhnPoker
+    }
+}
+
+impl Game for KuhnPoker {
+    type State = KuhnState;
+    type Action = KuhnAction;
+
+    fn name(&self) -> &'static str {
+        "kuhn"
+    }
+
+    fn root(&self) -> KuhnState {
+        KuhnState {
+            cards: None,
+            history: Vec::new(),
+        }
+    }
+
+    fn is_terminal(&self, s: &KuhnState) -> bool {
+        s.cards.is_some() && terminal_history(&s.history)
+    }
+
+    fn is_chance(&self, s: &KuhnState) -> bool {
+        s.cards.is_none()
+    }
+
+    fn current_player(&self, s: &KuhnState) -> usize {
+        s.history.len() % 2
+    }
+
+    fn chance_outcomes(&self, _s: &KuhnState) -> Vec<(KuhnAction, f64)> {
+        // 6 equiprobable ordered deals of distinct cards.
+        let mut out = Vec::with_capacity(6);
+        for a in 0u8..3 {
+            for b in 0u8..3 {
+                if a != b {
+                    out.push((KuhnAction::Deal(a, b), 1.0 / 6.0));
+                }
+            }
+        }
+        out
+    }
+
+    fn legal_actions(&self, _s: &KuhnState) -> Vec<KuhnAction> {
+        vec![KuhnAction::Pass, KuhnAction::Bet]
+    }
+
+    fn apply(&self, s: &KuhnState, a: KuhnAction) -> KuhnState {
+        match a {
+            KuhnAction::Deal(c0, c1) => KuhnState {
+                cards: Some((c0, c1)),
+                history: Vec::new(),
+            },
+            other => {
+                let mut h = s.history.clone();
+                h.push(other);
+                KuhnState {
+                    cards: s.cards,
+                    history: h,
+                }
+            }
+        }
+    }
+
+    fn infoset_key(&self, s: &KuhnState) -> String {
+        let (c0, c1) = s.cards.expect("infoset_key on chance node");
+        let card = if self.current_player(s) == 0 { c0 } else { c1 };
+        format!("{}:{}", RANKS[card as usize], hist_str(&s.history))
+    }
+
+    fn state_key(&self, s: &KuhnState) -> String {
+        match s.cards {
+            None => "root".to_string(),
+            Some((c0, c1)) => format!("{c0}{c1}:{}", hist_str(&s.history)),
+        }
+    }
+
+    fn payoff(&self, s: &KuhnState, player: usize) -> f64 {
+        let (c0, c1) = s.cards.expect("payoff on undealt state");
+        let p0_wins_showdown = c0 > c1;
+        // Player-0 perspective, then flip for the requested player.
+        let u0 = match s.history.as_slice() {
+            // check-check: showdown for 1.
+            [KuhnAction::Pass, KuhnAction::Pass] => {
+                if p0_wins_showdown {
+                    1.0
+                } else {
+                    -1.0
+                }
+            }
+            // check, bet, fold: player 0 folds, loses ante.
+            [KuhnAction::Pass, KuhnAction::Bet, KuhnAction::Pass] => -1.0,
+            // check, bet, call: showdown for 2.
+            [KuhnAction::Pass, KuhnAction::Bet, KuhnAction::Bet] => {
+                if p0_wins_showdown {
+                    2.0
+                } else {
+                    -2.0
+                }
+            }
+            // bet, fold: player 1 folds, player 0 wins ante.
+            [KuhnAction::Bet, KuhnAction::Pass] => 1.0,
+            // bet, call: showdown for 2.
+            [KuhnAction::Bet, KuhnAction::Bet] => {
+                if p0_wins_showdown {
+                    2.0
+                } else {
+                    -2.0
+                }
+            }
+            other => panic!("payoff on non-terminal history {other:?}"),
+        };
+        if player == 0 {
+            u0
+        } else {
+            -u0
+        }
+    }
+
+    fn action_label(&self, a: KuhnAction) -> String {
+        match a {
+            KuhnAction::Pass => "pass".into(),
+            KuhnAction::Bet => "bet".into(),
+            KuhnAction::Deal(c0, c1) => {
+                format!("deal({},{})", RANKS[c0 as usize], RANKS[c1 as usize])
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tree_has_expected_terminals() {
+        // Walk the whole tree and count terminals / decision infosets.
+        let g = KuhnPoker::new();
+        let mut terminals = 0usize;
+        let mut infosets = std::collections::BTreeSet::new();
+        let mut stack = vec![g.root()];
+        while let Some(s) = stack.pop() {
+            if g.is_terminal(&s) {
+                terminals += 1;
+                continue;
+            }
+            if g.is_chance(&s) {
+                for (a, _) in g.chance_outcomes(&s) {
+                    stack.push(g.apply(&s, a));
+                }
+            } else {
+                infosets.insert(g.infoset_key(&s));
+                for a in g.legal_actions(&s) {
+                    stack.push(g.apply(&s, a));
+                }
+            }
+        }
+        // 6 deals × 5 terminal betting sequences = 30 terminal leaves.
+        assert_eq!(terminals, 30);
+        // 12 information sets (the textbook number for Kuhn).
+        assert_eq!(infosets.len(), 12);
+    }
+
+    #[test]
+    fn payoffs_are_zero_sum() {
+        let g = KuhnPoker::new();
+        let s = KuhnState {
+            cards: Some((2, 0)),
+            history: vec![KuhnAction::Bet, KuhnAction::Bet],
+        };
+        assert_eq!(g.payoff(&s, 0), 2.0);
+        assert_eq!(g.payoff(&s, 1), -2.0);
+    }
+}

--- a/crates/poker-darwin/src/games/leduc.rs
+++ b/crates/poker-darwin/src/games/leduc.rs
@@ -1,0 +1,372 @@
+// SPDX-License-Identifier: MIT
+//
+// Leduc Hold'em — the standard "next step up" from Kuhn and a real CFR
+// benchmark. A 6-card deck (ranks J<Q<K, two suits each), one private card per
+// player, a betting round, one public card, a second betting round, showdown.
+// Fixed-limit: bet size 2 pre-board, 4 post-board, max two raises per round.
+// A private card that matches the public card is a pair and beats any unpaired
+// hand; otherwise the higher private card wins, equal ranks split.
+//
+// It has ~288 information sets and a few thousand histories — small enough for
+// exact best-response, large enough that a buggy solver will visibly fail to
+// converge. Suits are irrelevant to strategy, so information sets collapse over
+// suit while `state_key` keeps physical-card identity for exact chance math.
+
+use crate::game::Game;
+
+const RANKS: [&str; 3] = ["J", "Q", "K"];
+const BET_SIZE: [f64; 2] = [2.0, 4.0]; // round 0, round 1
+const MAX_RAISES: u8 = 2;
+
+#[inline]
+fn rank_of(card: u8) -> u8 {
+    card / 2
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum LeducAction {
+    /// Chance: deal (player-0 physical card, player-1 physical card).
+    DealHole(u8, u8),
+    /// Chance: deal the public physical card.
+    DealBoard(u8),
+    /// Fold (only legal when facing a bet).
+    Fold,
+    /// Call a bet, or check when nothing is owed.
+    Call,
+    /// Bet / raise.
+    Raise,
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum Phase {
+    DealHole,
+    Round0,
+    DealBoard,
+    Round1,
+    Done,
+}
+
+#[derive(Clone, Debug)]
+pub struct LeducState {
+    p: [Option<u8>; 2],
+    board: Option<u8>,
+    phase: Phase,
+    contrib: [f64; 2],
+    to_act: usize,
+    bets_this_round: u8,
+    to_call: f64,
+    last_was_check: bool,
+    folded: Option<usize>,
+    r0: String,
+    r1: String,
+}
+
+#[derive(Default, Clone, Copy)]
+pub struct LeducHoldem;
+
+impl LeducHoldem {
+    pub fn new() -> Self {
+        LeducHoldem
+    }
+
+    fn round_idx(s: &LeducState) -> usize {
+        matches!(s.phase, Phase::Round1) as usize
+    }
+
+    fn hist_mut(s: &mut LeducState) -> &mut String {
+        if matches!(s.phase, Phase::Round1) {
+            &mut s.r1
+        } else {
+            &mut s.r0
+        }
+    }
+
+    /// Advance the state machine after a betting round closes.
+    fn close_round(s: &mut LeducState) {
+        match s.phase {
+            Phase::Round0 => {
+                s.phase = Phase::DealBoard;
+            }
+            Phase::Round1 => {
+                s.phase = Phase::Done;
+            }
+            _ => unreachable!("close_round in non-betting phase"),
+        }
+    }
+
+    fn reset_betting(s: &mut LeducState) {
+        s.bets_this_round = 0;
+        s.to_call = 0.0;
+        s.last_was_check = false;
+        s.to_act = 0;
+    }
+}
+
+impl Game for LeducHoldem {
+    type State = LeducState;
+    type Action = LeducAction;
+
+    fn name(&self) -> &'static str {
+        "leduc"
+    }
+
+    fn root(&self) -> LeducState {
+        LeducState {
+            p: [None, None],
+            board: None,
+            phase: Phase::DealHole,
+            contrib: [1.0, 1.0], // antes
+            to_act: 0,
+            bets_this_round: 0,
+            to_call: 0.0,
+            last_was_check: false,
+            folded: None,
+            r0: String::new(),
+            r1: String::new(),
+        }
+    }
+
+    fn is_terminal(&self, s: &LeducState) -> bool {
+        matches!(s.phase, Phase::Done)
+    }
+
+    fn is_chance(&self, s: &LeducState) -> bool {
+        matches!(s.phase, Phase::DealHole | Phase::DealBoard)
+    }
+
+    fn current_player(&self, s: &LeducState) -> usize {
+        s.to_act
+    }
+
+    fn chance_outcomes(&self, s: &LeducState) -> Vec<(LeducAction, f64)> {
+        match s.phase {
+            Phase::DealHole => {
+                let mut out = Vec::with_capacity(30);
+                for i in 0u8..6 {
+                    for j in 0u8..6 {
+                        if i != j {
+                            out.push((LeducAction::DealHole(i, j), 1.0 / 30.0));
+                        }
+                    }
+                }
+                out
+            }
+            Phase::DealBoard => {
+                let p0 = s.p[0].unwrap();
+                let p1 = s.p[1].unwrap();
+                let remaining: Vec<u8> = (0u8..6).filter(|&c| c != p0 && c != p1).collect();
+                let prob = 1.0 / remaining.len() as f64;
+                remaining
+                    .into_iter()
+                    .map(|c| (LeducAction::DealBoard(c), prob))
+                    .collect()
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn legal_actions(&self, s: &LeducState) -> Vec<LeducAction> {
+        let mut acts = Vec::with_capacity(3);
+        // Call/check is always available at a decision node.
+        acts.push(LeducAction::Call);
+        if s.bets_this_round < MAX_RAISES {
+            acts.push(LeducAction::Raise);
+        }
+        if s.to_call > 0.0 {
+            acts.push(LeducAction::Fold);
+        }
+        acts
+    }
+
+    fn apply(&self, s: &LeducState, a: LeducAction) -> LeducState {
+        let mut t = s.clone();
+        match a {
+            LeducAction::DealHole(i, j) => {
+                t.p = [Some(i), Some(j)];
+                t.phase = Phase::Round0;
+                Self::reset_betting(&mut t);
+            }
+            LeducAction::DealBoard(c) => {
+                t.board = Some(c);
+                t.phase = Phase::Round1;
+                Self::reset_betting(&mut t);
+            }
+            LeducAction::Fold => {
+                Self::hist_mut(&mut t).push('f');
+                t.folded = Some(t.to_act);
+                t.phase = Phase::Done;
+            }
+            LeducAction::Call => {
+                Self::hist_mut(&mut t).push('c');
+                let facing_bet = t.to_call > 0.0;
+                t.contrib[t.to_act] += t.to_call;
+                t.to_call = 0.0;
+                if facing_bet {
+                    // Calling a bet closes the round.
+                    Self::close_round(&mut t);
+                } else if t.last_was_check {
+                    // Check-check closes the round.
+                    Self::close_round(&mut t);
+                } else {
+                    // First check; pass the turn.
+                    t.last_was_check = true;
+                    t.to_act ^= 1;
+                }
+            }
+            LeducAction::Raise => {
+                Self::hist_mut(&mut t).push('r');
+                let size = BET_SIZE[Self::round_idx(s)];
+                // Pay any outstanding call, then add the raise increment.
+                t.contrib[t.to_act] += t.to_call + size;
+                t.to_call = size;
+                t.bets_this_round += 1;
+                t.last_was_check = false;
+                t.to_act ^= 1;
+            }
+        }
+        t
+    }
+
+    fn infoset_key(&self, s: &LeducState) -> String {
+        let me = s.to_act;
+        let card = RANKS[rank_of(s.p[me].expect("infoset on undealt")) as usize];
+        let board = match s.board {
+            Some(b) => RANKS[rank_of(b) as usize],
+            None => "-",
+        };
+        format!("{card}|{}|{board}|{}", s.r0, s.r1)
+    }
+
+    fn state_key(&self, s: &LeducState) -> String {
+        let f = |o: Option<u8>| o.map(|c| c.to_string()).unwrap_or_else(|| "_".into());
+        format!(
+            "{}/{}/{}|{:?}|{}|{}",
+            f(s.p[0]),
+            f(s.p[1]),
+            f(s.board),
+            s.phase,
+            s.r0,
+            s.r1
+        )
+    }
+
+    fn payoff(&self, s: &LeducState, player: usize) -> f64 {
+        debug_assert!(matches!(s.phase, Phase::Done));
+        // Net to player 0, then flip.
+        let u0 = if let Some(folder) = s.folded {
+            // Winner gains the folder's contribution.
+            let winner = folder ^ 1;
+            let amount = s.contrib[folder];
+            if winner == 0 {
+                amount
+            } else {
+                -amount
+            }
+        } else {
+            // Showdown.
+            let p0 = rank_of(s.p[0].unwrap());
+            let p1 = rank_of(s.p[1].unwrap());
+            let b = rank_of(s.board.unwrap());
+            let pair0 = p0 == b;
+            let pair1 = p1 == b;
+            let result = if pair0 && !pair1 {
+                1
+            } else if pair1 && !pair0 {
+                -1
+            } else {
+                // Neither pairs (can't both pair: only one card of the board
+                // rank remains in the deck). Compare ranks.
+                p0.cmp(&p1) as i32
+            };
+            match result.signum() {
+                1 => s.contrib[1],
+                -1 => -s.contrib[0],
+                _ => 0.0,
+            }
+        };
+        if player == 0 {
+            u0
+        } else {
+            -u0
+        }
+    }
+
+    fn action_label(&self, a: LeducAction) -> String {
+        match a {
+            LeducAction::Fold => "fold".into(),
+            LeducAction::Call => "call".into(),
+            LeducAction::Raise => "raise".into(),
+            LeducAction::DealHole(i, j) => format!("deal({i},{j})"),
+            LeducAction::DealBoard(c) => format!("board({c})"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    fn walk(g: &LeducHoldem) -> (usize, usize, f64) {
+        // Returns (terminals, infosets, sum of leaf chance-mass) via DFS.
+        let mut terminals = 0usize;
+        let mut infosets = BTreeSet::new();
+        let mut leaf_mass = 0.0;
+        let mut stack = vec![(g.root(), 1.0f64)];
+        while let Some((s, m)) = stack.pop() {
+            if g.is_terminal(&s) {
+                terminals += 1;
+                leaf_mass += m;
+                continue;
+            }
+            if g.is_chance(&s) {
+                for (a, p) in g.chance_outcomes(&s) {
+                    stack.push((g.apply(&s, a), m * p));
+                }
+            } else {
+                infosets.insert(g.infoset_key(&s));
+                let acts = g.legal_actions(&s);
+                assert!(!acts.is_empty());
+                for a in acts {
+                    stack.push((g.apply(&s, a), m));
+                }
+            }
+        }
+        (terminals, infosets.len(), leaf_mass)
+    }
+
+    #[test]
+    fn tree_well_formed() {
+        let g = LeducHoldem::new();
+        let (terminals, infosets, _) = walk(&g);
+        assert!(terminals > 0);
+        // Standard Leduc has 288 information sets.
+        assert_eq!(infosets, 288, "expected 288 infosets, got {infosets}");
+    }
+
+    #[test]
+    fn pair_beats_high_card() {
+        let g = LeducHoldem::new();
+        // p0 = J(card0), p1 = K(card4), board = J(card1) -> p0 pairs Js, wins.
+        let s = LeducState {
+            p: [Some(0), Some(4)],
+            board: Some(1),
+            phase: Phase::Done,
+            contrib: [3.0, 3.0],
+            ..g.root()
+        };
+        assert!(g.payoff(&s, 0) > 0.0);
+        assert_eq!(g.payoff(&s, 0), -g.payoff(&s, 1));
+    }
+
+    #[test]
+    fn fold_pays_contribution() {
+        let g = LeducHoldem::new();
+        let mut s = g.root();
+        s.contrib = [3.0, 1.0];
+        s.folded = Some(1); // player 1 folded
+        s.phase = Phase::Done;
+        // Player 0 wins player 1's contribution (1.0).
+        assert_eq!(g.payoff(&s, 0), 1.0);
+    }
+}

--- a/crates/poker-darwin/src/games/mod.rs
+++ b/crates/poker-darwin/src/games/mod.rs
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+//
+// Concrete poker games implementing `crate::game::Game`. These are the standard
+// research testbeds for equilibrium solving: small enough that exact
+// exploitability is computable (so correctness is *provable*, not merely
+// plausible), yet structurally identical to full poker — private cards, betting
+// rounds, bluffing, slow-playing.
+
+pub mod kuhn;
+pub mod leduc;
+
+pub use kuhn::{KuhnAction, KuhnPoker, KuhnState};
+pub use leduc::{LeducAction, LeducHoldem, LeducState};

--- a/crates/poker-darwin/src/lib.rs
+++ b/crates/poker-darwin/src/lib.rs
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+#![doc = include_str!("../README.md")]
+
+pub mod cfr;
+pub mod darwin;
+pub mod exploit;
+pub mod features;
+pub mod game;
+pub mod games;
+pub mod optimize;
+pub mod rng;
+
+#[cfg(feature = "ruvector")]
+pub mod abstraction;
+#[cfg(feature = "neural")]
+pub mod neural;
+#[cfg(feature = "realgames")]
+pub mod realgames;
+
+pub use cfr::{CfrVariant, Solver, SolverConfig};
+pub use darwin::{DarwinConfig, DarwinReport, Genome};
+pub use exploit::{best_response_value, exploitability, profile_value};
+pub use game::Game;
+pub use games::{KuhnPoker, LeducHoldem};

--- a/crates/poker-darwin/src/neural.rs
+++ b/crates/poker-darwin/src/neural.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+//
+// Deep-CFR-style policy network via candle (feature `neural`).
+//
+// Tabular CFR stores a strategy per information set, which doesn't scale to full
+// poker. Deep CFR replaces the table with a neural network that *generalizes*
+// across information sets from their features. This module demonstrates the core
+// mechanism end-to-end: solve Kuhn with CFR+, then train a candle MLP to predict
+// the equilibrium action distribution from the same interpretable infoset
+// features used by the ruvector abstraction. The training loss falling and the
+// network reproducing the solved strategy is the proof the integration works.
+
+use crate::cfr::{Solver, SolverConfig};
+use crate::features::featurize;
+use crate::games::KuhnPoker;
+use candle_core::{DType, Device, Result as CResult, Tensor};
+use candle_nn::{linear, AdamW, Linear, Module, Optimizer, ParamsAdamW, VarBuilder, VarMap};
+
+/// A small two-layer perceptron mapping infoset features → action logits.
+pub struct PolicyNet {
+    l1: Linear,
+    l2: Linear,
+}
+
+impl PolicyNet {
+    pub fn new(vb: VarBuilder, in_dim: usize, hidden: usize, actions: usize) -> CResult<Self> {
+        Ok(PolicyNet {
+            l1: linear(in_dim, hidden, vb.pp("l1"))?,
+            l2: linear(hidden, actions, vb.pp("l2"))?,
+        })
+    }
+
+    /// Forward to raw logits (apply softmax for probabilities).
+    pub fn logits(&self, x: &Tensor) -> CResult<Tensor> {
+        let h = self.l1.forward(x)?.relu()?;
+        self.l2.forward(&h)
+    }
+
+    /// Action-probability predictions.
+    pub fn probs(&self, x: &Tensor) -> CResult<Tensor> {
+        candle_nn::ops::softmax(&self.logits(x)?, 1)
+    }
+}
+
+/// Train a policy net to reproduce `targets` (rows of action distributions) from
+/// `features`. Returns the per-epoch loss curve and the trained net + varmap.
+pub fn train_policy_net(
+    features: &[Vec<f32>],
+    targets: &[Vec<f32>],
+    hidden: usize,
+    epochs: usize,
+    lr: f64,
+) -> CResult<(Vec<f32>, PolicyNet, VarMap)> {
+    let device = Device::Cpu;
+    let n = features.len();
+    assert!(n > 0 && n == targets.len());
+    let in_dim = features[0].len();
+    let actions = targets[0].len();
+
+    let x = Tensor::from_vec(features.concat(), (n, in_dim), &device)?;
+    let y = Tensor::from_vec(targets.concat(), (n, actions), &device)?;
+
+    let varmap = VarMap::new();
+    let vb = VarBuilder::from_varmap(&varmap, DType::F32, &device);
+    let net = PolicyNet::new(vb, in_dim, hidden, actions)?;
+    let mut opt = AdamW::new(
+        varmap.all_vars(),
+        ParamsAdamW {
+            lr,
+            ..Default::default()
+        },
+    )?;
+
+    let mut losses = Vec::with_capacity(epochs);
+    for _ in 0..epochs {
+        let pred = net.probs(&x)?;
+        let loss = candle_nn::loss::mse(&pred, &y)?;
+        opt.backward_step(&loss)?;
+        losses.push(loss.to_scalar::<f32>()?);
+    }
+    Ok((losses, net, varmap))
+}
+
+/// CLI demo: solve Kuhn, distil the equilibrium policy into a candle MLP, print
+/// the loss curve and predicted-vs-solved strategies.
+pub fn demo(epochs: usize) {
+    println!("== candle Deep-CFR policy distillation (Kuhn) ==");
+    let mut solver = Solver::new(KuhnPoker::new(), SolverConfig::default());
+    solver.train(5000);
+    let avg = solver.average_strategy();
+
+    // Build a supervised dataset: infoset features -> equilibrium action probs.
+    let mut keys: Vec<String> = avg.keys().cloned().collect();
+    keys.sort();
+    let features: Vec<Vec<f32>> = keys.iter().map(|k| featurize(k)).collect();
+    let targets: Vec<Vec<f32>> = keys
+        .iter()
+        .map(|k| avg[k].iter().map(|&p| p as f32).collect())
+        .collect();
+
+    let (losses, net, _vm) = match train_policy_net(&features, &targets, 32, epochs, 0.05) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("training failed: {e}");
+            return;
+        }
+    };
+
+    println!("samples: {}  (Kuhn infosets)", features.len());
+    let step = (losses.len() / 8).max(1);
+    println!("\n{:>6}  {:>10}", "epoch", "mse_loss");
+    for (i, l) in losses.iter().enumerate().step_by(step) {
+        println!("{i:>6}  {l:>10.6}");
+    }
+    println!(
+        "final loss: {:.6}",
+        losses.last().copied().unwrap_or(f32::NAN)
+    );
+
+    // Show a few predicted vs solved strategies.
+    println!("\ninfoset            solved[pass,bet]     net[pass,bet]");
+    let device = Device::Cpu;
+    for (k, f) in keys.iter().zip(&features).take(6) {
+        let x = Tensor::from_vec(f.clone(), (1, f.len()), &device).unwrap();
+        let p = net.probs(&x).unwrap().to_vec2::<f32>().unwrap();
+        let s = &avg[k];
+        println!(
+            "{k:<16}  [{:.3}, {:.3}]        [{:.3}, {:.3}]",
+            s[0], s[1], p[0][0], p[0][1]
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn net_learns_a_simple_mapping() {
+        // Two well-separated feature clusters -> two opposite distributions.
+        let features = vec![
+            vec![0.0, 0.0, 0.0],
+            vec![1.0, 1.0, 1.0],
+            vec![0.0, 0.1, 0.0],
+            vec![1.0, 0.9, 1.0],
+        ];
+        let targets = vec![
+            vec![0.9, 0.1],
+            vec![0.1, 0.9],
+            vec![0.9, 0.1],
+            vec![0.1, 0.9],
+        ];
+        let (losses, _net, _vm) = train_policy_net(&features, &targets, 16, 400, 0.05).unwrap();
+        assert!(losses[0].is_finite());
+        assert!(
+            *losses.last().unwrap() < losses[0] * 0.5,
+            "loss should drop substantially: {} -> {}",
+            losses[0],
+            losses.last().unwrap()
+        );
+    }
+
+    #[test]
+    fn distils_kuhn_policy() {
+        let mut solver = Solver::new(KuhnPoker::new(), SolverConfig::default());
+        solver.train(2000);
+        let avg = solver.average_strategy();
+        let mut keys: Vec<String> = avg.keys().cloned().collect();
+        keys.sort();
+        let features: Vec<Vec<f32>> = keys.iter().map(|k| featurize(k)).collect();
+        let targets: Vec<Vec<f32>> = keys
+            .iter()
+            .map(|k| avg[k].iter().map(|&p| p as f32).collect())
+            .collect();
+        let (losses, _net, _vm) = train_policy_net(&features, &targets, 32, 600, 0.05).unwrap();
+        assert!(
+            *losses.last().unwrap() < 0.05,
+            "should fit Kuhn policy: final {}",
+            losses.last().unwrap()
+        );
+    }
+}

--- a/crates/poker-darwin/src/optimize.rs
+++ b/crates/poker-darwin/src/optimize.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: MIT
+//
+// A domain-agnostic, non-stationary optimizer driven by the *same* Chebyshev
+// `Schedule` engine that schedules the CFR solver's α / ω / P. Its existence is
+// the answer to "is Darwin coupled to regret-matching?": no — the per-iteration
+// hook takes arbitrary gradient signals. CFR is one consumer of the schedule
+// machinery (it maps the schedules onto counterfactual-regret physics); this
+// optimizer is another (it maps them onto gradient descent with momentum and
+// magnitude pruning, à la the Lottery Ticket Hypothesis).
+//
+// The genome that Darwin evolves (Chebyshev coefficient vectors, ADR-188) is
+// equally applicable here: swap the fitness function from "−exploitability of a
+// solved game" to "−validation loss of a trained network" and the same
+// evolutionary loop tunes a bespoke optimizer schedule for any dataset.
+
+use crate::cfr::Schedule;
+
+/// Per-iteration physics shared across domains: a functional step-size, a
+/// functional momentum coefficient, and a functional magnitude-pruning
+/// threshold — each a [`Schedule`]. Fed arbitrary gradients via [`Self::step`].
+#[derive(Clone, Debug)]
+pub struct NonStationaryOptimizer {
+    step_size: Schedule,
+    momentum: Schedule,
+    pruning: Schedule,
+    weights: Vec<f64>,
+    velocity: Vec<f64>,
+    active: Vec<bool>,
+    t: u64,
+    horizon: u64,
+}
+
+impl NonStationaryOptimizer {
+    pub fn new(
+        initial_weights: Vec<f64>,
+        horizon: u64,
+        step_size: Schedule,
+        momentum: Schedule,
+        pruning: Schedule,
+    ) -> Self {
+        let n = initial_weights.len();
+        NonStationaryOptimizer {
+            step_size,
+            momentum,
+            pruning,
+            weights: initial_weights,
+            velocity: vec![0.0; n],
+            active: vec![true; n],
+            t: 0,
+            horizon,
+        }
+    }
+
+    /// The unified per-iteration hook. `gradients` are arbitrary — they need not
+    /// come from regret matching. Applies functional momentum, the weight
+    /// update, and non-stationary magnitude pruning (pruned weights freeze at 0
+    /// and stop accumulating momentum, isolating live weights from dead noise).
+    pub fn step(&mut self, gradients: &[f64]) {
+        assert_eq!(gradients.len(), self.weights.len());
+        let lr = self.step_size.at(self.t, self.horizon);
+        let mom = self.momentum.at(self.t, self.horizon);
+        let thr = self.pruning.at(self.t, self.horizon);
+        // Zip the parallel tracks so the compiler can elide bounds checks and
+        // auto-vectorize the fused update (the user's "unified hook" layout).
+        let iter = self
+            .weights
+            .iter_mut()
+            .zip(self.velocity.iter_mut())
+            .zip(self.active.iter_mut())
+            .zip(gradients.iter());
+        for (((weight, velocity), active), &grad) in iter {
+            if !*active {
+                continue;
+            }
+            *velocity = mom * *velocity + lr * grad;
+            *weight -= *velocity;
+            if weight.abs() < thr {
+                *weight = 0.0;
+                *velocity = 0.0;
+                *active = false;
+            }
+        }
+        self.t += 1;
+    }
+
+    pub fn weights(&self) -> &[f64] {
+        &self.weights
+    }
+
+    /// Number of weights not yet structurally pruned.
+    pub fn active_count(&self) -> usize {
+        self.active.iter().filter(|&&a| a).count()
+    }
+}
+
+/// Convenience driver: run `steps` iterations minimizing `loss_grad` (which maps
+/// the current weights to a gradient). Returns the final weights and the loss
+/// trajectory from `loss`.
+pub fn minimize<G, L>(
+    initial: Vec<f64>,
+    steps: u64,
+    step_size: Schedule,
+    momentum: Schedule,
+    pruning: Schedule,
+    mut loss_grad: G,
+    mut loss: L,
+) -> (Vec<f64>, Vec<f64>)
+where
+    G: FnMut(&[f64]) -> Vec<f64>,
+    L: FnMut(&[f64]) -> f64,
+{
+    let mut opt = NonStationaryOptimizer::new(initial, steps, step_size, momentum, pruning);
+    let mut curve = Vec::with_capacity(steps as usize);
+    for _ in 0..steps {
+        let g = loss_grad(opt.weights());
+        opt.step(&g);
+        curve.push(loss(opt.weights()));
+    }
+    (opt.weights().to_vec(), curve)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimizes_a_quadratic_with_gradient_signal() {
+        // f(w) = Σ wᵢ²  →  ∇ = 2w. No pruning (threshold below any value reached).
+        let init = vec![3.0, -4.0, 1.5];
+        let (w, curve) = minimize(
+            init,
+            200,
+            Schedule::constant(0.1),  // step size
+            Schedule::constant(0.8),  // momentum
+            Schedule::constant(-1.0), // pruning effectively off (|w| never < -1)
+            |w| w.iter().map(|x| 2.0 * x).collect(),
+            |w| w.iter().map(|x| x * x).sum(),
+        );
+        assert!(
+            curve.last().unwrap() < &1e-3,
+            "should converge to ~0: {}",
+            curve.last().unwrap()
+        );
+        assert!(w.iter().all(|x| x.abs() < 0.05));
+    }
+
+    #[test]
+    fn magnitude_pruning_sparsifies() {
+        // Annealing pruning threshold should cull the small weight and freeze it.
+        let init = vec![5.0, 0.02, -5.0];
+        let (w, _) = minimize(
+            init,
+            50,
+            Schedule::constant(0.01),
+            Schedule::constant(0.0),
+            Schedule::linear(0.0, 0.1), // threshold grows toward 0.1
+            |w| w.iter().map(|x| 0.001 * x).collect(),
+            |w| w.iter().map(|x| x * x).sum(),
+        );
+        assert_eq!(w[1], 0.0, "small weight should be pruned to exactly 0");
+        assert!(
+            w[0].abs() > 1.0 && w[2].abs() > 1.0,
+            "large weights survive"
+        );
+    }
+
+    #[test]
+    fn chebyshev_schedule_drives_a_nonpoker_optimizer() {
+        // Proof of decoupling: a Chebyshev (non-monotone) step-size curve drives a
+        // plain gradient optimizer with no CFR/regret concepts in sight.
+        let lr = Schedule::chebyshev(&[0.05, -0.03, 0.01], 0.001, 0.1);
+        let (_w, curve) = minimize(
+            vec![10.0],
+            300,
+            lr,
+            Schedule::constant(0.9),
+            Schedule::constant(-1.0),
+            |w| vec![2.0 * w[0]],
+            |w| w[0] * w[0],
+        );
+        assert!(
+            curve.last().unwrap() < &curve[0],
+            "loss must fall under a Chebyshev LR schedule"
+        );
+    }
+}

--- a/crates/poker-darwin/src/realgames.rs
+++ b/crates/poker-darwin/src/realgames.rs
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: MIT
+//
+// Real Texas Hold'em via `rs_poker` (feature `realgames`). The CFR solver in
+// this crate targets the standard *research* poker games (Kuhn, Leduc) where
+// exact equilibria are computable. This module connects to *full* poker: real
+// 52-card hand evaluation and Monte Carlo equity, so the harness can be
+// benchmarked against the actual game it abstracts. It also provides a real
+// hand-strength feature that a Hold'em abstraction or value net would consume.
+
+use rs_poker::core::{Hand, Rankable};
+use rs_poker::holdem::MonteCarloGame;
+
+/// Estimate each player's all-in equity (probability of winning, ties split) by
+/// Monte Carlo rollout of the remaining board. `hands` are hole cards like
+/// "AsKs". Returns one equity per hand, summing to ~1.0.
+pub fn equity(hands: &[String], iters: usize) -> Result<Vec<f32>, String> {
+    let parsed: Result<Vec<Hand>, _> = hands
+        .iter()
+        .map(|h| Hand::new_from_str(h).map_err(|e| format!("bad hand {h:?}: {e:?}")))
+        .collect();
+    let parsed = parsed?;
+    if parsed.len() < 2 {
+        return Err("need at least two hands".into());
+    }
+    let mut game =
+        MonteCarloGame::new(parsed).map_err(|e| format!("monte carlo init failed: {e:?}"))?;
+    let mut wins = vec![0.0f64; hands.len()];
+    for _ in 0..iters {
+        let (winners, _rank) = game.simulate();
+        let n = winners.count() as f64;
+        if n > 0.0 {
+            for idx in winners.ones() {
+                wins[idx] += 1.0 / n;
+            }
+        }
+        game.reset();
+    }
+    Ok(wins
+        .into_iter()
+        .map(|w| (w / iters as f64) as f32)
+        .collect())
+}
+
+/// Rank a concrete 5–7 card hand (e.g. "2h2d8d8sKd6sTh") with the real
+/// evaluator. Higher `Rank` is a stronger hand.
+pub fn hand_rank(cards: &str) -> Result<rs_poker::core::Rank, String> {
+    let hand = Hand::new_from_str(cards).map_err(|e| format!("bad hand {cards:?}: {e:?}"))?;
+    Ok(hand.rank())
+}
+
+/// A normalized [0,1] hand-strength feature for a hole pair against a single
+/// random opponent — exactly the kind of signal a Hold'em information-set
+/// abstraction or candle value net would use as input.
+pub fn hand_strength(hole: &str, iters: usize) -> Result<f32, String> {
+    let hero = Hand::new_from_str(hole).map_err(|e| format!("bad hand {hole:?}: {e:?}"))?;
+    // Villain hole cards are unknown; rs_poker fills them randomly each rollout.
+    let villain = Hand::new_from_str("").map_err(|e| format!("villain init: {e:?}"))?;
+    let mut game = MonteCarloGame::new(vec![hero, villain])
+        .map_err(|e| format!("monte carlo init failed: {e:?}"))?;
+    let mut hero_eq = 0.0f64;
+    for _ in 0..iters {
+        let (winners, _) = game.simulate();
+        let n = winners.count() as f64;
+        if winners.ones().any(|i| i == 0) && n > 0.0 {
+            hero_eq += 1.0 / n;
+        }
+        game.reset();
+    }
+    Ok((hero_eq / iters as f64) as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rs_poker::core::CoreRank;
+
+    #[test]
+    fn royal_flush_outranks_pair() {
+        let royal = hand_rank("AsKsQsJsTs").unwrap();
+        let pair = hand_rank("AhAd2c3d4s").unwrap();
+        assert!(royal > pair, "royal flush should outrank a pair");
+        assert_eq!(royal.category(), CoreRank::StraightFlush);
+    }
+
+    #[test]
+    fn aces_beat_offsuit_rag_heads_up() {
+        // Pocket aces should crush 7-2 offsuit; equities sum to ~1.
+        let eq = equity(&["AsAc".into(), "7d2h".into()], 20_000).unwrap();
+        assert!(
+            (eq.iter().sum::<f32>() - 1.0).abs() < 1e-3,
+            "equities should sum to 1: {eq:?}"
+        );
+        assert!(eq[0] > 0.8, "AA equity {} should be > 0.8 vs 72o", eq[0]);
+    }
+}

--- a/crates/poker-darwin/src/rng.rs
+++ b/crates/poker-darwin/src/rng.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: MIT
+//
+// A tiny, dependency-free, fully-deterministic PRNG (SplitMix64 seeding a
+// xoshiro256** stream). The whole crate's stochastic behaviour — Darwin
+// mutation, neural mini-batch sampling, Monte Carlo rollouts — funnels through
+// this so every run is byte-reproducible from a single u64 seed. That property
+// is what lets the tests assert exact champion receipts and lets benchmarks
+// compare like-for-like across commits.
+
+/// Deterministic xoshiro256** PRNG, seeded via SplitMix64.
+#[derive(Clone, Debug)]
+pub struct Rng {
+    s: [u64; 4],
+}
+
+impl Rng {
+    /// Construct from a 64-bit seed. Distinct seeds give independent streams.
+    pub fn new(seed: u64) -> Self {
+        // SplitMix64 to expand the seed into the 256-bit state.
+        let mut z = seed;
+        let mut next = || {
+            z = z.wrapping_add(0x9E3779B97F4A7C15);
+            let mut x = z;
+            x = (x ^ (x >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+            x = (x ^ (x >> 27)).wrapping_mul(0x94D049BB133111EB);
+            x ^ (x >> 31)
+        };
+        Rng {
+            s: [next(), next(), next(), next()],
+        }
+    }
+
+    #[inline]
+    fn rotl(x: u64, k: u32) -> u64 {
+        (x << k) | (x >> (64 - k))
+    }
+
+    /// Next raw u64 in the stream.
+    #[inline]
+    pub fn next_u64(&mut self) -> u64 {
+        let result = Self::rotl(self.s[1].wrapping_mul(5), 7).wrapping_mul(9);
+        let t = self.s[1] << 17;
+        self.s[2] ^= self.s[0];
+        self.s[3] ^= self.s[1];
+        self.s[1] ^= self.s[2];
+        self.s[0] ^= self.s[3];
+        self.s[2] ^= t;
+        self.s[3] = Self::rotl(self.s[3], 45);
+        result
+    }
+
+    /// Uniform f64 in [0, 1).
+    #[inline]
+    pub fn next_f64(&mut self) -> f64 {
+        // 53 high bits → uniform in [0,1).
+        (self.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64)
+    }
+
+    /// Uniform usize in `[0, n)`. Panics if `n == 0`.
+    #[inline]
+    pub fn below(&mut self, n: usize) -> usize {
+        assert!(n > 0, "Rng::below(0)");
+        (self.next_f64() * n as f64) as usize % n
+    }
+
+    /// Return `true` with probability `p`.
+    #[inline]
+    pub fn chance(&mut self, p: f64) -> bool {
+        self.next_f64() < p
+    }
+
+    /// Uniform f64 in `[lo, hi)`.
+    #[inline]
+    pub fn range_f64(&mut self, lo: f64, hi: f64) -> f64 {
+        lo + (hi - lo) * self.next_f64()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Rng;
+
+    #[test]
+    fn deterministic_from_seed() {
+        let a: Vec<u64> = (0..8)
+            .map(|_| 0)
+            .scan(Rng::new(42), |r, _| Some(r.next_u64()))
+            .collect();
+        let b: Vec<u64> = (0..8)
+            .map(|_| 0)
+            .scan(Rng::new(42), |r, _| Some(r.next_u64()))
+            .collect();
+        assert_eq!(a, b);
+        let c: Vec<u64> = (0..8)
+            .map(|_| 0)
+            .scan(Rng::new(43), |r, _| Some(r.next_u64()))
+            .collect();
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn uniform_in_range() {
+        let mut r = Rng::new(7);
+        for _ in 0..10_000 {
+            let x = r.next_f64();
+            assert!((0.0..1.0).contains(&x));
+            assert!(r.below(5) < 5);
+        }
+    }
+
+    #[test]
+    fn below_roughly_uniform() {
+        let mut r = Rng::new(123);
+        let mut counts = [0u32; 6];
+        for _ in 0..60_000 {
+            counts[r.below(6)] += 1;
+        }
+        // Each bucket should be near 10_000; allow generous slack.
+        for c in counts {
+            assert!((8_500..11_500).contains(&c), "bucket skew: {counts:?}");
+        }
+    }
+}

--- a/crates/poker-darwin/tests/convergence.rs
+++ b/crates/poker-darwin/tests/convergence.rs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+//
+// Integration tests that pin the solver's *ground-truth* behaviour:
+//   * Kuhn Poker converges to its known game value of -1/18 to the first player.
+//   * CFR drives exploitability toward zero (a proof of Nash convergence).
+//   * CFR+ converges strictly faster than vanilla CFR on Leduc (the property the
+//     "one strategy per infoset per iteration" fix restored).
+//   * Darwin's evolved champion is no worse than the vanilla baseline.
+
+use poker_darwin::cfr::{CfrVariant, Solver, SolverConfig};
+use poker_darwin::darwin::{evolve, DarwinConfig};
+use poker_darwin::exploit::{exploitability, profile_value};
+use poker_darwin::games::{KuhnPoker, LeducHoldem};
+
+fn train_exploit<G: poker_darwin::game::Game + Clone>(
+    game: G,
+    variant: CfrVariant,
+    iters: u64,
+) -> f64 {
+    let mut s = Solver::new(game.clone(), SolverConfig::new(variant));
+    s.train(iters);
+    exploitability(&game, &s.average_strategy())
+}
+
+#[test]
+fn kuhn_converges_to_known_game_value() {
+    // Kuhn Poker's game value to player 0 at equilibrium is exactly -1/18.
+    let mut s = Solver::new(KuhnPoker::new(), SolverConfig::default());
+    s.train(3000);
+    let v = profile_value(s.game(), &s.average_strategy());
+    assert!(
+        (v - (-1.0 / 18.0)).abs() < 5e-3,
+        "Kuhn value {v} should be ~ -1/18 = {}",
+        -1.0 / 18.0
+    );
+}
+
+#[test]
+fn kuhn_exploitability_drops_to_near_zero() {
+    let e = train_exploit(KuhnPoker::new(), CfrVariant::CfrPlus, 3000);
+    assert!(e < 0.01, "Kuhn CFR+ exploitability {e} should be < 0.01");
+}
+
+#[test]
+fn cfr_plus_beats_vanilla_on_leduc() {
+    // The defining property of CFR+: at an equal iteration budget it is far
+    // less exploitable than vanilla CFR on a multi-round game.
+    let iters = 400;
+    let vanilla = train_exploit(LeducHoldem::new(), CfrVariant::Vanilla, iters);
+    let cfr_plus = train_exploit(LeducHoldem::new(), CfrVariant::CfrPlus, iters);
+    assert!(
+        cfr_plus < vanilla * 0.5,
+        "CFR+ ({cfr_plus}) should be <50% of vanilla ({vanilla}) exploitability on Leduc"
+    );
+}
+
+#[test]
+fn leduc_exploitability_monotone_trend() {
+    // More iterations => lower exploitability (allowing CFR+ oscillation slack).
+    let e_short = train_exploit(LeducHoldem::new(), CfrVariant::CfrPlus, 200);
+    let e_long = train_exploit(LeducHoldem::new(), CfrVariant::CfrPlus, 1000);
+    assert!(
+        e_long < e_short,
+        "exploitability should fall with iterations: {e_short} -> {e_long}"
+    );
+}
+
+#[test]
+fn darwin_champion_beats_vanilla_baseline_on_leduc() {
+    let report = evolve(
+        &LeducHoldem::new(),
+        &DarwinConfig {
+            population: 10,
+            generations: 6,
+            eval_iterations: 300,
+            seed: 1,
+            elite: 3,
+        },
+    );
+    assert!(
+        report.improved_over_baseline,
+        "Darwin should beat the vanilla baseline"
+    );
+    assert!(
+        report.champion_exploitability < report.baseline_exploitability,
+        "champion {} should be < baseline {}",
+        report.champion_exploitability,
+        report.baseline_exploitability
+    );
+}

--- a/docs/adrs/ADR-186-poker-darwin-cfr-solver.md
+++ b/docs/adrs/ADR-186-poker-darwin-cfr-solver.md
@@ -55,3 +55,16 @@ integrations, so default builds stay fast and wasm-safe:
   The crate is native-only (candle + redb don't target wasm) and excluded from the wasm matrix.
 - **Validated integrations.** AA vs 72o equity = 87.4% (rs_poker); ruvector stores all 288 Leduc
   infosets and reaches 86.8% bucket compression; the candle net fits the Kuhn policy (loss 0.26→0.02).
+
+## Reference implementation
+
+`crates/poker-darwin` — dependency-light core, native-only, excluded from the wasm matrix.
+
+- `game.rs` (the `Game` trait + `tree_stats`), `games/{kuhn,leduc}.rs`, `cfr.rs` (solver),
+  `exploit.rs` (exact best-response), `rng.rs` (deterministic SplitMix64/xoshiro256**).
+- Feature modules: `abstraction.rs` (`ruvector`), `neural.rs` (`neural`), `realgames.rs` (`realgames`),
+  with shared `features.rs`.
+- CLI eval harness `src/bin/poker-darwin.rs`: `info | solve | exploit | evolve` (+ feature demos).
+- Tests: 35 passing (29 unit + 5 `tests/convergence.rs` + 1 doc); criterion benches in `benches/cfr_bench.rs`.
+- Environment sizes (`poker-darwin info --game all`): Kuhn 12 infosets / 55 histories / depth 4;
+  Leduc 288 infosets / 3,780 decision nodes / 9,451 histories / depth 10. Utility unit: chips (1 ante).

--- a/docs/adrs/ADR-186-poker-darwin-cfr-solver.md
+++ b/docs/adrs/ADR-186-poker-darwin-cfr-solver.md
@@ -1,0 +1,57 @@
+# ADR-186 — poker-darwin: a CFR poker solver with exact exploitability + ruvector/candle/rs_poker
+
+**Status:** Implemented (`crates/poker-darwin`, 26 tests passing)
+**Date:** 2026-06-24
+**Related:** ADR-119 (Darwin multidomain evolution), ADR-161 (ruVector memory tiers), ADR-187 (non-stationary genome), ADR-188 (Chebyshev schedules)
+
+## Context
+
+Darwin Mode in this repo evolves *structured policies, not prompts* (ADR-119/137/165). To prove the
+pattern transfers to a domain with a hard, non-gameable oracle, we need a problem where "better" is a
+number that cannot be faked. Two-player zero-sum poker is ideal: a strategy's distance from a Nash
+equilibrium — its **exploitability** — is exactly computable on small games, so progress is provable
+rather than plausible. The request was a poker trainer/solver built on Darwin and `ruvnet/ruvector`,
+using `candle` as needed, fully implemented, tested, and benchmarked on real games.
+
+Constraints discovered while scoping:
+- `ruvnet/ruvector` is a 100+ crate workspace; the git protocol to GitHub is egress-blocked here, but
+  `ruvector-core` **0.1.31** is published on crates.io and compiles in ~30s with
+  `default-features = false, features = ["hnsw","memory-only","parallel"]` (no native/C deps).
+- `rs_poker` 3.x/4.x require nightly (`#![feature(assert_matches)]`); **5.0.0** builds on stable 1.88.
+- `candle` is a ~290-crate tree; building it under the workspace LTO profile is slow.
+
+## Decision
+
+Add a workspace crate `crates/poker-darwin` with a **pure-Rust core** and **feature-gated** heavy
+integrations, so default builds stay fast and wasm-safe:
+
+- **Game abstraction** (`game::Game`): a perfect-recall, two-player zero-sum extensive-form trait with
+  explicit chance nodes, so CFR and best-response integrate over the deal *exactly* (no sampling).
+  Implemented games: **Kuhn Poker** (12 infosets, 55 histories) and **Leduc Hold'em** (288 infosets,
+  3,780 decision nodes, 9,451 histories, depth 10) — the canonical CFR testbeds.
+- **Solver** (`cfr`): one parameterized engine covering Vanilla CFR, CFR+, Linear CFR, and Discounted
+  CFR, with the invariant that an information set's strategy is computed **once per iteration** (a
+  per-history recompute silently breaks multi-round convergence — see Consequences).
+- **Exact best response / exploitability** (`exploit`): a two-pass, deepest-first infoset resolution
+  with memoized values — ground-truth ε, not an estimate.
+- **Darwin trainer** (`darwin`): evolutionary search over the solver's configuration genome, fitness =
+  −exploitability, with elitism, a monotone champion curve, and a deterministic FNV-1a receipt.
+- **Feature `ruvector`** (`abstraction`): `ruvector-core` `VectorDB` (HNSW) for information-set state
+  abstraction (nearest-neighbour retrieval + greedy bucketing) and episodic memory.
+- **Feature `neural`** (`neural`): a `candle` MLP that distils the solved policy (Deep-CFR-style).
+- **Feature `realgames`** (`realgames`): `rs_poker` real Texas Hold'em hand evaluation + Monte Carlo
+  equity, for benchmarking the abstraction against full poker.
+
+## Consequences
+
+- **Provable correctness.** CFR+ drives Kuhn's game value to **−0.05556 = −1/18** (the known
+  analytic value) and Leduc to **≈ −0.085**; tests assert exploitability → 0. This is the anti-slop
+  property (ADR-009) made literal: the oracle runs, it isn't trusted.
+- **A real bug was caught by the oracle.** An initial implementation recomputed each infoset's strategy
+  per reaching history; it converged on Kuhn but made CFR+ *slower than vanilla* on Leduc. Pinning one
+  strategy per infoset per iteration restored CFR+'s expected ~5× edge. A weaker metric than exact
+  exploitability would have hidden this.
+- **Cost discipline.** Default build is dependency-light; `ruvector`/`neural`/`realgames` are opt-in.
+  The crate is native-only (candle + redb don't target wasm) and excluded from the wasm matrix.
+- **Validated integrations.** AA vs 72o equity = 87.4% (rs_poker); ruvector stores all 288 Leduc
+  infosets and reaches 86.8% bucket compression; the candle net fits the Kuhn policy (loss 0.26→0.02).

--- a/docs/adrs/ADR-187-darwin-nonstationary-cfr-genome.md
+++ b/docs/adrs/ADR-187-darwin-nonstationary-cfr-genome.md
@@ -50,3 +50,13 @@ non-stationary edge is reported explicitly. Fitness remains exact exploitability
 - **Risk.** Pruning can, in principle, prune an action that later matters; the re-entry mechanism (regret
   discount lifting it back above P) plus the `sigma == 0` guard keeps best-response convergence intact —
   asserted by tests (dynamic ≤ best static on Leduc; exploitability still falls).
+
+## Reference implementation
+
+- The three levers live on one per-iteration hook in `cfr.rs`: `Schedule`-typed `alpha_schedule` /
+  `beta_schedule` on `SolverConfig`, predictive momentum in `prepare_node` (`regret + ω · last_instant`),
+  and regret pruning in `cfr_rec` (with a `SolveStats` prune-rate counter).
+- The kind-4 genome and the static/dynamic-aware `evolve` are in `darwin.rs`; `DarwinReport` exposes
+  `best_static_exploitability` / `best_dynamic_exploitability`, surfaced by the CLI `evolve` "dynamic edge".
+- Reproduce: `poker-darwin evolve --game leduc --generations 12 --population 18 --eval-iters 500`
+  (deterministic for a fixed seed).

--- a/docs/adrs/ADR-187-darwin-nonstationary-cfr-genome.md
+++ b/docs/adrs/ADR-187-darwin-nonstationary-cfr-genome.md
@@ -1,0 +1,52 @@
+# ADR-187 — Non-stationary Darwin: time-variant schedules, predictive momentum, regret pruning
+
+**Status:** Implemented (`crates/poker-darwin`, kind-4 genome + dynamic solver)
+**Date:** 2026-06-24
+**Related:** ADR-186 (poker-darwin), ADR-188 (Chebyshev schedules)
+
+## Context
+
+ADR-186's Darwin trainer found the best *static* solver configuration: on Leduc it evolved a Discounted-CFR
+setting (α≈2.75, β≈−0.48, γ≈2.08) that cut exploitability ~83% vs vanilla. But a static configuration
+assumes the optimal "hyperparameter physics" is constant for the whole solve, which is false: the game
+tree's volatility early (iteration ~10) differs sharply from late (iteration ~1000). Early you want
+aggressive exploration and large regret updates; near equilibrium you want stability and micro-adjustment.
+Beating the absolute ceiling requires giving Darwin the architectural levers to build a *non-stationary*
+solver, not just to tune constants.
+
+## Decision
+
+Generalize the genome from scalars to a non-stationary solver across three orthogonal levers, all bolted
+onto one per-iteration hook in the CFR loop:
+
+1. **Time-variant DCFR schedules.** α and β become functions of iteration `t` over a known horizon
+   (`alpha_schedule`/`beta_schedule`). The hypothesis: start α aggressive (~4) to blast through the early
+   tree and anneal toward CFR+ levels (~1) near equilibrium.
+2. **Predictive (optimistic) regret matching.** A momentum weight ω extrapolates each information set's
+   regret trend before choosing the next strategy: the strategy is computed from
+   `regret + ω · last_iteration_instantaneous_regret`, "skating to where the puck is going."
+3. **Regret-based pruning.** A threshold P skips zero-probability actions whose cumulative regret is
+   below P (they re-enter automatically as DCFR's negative-regret discount lifts them), trading a little
+   exploitability-per-iteration for exploitability-per-**wall-clock-second**. A `SolveStats` counter
+   reports the prune rate.
+
+The genome carries `kind` (0 Vanilla … 4 linear-dynamic DCFR), the static DCFR exponents, the dynamic
+α/β schedule endpoints + decay, ω, and P. Mutation flips family or jitters one gene; `evolve` seeds the
+population across the static/dynamic spectrum and tracks the **best static vs best dynamic** genome so the
+non-stationary edge is reported explicitly. Fitness remains exact exploitability; runs stay deterministic.
+
+## Consequences
+
+- **The dynamic family wins, and rediscovers the hypothesis.** On Leduc (eval 500 it), Darwin's champion
+  is dynamic with α annealing **3.81 → 1.79** — exactly "aggressive early, stabilize late," found
+  autonomously. Best dynamic **0.003372** vs best static **0.010801**: a **68.8%** reduction *on top of*
+  the static gain, and **94%** below vanilla.
+- **A new reporting axis.** `DarwinReport` exposes `best_static_exploitability` and
+  `best_dynamic_exploitability`; the CLI `evolve` prints the "dynamic edge". This is the experiment that
+  proves the lever, not a claim.
+- **Generality.** Momentum and pruning are independent of the DCFR discount and compose with any variant;
+  the per-iteration hook is the single place all three levers apply, which sets up ADR-188's functional
+  schedules and a domain-agnostic optimizer.
+- **Risk.** Pruning can, in principle, prune an action that later matters; the re-entry mechanism (regret
+  discount lifting it back above P) plus the `sigma == 0` guard keeps best-response convergence intact —
+  asserted by tests (dynamic ≤ best static on Leduc; exploitability still falls).

--- a/docs/adrs/ADR-188-chebyshev-functional-schedule-genome.md
+++ b/docs/adrs/ADR-188-chebyshev-functional-schedule-genome.md
@@ -46,3 +46,15 @@ its per-iteration hook should accept arbitrary signals (e.g. gradients), not onl
   evolution). The poker solver is the first application of the engine, not its boundary.
 - **Cost.** Evaluating Chebyshev curves is a handful of FMA per iteration (Clenshaw, order ≤ 8) — negligible
   next to a tree traversal.
+
+## Reference implementation
+
+- `Schedule` (Clenshaw recurrence, fixed `[f64; 8]`, `[lo,hi]` clamp) and the `omega_schedule` /
+  `prune_schedule` config fields are in `cfr.rs`; the kind-5 genome (α/ω/P Chebyshev coefficient arrays)
+  and `LineageNode` / `trace_ancestry` are in `darwin.rs`.
+- `optimize.rs` (`NonStationaryOptimizer`, `minimize`) is the domain-agnostic hook: the same `Schedule`
+  driving a gradient optimizer with magnitude pruning — no CFR/regret concepts, proving decoupling.
+- The CLI `evolve` prints the champion's seed→champion lineage and `evaluated genomes` count.
+- **Parallelism note:** per-generation scoring is embarrassingly parallel, but scoring stays sequential to
+  preserve the deterministic receipt; a Rayon pass over the pure `score()` map (RNG/selection kept
+  sequential) is the intended opt-in if eval cost grows. Tests pin same-seed reproducibility.

--- a/docs/adrs/ADR-188-chebyshev-functional-schedule-genome.md
+++ b/docs/adrs/ADR-188-chebyshev-functional-schedule-genome.md
@@ -1,0 +1,48 @@
+# ADR-188 — Chebyshev functional-schedule genome, lineage tracking, and a domain-agnostic hook
+
+**Status:** Implemented (`crates/poker-darwin`, kind-5 genome + `optimize` module)
+**Date:** 2026-06-24
+**Related:** ADR-186 (poker-darwin), ADR-187 (non-stationary genome)
+
+## Context
+
+ADR-187's dynamic genome used simple start→end ramps. A start/end ramp can only express monotone
+trajectories; it cannot represent warming, cyclic, or volatile schedules, and naive step-decay /
+piecewise-constant alternatives make mutation produce discontinuous spikes. State-of-the-art
+evolutionary schedule search parameterizes *continuous trajectories* with compact orthogonal basis
+functions so that a one-coefficient mutation yields a smooth global-or-localized deformation of the curve.
+Separately: if Darwin is really a *phase-aware optimization engine* rather than a poker-specific solver,
+its per-iteration hook should accept arbitrary signals (e.g. gradients), not only counterfactual regrets.
+
+## Decision
+
+1. **Chebyshev functional schedules.** Replace the ramp `Schedule` with a shifted Chebyshev polynomial
+   of the first kind over normalized time `t̂ = 2·progress − 1 ∈ [−1, 1]`, evaluated by **Clenshaw's
+   recurrence** (numerically stable — avoids `xⁿ` catastrophic cancellation) and clamped to `[lo, hi]`
+   so mutation can never produce explosive values. Storage is a fixed `[f64; 8]` array, keeping the
+   schedule `Copy` and zero-allocation. `Schedule::{constant, linear, chebyshev}` cover the prior cases.
+2. **Kind-5 genome (Chebyshev-dynamic).** The genome emits three trajectories — the value curve α(t), the
+   momentum curve ω(t), and the pruning curve P(t) — each as order-4 Chebyshev coefficients, plus β and γ.
+   Mutation jitters individual coefficients (higher orders get smaller steps to keep curves smooth).
+3. **Lineage tracking.** Each population member carries a stable id + parent id; `evolve` records a
+   `LineageNode` per evaluated genome and reconstructs the champion's ancestry seed→champion. This is the
+   explicit, deterministic answer to "track parent-child trajectory lineages across generations."
+4. **Domain-agnostic hook (`optimize`).** Extract the per-iteration physics (functional step-size,
+   predictive momentum, magnitude pruning) into a `NonStationaryOptimizer` driven by the *same* `Schedule`
+   type but fed arbitrary gradient/loss signals — demonstrating the engine is not coupled to
+   regret-matching. CFR remains one consumer of the schedule machinery, not its definition.
+
+## Consequences
+
+- **Higher-order schedules push further.** On Leduc (eval 600 it), a Chebyshev champion (α curve
+  `[3.13, 0.14, 0.56, 0.53]` — non-monotone, unrepresentable by a ramp) reached exploitability
+  **0.002184**: best dynamic vs best static = **79.2%** lower (up from 68.8% with ramps), and **96%**
+  below vanilla. The champion's lineage crossed three families: static DCFR → linear-dynamic → Chebyshev.
+- **Determinism preserved.** Larger genomes change the RNG draw sequence (so receipts differ from
+  ADR-187) but same-seed reproducibility and the monotone champion curve hold; tests pin both.
+- **Decoupling is real.** Because `Schedule` and the optimizer hook take plain `f64` signals, the same
+  Chebyshev trajectory engine that schedules CFR's α/ω/P can schedule a learning rate / momentum / sparsity
+  mask for a gradient optimizer (Lottery-Ticket-style magnitude pruning, hyperparameter-schedule
+  evolution). The poker solver is the first application of the engine, not its boundary.
+- **Cost.** Evaluating Chebyshev curves is a handful of FMA per iteration (Clenshaw, order ≤ 8) — negligible
+  next to a tree traversal.

--- a/docs/adrs/INDEX.md
+++ b/docs/adrs/INDEX.md
@@ -134,6 +134,14 @@ ADR-006 (memory + learning) and ADR-008 (drift detection) cut across all phases.
 
 > **ADR-156…167 implementation note:** the ADR-156 program and its ten patterns (ADR-157…166) plus ADR-167 are implemented in `packages/projects` (`@metaharness/projects`) — dependency-free, deterministic, 117+ tests, with benchmark receipts under `bench/results/`. Each carries a `## Reference implementation` section. Real-LLM benches are optional/key-gated and excluded from the deterministic suite.
 
+## Darwin applied to game-theoretic solving (`crates/poker-darwin`)
+
+| ADR | Title | Status | Summary |
+|-----|-------|--------|---------|
+| [ADR-186](./ADR-186-poker-darwin-cfr-solver.md) | poker-darwin: CFR solver with exact exploitability + ruvector/candle/rs_poker | Implemented | A workspace crate proving Darwin's *mutate-structured-policies* thesis on a hard, non-gameable oracle: a CFR/CFR+/DCFR solver for Kuhn (12 infosets) and Leduc (288 infosets, 9,451 histories) scored by **exact exploitability**. Reaches Kuhn's known −1/18 value. Feature-gated `ruvector` (infoset abstraction, 86.8% compression), `candle` (Deep-CFR policy distillation), `rs_poker` (real Hold'em equity). |
+| [ADR-187](./ADR-187-darwin-nonstationary-cfr-genome.md) | Non-stationary Darwin: time-variant schedules, predictive momentum, regret pruning | Implemented | Generalizes the genome from scalars to a non-stationary solver: α/β anneal over the run, predictive (optimistic) momentum ω extrapolates regret trends, and a pruning threshold P trades ε/iteration for ε/second. Darwin autonomously rediscovers "α aggressive→stable" (3.81→1.79) and its dynamic champion beats the best static one by **68.8%** (94% vs vanilla) on Leduc. |
+| [ADR-188](./ADR-188-chebyshev-functional-schedule-genome.md) | Chebyshev functional-schedule genome, lineage tracking, domain-agnostic hook | Implemented | The genome emits **Chebyshev polynomial trajectories** (Clenshaw recurrence, bounded, zero-alloc) for α/ω/P — smooth, non-monotone curves a ramp can't express; pushes the dynamic edge to **79.2%** over best static. Adds parent-child **lineage tracking** (champion ancestry) and an `optimize` module proving the per-iteration hook is decoupled from regret-matching (same `Schedule` drives a gradient optimizer with magnitude pruning). |
+
 ## Conventions used across the series
 
 - **"Kernel"** = `@metaharness/kernel`, the package extracted from ruflo that contains primitives a harness needs regardless of identity or content (MCP wiring, hooks runtime, memory bridge, routing). Defined in ADR-002.


### PR DESCRIPTION
## Summary

A new workspace crate, `crates/poker-darwin`, that proves the Darwin **"mutate structured policies, not prompts"** thesis on a hard, non-gameable oracle: a counterfactual-regret poker solver scored by **exact exploitability**, then *evolved* into a non-stationary solver that beats every static configuration.

The model (CFR) stays frozen; the harness around it learns — from its own measured exploitability — a dynamic solver schedule.

## What's in it

**Core (pure Rust, no heavy deps; default build is wasm-safe & fast)**
- `game::Game` extensive-form abstraction with *exact* chance integration (no sampling).
- Games: **Kuhn Poker** (12 infosets / 55 histories) and **Leduc Hold'em** (288 infosets / 9,451 histories / depth 10).
- `cfr`: one parameterized engine — Vanilla / CFR+ / Linear / Discounted CFR — with the *"one strategy per infoset per iteration"* invariant. (A per-history recompute silently made CFR+ slower than vanilla on Leduc; the exact oracle caught it.)
- `exploit`: exact best-response / exploitability — **ground truth, not sampled**. CFR+ reproduces Kuhn's known game value **−1/18** and Leduc's **≈ −0.085**.

**Darwin self-learning trainer (`darwin`)**
- Evolutionary search over the solver's policy genome, fitness = −exploitability, elitism, monotone champion curve, deterministic FNV-1a receipt.
- **Non-stationary levers (ADR-187):** time-variant α/β schedules, predictive (optimistic) momentum, regret-based pruning. Darwin autonomously rediscovers "α aggressive → stable" (3.81 → 1.79); dynamic champion beats best static by **68.8%** (94% vs vanilla) on Leduc.
- **Chebyshev functional-schedule genome (ADR-188):** Clenshaw recurrence, bounded, zero-alloc; emits arbitrary smooth α/ω/P trajectories. Pushes the dynamic edge to **79.2%** over best static. Adds parent-child **lineage tracking** (champion ancestry).

**Feature-gated integrations**
- `ruvector` — `ruvector-core` VectorDB infoset abstraction (86.8% compression) + episodic memory.
- `neural` — `candle` MLP Deep-CFR policy distillation.
- `realgames` — `rs_poker` real Texas Hold'em equity (AA vs 72o = 87.4%).

**Decoupling proof (`optimize`)**
- A domain-agnostic `NonStationaryOptimizer` driven by the *same* `Schedule` engine, fed arbitrary gradients (gradient descent + magnitude pruning) — CFR is one consumer of the schedule machinery, not its boundary.

**Harness & docs**
- CLI eval harness: `poker-darwin {info|solve|exploit|evolve}` (+ feature demos).
- ADR-186/187/188 (+ INDEX entry), each with a `## Reference implementation` section.

## Results (Leduc, exact exploitability, chips/ante)

| configuration | exploitability |
|---|---|
| vanilla baseline | 0.0558 |
| best **static** genome | 0.0108 |
| best **dynamic** (linear ramps) | 0.0034 — 68.8% below best static |
| best **dynamic** (Chebyshev) | **0.0022** — 79.2% below best static, 96% below vanilla |

## Tests & quality

- **35 tests passing** (29 unit + 5 `tests/convergence.rs` + 1 doc), `cargo clippy` clean, `cargo fmt` applied.
- criterion benches in `benches/cfr_bench.rs`.
- Feature suites validated individually (ruvector/neural/realgames) to avoid candle's heavy test-profile rebuild in one shot.

## Notes
- The crate is native-only (candle + redb don't target wasm) and excluded from the wasm matrix.
- `ruvector-core` is consumed from crates.io (0.1.31) since GitHub git-protocol egress is blocked; `rs_poker` pinned to 5.x (3.x/4.x need nightly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAG4kfgxnjKbsJipv7X9M2)_