### PR TITLE
fix(ci): green the Rust workspace gates (fmt/clippy/test/doc)

### DIFF
--- a/crates/poker-darwin/src/bin/poker-darwin.rs
+++ b/crates/poker-darwin/src/bin/poker-darwin.rs
@@ -219,7 +219,10 @@ fn run_evolve<G: Game + Clone>(game: G, cfg: DarwinConfig) {
         "baseline (vanilla CFR @ {h} it): exploitability = {:.6}\n",
         report.baseline_exploitability
     );
-    println!("{:>4}  {:>14}  {:>14}  champion", "gen", "champ_exploit", "mean_exploit");
+    println!(
+        "{:>4}  {:>14}  {:>14}  champion",
+        "gen", "champ_exploit", "mean_exploit"
+    );
     for g in &report.generations {
         println!(
             "{:>4}  {:>14.6}  {:>14.6}  {}",


### PR DESCRIPTION
## What was failing

The `Rust / ${os}` CI job (`.github/workflows/ci.yml`) was red on `main` (pre-existing, predates PR #49). The job runs 4 gates in order and stops at the **first** failure:

| # | Gate | Status before |
|---|------|---------------|
| 1 | `cargo fmt --all -- --check` | ❌ **FAILING** |
| 2 | `cargo clippy --workspace --all-targets -- -D warnings` | ✅ green (never reached in CI) |
| 3 | `cargo test --workspace --verbose` | ✅ green |
| 4 | `cargo doc --workspace --no-deps` | ✅ green |

The CI red was caused **entirely by gate 1 (fmt)**. Because fmt runs first and the job short-circuits on the first failure, the green clippy/test/doc gates were never reached on CI — so the whole job showed red.

### The single fmt violation

`crates/poker-darwin/src/bin/poker-darwin.rs:219` — a long `println!("{:>4}  {:>14}  {:>14}  champion", "gen", "champ_exploit", "mean_exploit");` exceeded the line width and rustfmt wants it wrapped onto multiple lines. It was committed un-formatted.

## The fix (per gate)

- **Gate 1 (fmt):** ran `cargo fmt --all`. Result is a 1-statement, 4-line formatting wrap of the `println!` at line 219. No behavior change, no logic touched.
- **Gates 2/3/4:** no changes needed — they were already green on the `main` tree. No `#[allow]` suppressions, no dependency removals, no refactors.

## Local verification (on the exact `origin/main` tree)

All 4 gates pass in CI order:

```
GATE 1 (fmt):    exit 0
GATE 2 (clippy): exit 0   # --workspace --all-targets -- -D warnings
GATE 3 (test):   exit 0   # 121 tests passed, 0 failed across the workspace
GATE 4 (doc):    exit 0
```

Diff is one file, +4/-1:

```
crates/poker-darwin/src/bin/poker-darwin.rs | 5 ++++-
```

No infra/flaky issues encountered — the failure was a real (trivial) code-formatting defect, now fixed.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)