### PR TITLE
fix(minimal-template): remove phantom `memory search` / `route` CLI commands from docs (#48)

### DIFF
--- a/packages/create-agent-harness/templates/minimal/CLAUDE.md.tmpl
+++ b/packages/create-agent-harness/templates/minimal/CLAUDE.md.tmpl
@@ -5,18 +5,19 @@
 ## Behavioral rules
 
 - Use the harness's MCP tools (`mcp__{{name}}__*`) for orchestration
-- Memory and routing are handled by the kernel — you don't need to learn them
+- The kernel ships memory-ranking and routing **primitives** as a library (`@metaharness/kernel`); the minimal template does not expose them as CLI commands — call them from your own code if needed
 - Defer destructive operations to the user
 
 ## Commands
 
-After `{{name}} init`, the following are available:
+The minimal template's CLI (`bin/cli.js`) implements exactly these:
 
 | Command | What it does |
 |---|---|
-| `{{name}} doctor` | Health check the install |
-| `{{name}} memory search <query>` | Semantic search across stored patterns |
-| `{{name}} route <task>` | Get the routing tier recommendation |
+| `{{name}} init` | Boot the kernel + host adapter (default command) |
+| `{{name}} doctor` | Health-check the install end-to-end |
+| `{{name}} --version` | Print the kernel version |
+| `{{name}} --help` | Show usage |
 
 ## Architecture
 


### PR DESCRIPTION
Fixes #48 (thanks @Tovli for the precise report).

The `minimal` template's `CLAUDE.md.tmpl` documented two CLI commands — `memory search <query>` and `route <task>` — that `bin/cli.js.tmpl` never implements; both fall through to the `default:` `Unknown command` branch (exit 2). An agent reading the generated CLAUDE.md would confidently invoke commands that always error.

As the issue notes, the published `@metaharness/kernel` surface doesn't make these turnkey (memory exposes `rankWithDecay`/`distillTrigger` re-rankers, not a string→embed→search; routing is a library subsystem). So the honest fix is **docs↔code fidelity**, not faking the commands:

- Removed the two phantom command rows; the table now lists exactly what the CLI implements (`init`, `doctor`, `--version`, `--help`) — matching cli.js's own `--help` text.
- Reworded the behavioral-rules line so it no longer implies memory/routing are turnkey — it now says the kernel ships them as **library primitives**, call them from your own code.

Scope: one file, `templates/minimal/CLAUDE.md.tmpl`. No code/behavior change. Verified (per the issue) that no template implements a `memory`/`route` dispatch and only the minimal docs made the claim.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)