### PR TITLE
feat(jujutsu): @metaharness/jujutsu — version-control-for-agents + agenticow dual-state bridge (ADR-202)

### DIFF
--- a/docs/adrs/ADR-202-agenticow-jujutsu-dual-state-bridge.md
+++ b/docs/adrs/ADR-202-agenticow-jujutsu-dual-state-bridge.md
@@ -1,0 +1,131 @@
+# ADR-202: Dual-state branching — agentic-jujutsu (code/op) ⇄ agenticow (memory)
+
+**Status:** Proposed — bridge WIRED end-to-end (real jj 0.35.0 bookmarks + agenticow COW); cross-branch ANN query STUBBED behind an interface pending RuVector PR #617.
+**Date:** 2026-06-28
+**Related:** ADR-006 (memory & learning integration), ADR-022 (MCP primitive), ADR-074 (darwin ruvector memory fabric), ADR-161 (ruvector memory tiers), ADR-201 (vector-memory lift). Architectural constraint: **ADR-150 principle** (removable augmentation, never a required runtime dep — see "On ADR-150" below).
+
+## Context
+
+A coding agent that explores must branch and roll back **two** state planes:
+
+1. **The code/op plane** — what the agent *did*: edits, commits, rebases. We
+   adopt [`agentic-jujutsu`](https://www.npmjs.com/package/agentic-jujutsu)
+   (npm v2.3.6), a Rust+NAPI wrapper over the Jujutsu (`jj`) VCS. It exposes a
+   lock-free **operation log**, **QuantumDAG** agent coordination (conflict
+   detection across concurrent agents), a **ReasoningBank** trajectory learner,
+   and **ML-DSA-65** quantum-resistant operation signing.
+2. **The memory plane** — what the agent *learned*: the vectors in its
+   ReasoningBank/RAG store. We adopt
+   [`agenticow`](https://www.npmjs.com/package/agenticow) (npm v0.1.0), a
+   copy-on-write vector-branching layer over ruvector's RVF format. It derives a
+   branch off any base in **~0.5 ms / 162 bytes regardless of base size**
+   (83× faster, ~3000× smaller than full-copy snapshots at 1M vectors).
+
+Used independently the planes **drift**: an agent can revert its code while
+keeping memory poisoned by the abandoned trajectory, or promote a memory delta
+whose ops it never merged. The fix is a **1:1 dual-state branch**: one agent ⇒
+one op branch + one memory branch, created/learned/reverted/merged as a unit.
+
+This ADR records the bridge design, what is wired vs stubbed, and a real
+upstream bug found + worked around during integration.
+
+## Decision
+
+Ship `@metaharness/jujutsu` (`packages/jujutsu`) exposing:
+
+- **A capability facade** (`JujutsuCapability`) over agentic-jujutsu's op-log /
+  coordination / trajectory / signing primitives, with honest capability
+  reporting via `probe()`.
+- **A dual-state bridge** (`DualStateBridge`) implementing the four lifecycle
+  verbs over a ports-and-adapters seam.
+
+### The 1:1 lifecycle mapping
+
+| Verb | Code/op branch (agentic-jujutsu) | Memory branch (agenticow) | Status |
+|---|---|---|---|
+| **spawn** | `registerAgent` (QuantumDAG) + `jj bookmark create` + `startTrajectory` | `fork()` off the read-only base + `checkpoint('spawn')` | **wired** |
+| **learn** | `finalizeTrajectory(score, critique)` + read op-sequence (`getUserOperations`) | embed op-sequence → `ingest()` into the branch (ReasoningBank-as-agenticow) | **wired** |
+| **revert** | `jj undo` (op-log rollback) | `rollback()` to the spawn checkpoint (drops the delta) | **wired** |
+| **merge/promote** | `jj squash` ops into base + drop bookmark | `promote()` winning delta into the base memory | **wired** |
+| **query** | — | cross-branch k-NN | **STUBBED** (see below) |
+
+### Ports & adapters (hexagonal)
+
+The bridge depends only on three interfaces so it is testable offline and
+degrades when a plane is absent:
+
+- `OpBranchProvider` — code/op plane. Real: `AgenticJujutsuOpProvider`. Mock:
+  `MockOpProvider`.
+- `MemoryBranchProvider` — memory plane. Real: `AgenticowMemoryProvider`. Mock:
+  `MockMemoryProvider`.
+- `MemoryQueryProvider` — the **stubbed** cross-branch query plane. Real
+  (read-through today): `AgenticowQueryProvider`. Mock: `MockQueryProvider`
+  (honest brute-force cosine).
+
+### What is wired vs stubbed (honest)
+
+- **Wired & verified end-to-end:** spawn/learn/revert/merge with *both* real
+  native planes — jj 0.35.0 bookmark branch + agenticow COW branch + trajectory
+  finalize + op-sequence embedding + COW ingest/rollback/promote. 15/15 unit
+  tests + an offline smoke test + a real-peer integration check all green.
+- **Stubbed — cross-branch ANN query:** `queryMemory()` is routed through the
+  `MemoryQueryProvider` port. `AgenticowQueryProvider` wires agenticow's
+  **exact read-through** `query()` (parent ∪ child edits, child wins, deletes
+  honored) — correct but **unaccelerated** across the COW boundary. The
+  **native single index that spans the boundary** lands with **ruvnet/RuVector
+  PR #617**; until then `nativeAnn === false`. When PR #617 ships, only the
+  adapter swaps — the bridge and the port are unchanged.
+
+## On ADR-150 (removable augmentation)
+
+The task brief cites "ADR-150 (removable augmentation, never a required runtime
+dep)". Note a **numbering nuance**: in *this* repo `docs/adrs/ADR-150` is
+"Tailscale-served local frontier model". The *principle* invoked — MetaHarness
+augmentations must be optional and removable — is the one the ruflo-metaharness
+plugin enforces as its "ADR-150 constraint". We honor the **principle** here:
+`agentic-jujutsu` and `agenticow` are **optional peer dependencies**
+(`peerDependenciesMeta.optional`). The package imports and type-checks with
+neither installed; `probe()` reports what is live; the bridge runs degraded (or
+fully mock-backed) when a plane is missing. Nothing in MetaHarness's required
+runtime path depends on either native peer.
+
+## Upstream bug found (agentic-jujutsu ≤ 2.3.6)
+
+`JjWrapper.branchCreate()` shells out to the **removed** `jj branch create`
+subcommand. Jujutsu **≥ 0.21** renamed `jj branch` → `jj bookmark`, and the
+addon **bundles jj 0.35.0**, so the call fails at runtime:
+
+```
+jj command failed: error: unrecognized subcommand 'branch'
+```
+
+This breaks the core branch primitive (and, by the same token, `branchDelete`
+→ `jj branch delete`, `branchList` → `jj branch list`). The Rust
+`OperationType` enum already carries both `Branch` and `Bookmark` variants, so
+the model knows about bookmarks — only the CLI invocation was never migrated.
+
+**Workaround (this package):** `AgenticJujutsuOpProvider` drives branching via
+`execute(['bookmark', 'create', '-r', rev, name])` and only falls back to
+`branchCreate()` for old jj. **Upstream fix (to be PR'd to
+`ruvnet/agentic-flow`, `packages/agentic-jujutsu`):** version-detect `jj`
+(`jj --version`) and select `branch` vs `bookmark`, or migrate to `bookmark`
+and document a minimum jj version. Warrants a patch release (e.g. 2.3.7).
+
+## Consequences
+
+- **Positive:** agents get atomic dual-state checkpoints; abandoned trajectories
+  cannot leave poisoned memory; winning deltas promote with their ops. The
+  read-through query is correct today and upgrades to native ANN transparently.
+- **Negative / deferred:** cross-branch search is O(n) read-through until PR
+  #617; the default `HashEmbedder` is a placeholder (inject a real model for
+  production); the op plane requires the `jj` CLI at runtime (the addon bundles
+  it). The upstream `jj branch` bug must be fixed in agentic-jujutsu for the
+  native `branchCreate`/`branchList`/`branchDelete` surface to work on modern jj.
+
+## Verification
+
+- `npm run -w @metaharness/jujutsu build` — clean (tsc, no native dep needed).
+- `npm run -w @metaharness/jujutsu test` — 15/15 (offline, mock-backed).
+- `npm run -w @metaharness/jujutsu smoke` — offline lifecycle + capability probe.
+- Real-peer check (with `agentic-jujutsu` + `agenticow` installed + bundled jj
+  0.35.0): full spawn→learn→query→revert→merge cycle green.

--- a/package-lock.json
+++ b/package-lock.json
@@ -852,6 +852,10 @@
       "resolved": "packages/host-rvm",
       "link": true
     },
+    "node_modules/@metaharness/jujutsu": {
+      "resolved": "packages/jujutsu",
+      "link": true
+    },
     "node_modules/@metaharness/kernel": {
       "resolved": "packages/kernel-js",
       "link": true
@@ -4521,6 +4525,30 @@
         "node": ">=20.0.0"
       }
     },
+    "packages/jujutsu": {
+      "name": "@metaharness/jujutsu",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.4.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "agentic-jujutsu": "^2.3.6",
+        "agenticow": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "agentic-jujutsu": {
+          "optional": true
+        },
+        "agenticow": {
+          "optional": true
+        }
+      }
+    },
     "packages/kernel-js": {
       "name": "@metaharness/kernel",
       "version": "0.1.2",
@@ -4561,7 +4589,7 @@
     },
     "packages/redblue": {
       "name": "@metaharness/redblue",
-      "version": "0.1.1",
+      "version": "0.1.4",
       "license": "MIT",
       "bin": {
         "metaharness-redblue": "dist/cli/index.js",

--- a/packages/jujutsu/LICENSE
+++ b/packages/jujutsu/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 RuvNet (https://ruv.io)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/jujutsu/README.md
+++ b/packages/jujutsu/README.md
@@ -1,0 +1,148 @@
+# @metaharness/jujutsu — version-control-for-agents capability + dual-state bridge
+
+> **Give each agent its own branch — of *both* its code and its memory.** Wraps
+> [`agentic-jujutsu`](https://www.npmjs.com/package/agentic-jujutsu) (lock-free
+> jj/Jujutsu op-log, QuantumDAG agent coordination, ReasoningBank trajectories,
+> ML-DSA signing) as a **removable** MetaHarness capability, and bridges it to
+> [`agenticow`](https://www.npmjs.com/package/agenticow) copy-on-write vector
+> memory so an agent's **code/op branch** and its **memory branch** are created,
+> learned, reverted, and merged **as one unit**.
+
+```bash
+npm i @metaharness/jujutsu
+# optional native peers (removable augmentation — ADR-150):
+npm i agentic-jujutsu agenticow
+```
+
+## Why
+
+A coding agent that explores must be able to *branch and roll back*. jj gives a
+lock-free operation log for the **code/op** plane; agenticow gives ~0.5 ms / 162 B
+copy-on-write branches for the **memory** plane. Used separately they drift: you
+can revert the code but keep poisoned memory, or promote a memory delta whose
+ops you abandoned. This package keeps the two planes **1:1** so a spawn / learn /
+revert / merge always touches both.
+
+## Removable by design (ADR-150)
+
+`agentic-jujutsu` and `agenticow` are **optional peer dependencies**. Everything
+here imports and type-checks with **neither** installed; nothing is a required
+runtime dep. Use `probe()` for honest capability reporting and the bridge
+degrades to whichever planes are live.
+
+```ts
+import { probe } from '@metaharness/jujutsu';
+
+const cap = await probe();
+// { opLog, memory, jjCli, annAcrossBranch, notes[] }
+```
+
+| Field | Meaning |
+|---|---|
+| `opLog` | agentic-jujutsu native addon loadable |
+| `jjCli` | `jj` (Jujutsu) CLI resolvable (needed for branch/diff/log) |
+| `memory` | agenticow COW memory branching loadable |
+| `annAcrossBranch` | native ANN spanning the COW boundary (RuVector PR #617) — **pending** |
+
+## The capability facade
+
+```ts
+import { JujutsuCapability } from '@metaharness/jujutsu';
+
+const jj = JujutsuCapability.create();        // throws CapabilityUnavailableError if absent
+await jj.enableCoordination();                // QuantumDAG lock-free coordination
+await jj.registerAgent('alice', 'coder');
+jj.startTrajectory('implement auth');         // ReasoningBank trajectory
+jj.addToTrajectory();
+jj.finalizeTrajectory(0.9, 'good run');
+jj.suggestion('implement auth');              // learned suggestion
+jj.userOps(50);                               // op-log (needs jj CLI)
+```
+
+Quantum signing (ML-DSA-65) is passed through:
+
+```ts
+import { quantumSigner } from '@metaharness/jujutsu';
+const QS = quantumSigner();                    // null if addon absent
+const kp = QS.generateKeypair();
+```
+
+## The dual-state bridge
+
+```ts
+import {
+  DualStateBridge,
+  AgenticJujutsuOpProvider,
+  AgenticowMemoryProvider,
+  AgenticowQueryProvider,
+} from '@metaharness/jujutsu';
+
+const op  = new AgenticJujutsuOpProvider({ coordinate: true });
+const mem = await AgenticowMemoryProvider.create({ basePath: 'memory/base.rvf', dimension: 384 });
+const bridge = new DualStateBridge(op, mem, { queryProvider: new AgenticowQueryProvider(mem) });
+
+const branch = await bridge.spawn('alice');         // jj bookmark + COW branch, together
+// ... agent works ...
+await bridge.learn('alice', 0.95, 'tests green');   // finalize trajectory -> embed op-seq -> COW branch
+const hits = await bridge.queryMemory('alice', vec); // cross-branch query (stubbed plane, see below)
+await bridge.revert('alice');                        // jj undo + drop COW delta
+const promo = await bridge.merge('alice');           // squash ops + promote winning COW delta to base
+```
+
+### Lifecycle mapping (1:1)
+
+| Verb | Code/op branch (agentic-jujutsu) | Memory branch (agenticow) |
+|---|---|---|
+| **spawn** | register agent + `jj bookmark create` + open trajectory | `fork()` base + `checkpoint('spawn')` |
+| **learn** | `finalizeTrajectory(score)` + read op-sequence | embed op-sequence → `ingest()` into the branch |
+| **revert** | `jj undo` (op-log rollback) | `rollback()` to the spawn checkpoint (drop delta) |
+| **merge** | `jj squash` ops into base | `promote()` winning delta into the base memory |
+
+### Ports & adapters
+
+The bridge depends only on three interfaces — `OpBranchProvider`,
+`MemoryBranchProvider`, `MemoryQueryProvider` — so you can mix real and mock
+planes. Ship adapters:
+
+- `AgenticJujutsuOpProvider` / `AgenticowMemoryProvider` — real native planes.
+- `MockOpProvider` / `MockMemoryProvider` / `MockQueryProvider` — offline,
+  dependency-free (used by the smoke test + unit tests, and as a fallback).
+
+### What's wired vs stubbed
+
+- **Wired (works today):** spawn / learn / revert / merge across both real
+  planes — verified end-to-end with jj 0.35.0 bookmarks + agenticow COW.
+- **Stubbed plane — cross-branch query:** `queryMemory()` delegates to a
+  `MemoryQueryProvider`. `AgenticowQueryProvider` uses agenticow's **exact
+  read-through** `query()` (parent ∪ child edits, child wins). The
+  **accelerated native ANN that spans the COW boundary** (RuVector PR #617) is
+  still in flight; `nativeAnn` is `false` until it lands, at which point this
+  adapter swaps to it with no bridge change.
+
+## Embedding
+
+`learn()` turns the op-sequence into vectors via an `Embedder`. The default
+`HashEmbedder` is deterministic and offline (a placeholder). Inject a real model
+(e.g. ONNX all-MiniLM-L6-v2) for production:
+
+```ts
+new DualStateBridge(op, mem, { embedder: myMiniLmEmbedder });
+```
+
+## Known upstream issue (agentic-jujutsu ≤ 2.3.6)
+
+`JjWrapper.branchCreate()` invokes the **removed** `jj branch` subcommand; jj
+≥0.21 renamed it to `jj bookmark`, so it fails against the jj 0.35.0 the package
+bundles. This package **works around it** by driving branching through
+`bookmark` and falling back to `branchCreate()` only for old jj. See
+[ADR-202](../../docs/adrs/ADR-202-agenticow-jujutsu-dual-state-bridge.md).
+
+## Scripts
+
+```bash
+npm run -w @metaharness/jujutsu build   # tsc
+npm run -w @metaharness/jujutsu test    # vitest (offline, mock-backed)
+npm run -w @metaharness/jujutsu smoke   # offline lifecycle + capability probe
+```
+
+MIT © RuvNet

--- a/packages/jujutsu/__tests__/bridge.test.ts
+++ b/packages/jujutsu/__tests__/bridge.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+//
+// Offline bridge tests — exercise the full dual-state lifecycle with mock
+// adapters (no jj CLI, no native addon, no rvf-node).
+
+import { describe, it, expect } from 'vitest';
+import {
+  DualStateBridge,
+  MockOpProvider,
+  MockMemoryProvider,
+  MockQueryProvider,
+  HashEmbedder,
+} from '../src/index.js';
+
+function makeBridge(seedOps = 3) {
+  const op = new MockOpProvider(seedOps);
+  const mem = new MockMemoryProvider();
+  const query = new MockQueryProvider(mem);
+  const bridge = new DualStateBridge(op, mem, { queryProvider: query, embedder: new HashEmbedder(64) });
+  return { op, mem, query, bridge };
+}
+
+describe('DualStateBridge lifecycle', () => {
+  it('spawn creates both an op branch and a memory branch', async () => {
+    const { bridge } = makeBridge();
+    const b = await bridge.spawn('alice');
+    expect(b.agentId).toBe('alice');
+    expect(b.op).not.toBeNull();
+    expect(b.mem).not.toBeNull();
+    expect(bridge.status()).toEqual({ opPlane: true, memPlane: true, nativeAnn: false });
+  });
+
+  it('rejects double-spawn of the same agent', async () => {
+    const { bridge } = makeBridge();
+    await bridge.spawn('alice');
+    await expect(bridge.spawn('alice')).rejects.toThrow(/already spawned/);
+  });
+
+  it('learn embeds the op-sequence into the memory branch', async () => {
+    const { bridge, mem } = makeBridge(4);
+    const b = await bridge.spawn('alice');
+    const res = await bridge.learn('alice', 0.9, 'good run');
+    expect(res.opCount).toBe(4);
+    expect(res.ingested).toBe(4);
+    expect(res.opPlane && res.memPlane).toBe(true);
+    const delta = await mem.diff(b.mem!);
+    expect(delta.added.length).toBe(4);
+  });
+
+  it('revert drops the memory delta back to the spawn checkpoint', async () => {
+    const { bridge, mem } = makeBridge(3);
+    const b = await bridge.spawn('alice');
+    await bridge.learn('alice', 0.5);
+    expect((await mem.diff(b.mem!)).added.length).toBe(3);
+    await bridge.revert('alice');
+    expect((await mem.diff(b.mem!)).added.length).toBe(0);
+  });
+
+  it('merge promotes the winning delta into the base and closes the agent', async () => {
+    const { bridge, mem } = makeBridge(2);
+    await bridge.spawn('alice');
+    await bridge.learn('alice', 1.0);
+    const promo = await bridge.merge('alice');
+    expect(promo.ingested).toBe(2);
+    expect(mem.base.size).toBe(2);
+    // agent is gone after merge
+    await expect(bridge.merge('alice')).rejects.toThrow(/not spawned/);
+  });
+
+  it('queryMemory returns ranked hits via the (stubbed) query plane', async () => {
+    const { bridge } = makeBridge(5);
+    await bridge.spawn('alice');
+    await bridge.learn('alice', 0.8);
+    const q = bridge.embed('commit alice step 0');
+    const hits = await bridge.queryMemory('alice', q, 3);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits.length).toBeLessThanOrEqual(3);
+    // sorted ascending by distance
+    for (let i = 1; i < hits.length; i++) expect(hits[i].distance).toBeGreaterThanOrEqual(hits[i - 1].distance);
+  });
+
+  it('queryMemory without a provider fails with a clear stub message', async () => {
+    const op = new MockOpProvider();
+    const mem = new MockMemoryProvider();
+    const bridge = new DualStateBridge(op, mem); // no queryProvider
+    await bridge.spawn('bob');
+    await expect(bridge.queryMemory('bob', [1, 2, 3])).rejects.toThrow(/stubbed plane|PR #617/);
+  });
+});
+
+describe('degraded planes', () => {
+  it('works memory-only when the op plane is unavailable', async () => {
+    const op = { available: false } as unknown as MockOpProvider;
+    const mem = new MockMemoryProvider();
+    const bridge = new DualStateBridge(op, mem);
+    const b = await bridge.spawn('solo');
+    expect(b.op).toBeNull();
+    expect(b.mem).not.toBeNull();
+    const res = await bridge.learn('solo', 0.7);
+    expect(res.opPlane).toBe(false);
+    expect(res.memPlane).toBe(true);
+    expect(res.ingested).toBe(0); // no op-sequence to embed
+  });
+});

--- a/packages/jujutsu/__tests__/capability.test.ts
+++ b/packages/jujutsu/__tests__/capability.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+//
+// Capability + embedder tests. These pass whether or not the optional native
+// peers are installed — they assert the honest-degradation contract.
+
+import { describe, it, expect } from 'vitest';
+import {
+  probe,
+  jujutsuAvailable,
+  quantumSigner,
+  HashEmbedder,
+  CapabilityUnavailableError,
+} from '../src/index.js';
+
+describe('capability probe (honest degradation)', () => {
+  it('probe() never throws and reports each plane as a boolean', async () => {
+    const rep = await probe();
+    expect(typeof rep.opLog).toBe('boolean');
+    expect(typeof rep.memory).toBe('boolean');
+    expect(typeof rep.jjCli).toBe('boolean');
+    expect(rep.annAcrossBranch).toBe(false); // native ANN-across-branch pending
+    expect(Array.isArray(rep.notes)).toBe(true);
+  });
+
+  it('jujutsuAvailable() matches probe().opLog', async () => {
+    const rep = await probe();
+    expect(jujutsuAvailable()).toBe(rep.opLog);
+  });
+
+  it('quantumSigner() is null when the addon is absent, else has generateKeypair', () => {
+    const qs = quantumSigner() as { generateKeypair?: unknown } | null;
+    if (qs === null) {
+      expect(jujutsuAvailable()).toBe(false);
+    } else {
+      expect(typeof qs.generateKeypair).toBe('function');
+    }
+  });
+
+  it('CapabilityUnavailableError carries the capability name', () => {
+    const e = new CapabilityUnavailableError('agentic-jujutsu');
+    expect(e.capability).toBe('agentic-jujutsu');
+    expect(e.message).toMatch(/removable augmentation/);
+  });
+});
+
+describe('HashEmbedder', () => {
+  it('is deterministic and L2-normalized', () => {
+    const e = new HashEmbedder(128);
+    const a = e.embed('jj commit feature x');
+    const b = e.embed('jj commit feature x');
+    expect(Array.from(a)).toEqual(Array.from(b));
+    let norm = 0;
+    for (const x of a) norm += x * x;
+    expect(Math.sqrt(norm)).toBeCloseTo(1, 5);
+  });
+
+  it('different text yields different vectors', () => {
+    const e = new HashEmbedder(128);
+    const a = e.embed('commit');
+    const b = e.embed('rebase');
+    expect(Array.from(a)).not.toEqual(Array.from(b));
+  });
+
+  it('rejects non-positive dimension', () => {
+    expect(() => new HashEmbedder(0)).toThrow();
+  });
+});

--- a/packages/jujutsu/package.json
+++ b/packages/jujutsu/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@metaharness/jujutsu",
+  "version": "0.1.0",
+  "description": "Lock-free version-control-for-agents capability for MetaHarness. Wraps agentic-jujutsu (jj/Jujutsu op-log, QuantumDAG agent coordination, ReasoningBank trajectories, ML-DSA signing) as a removable augmentation, and bridges it to agenticow COW memory branching for dual-state (code-branch + memory-branch) agent lifecycles.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./bridge": {
+      "types": "./dist/bridge/index.d.ts",
+      "import": "./dist/bridge/index.js"
+    }
+  },
+  "files": [
+    "dist/**",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "tsc --noEmit",
+    "smoke": "node smoke.mjs"
+  },
+  "keywords": [
+    "jujutsu",
+    "jj",
+    "version-control-for-agents",
+    "vcs",
+    "op-log",
+    "lock-free",
+    "agent-coordination",
+    "quantumdag",
+    "reasoningbank",
+    "trajectory",
+    "agentic",
+    "ai-agents",
+    "agent-memory",
+    "copy-on-write",
+    "cow",
+    "agenticow",
+    "dual-state-branching",
+    "agent-harness",
+    "metaharness"
+  ],
+  "author": "rUv <ruv@ruv.net>",
+  "license": "MIT",
+  "homepage": "https://github.com/ruvnet/agent-harness-generator/tree/main/packages/jujutsu#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ruvnet/agent-harness-generator",
+    "directory": "packages/jujutsu"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  },
+  "peerDependencies": {
+    "agenticow": "^0.1.0",
+    "agentic-jujutsu": "^2.3.6"
+  },
+  "peerDependenciesMeta": {
+    "agenticow": {
+      "optional": true
+    },
+    "agentic-jujutsu": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/jujutsu/smoke.mjs
+++ b/packages/jujutsu/smoke.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+//
+// Smoke test for @metaharness/jujutsu. Runs fully offline against the built
+// dist/ using mock adapters, then probes for the real (optional) native peers
+// and reports what is live. Exit non-zero only on a real failure of the
+// always-available path.
+//
+//   npm run -w @metaharness/jujutsu build && npm run -w @metaharness/jujutsu smoke
+
+import {
+  DualStateBridge,
+  MockOpProvider,
+  MockMemoryProvider,
+  MockQueryProvider,
+  HashEmbedder,
+  probe,
+} from './dist/index.js';
+
+let failures = 0;
+const ok = (c, m) => { console.log(`${c ? 'PASS' : 'FAIL'}  ${m}`); if (!c) failures++; };
+
+console.log('=== @metaharness/jujutsu smoke ===\n');
+
+// 1) Offline dual-state lifecycle (always available — mock adapters).
+const op = new MockOpProvider(4);
+const mem = new MockMemoryProvider();
+const bridge = new DualStateBridge(op, mem, {
+  queryProvider: new MockQueryProvider(mem),
+  embedder: new HashEmbedder(64),
+});
+
+const spawned = await bridge.spawn('demo-agent');
+ok(spawned.op && spawned.mem, 'spawn() creates op-branch + memory-branch together');
+
+const learn = await bridge.learn('demo-agent', 0.92, 'clean run');
+ok(learn.opCount === 4 && learn.ingested === 4, `learn() embedded ${learn.ingested}/${learn.opCount} ops into COW memory branch`);
+
+const hits = await bridge.queryMemory('demo-agent', bridge.embed('jj commit demo-agent step 0'), 3);
+ok(hits.length > 0, `queryMemory() (stubbed ANN plane) returned ${hits.length} ranked hits`);
+
+await bridge.revert('demo-agent');
+const afterRevert = await mem.diff(spawned.mem);
+ok(afterRevert.added.length === 0, 'revert() dropped the memory delta back to spawn checkpoint');
+
+await bridge.learn('demo-agent', 1.0);
+const promo = await bridge.merge('demo-agent');
+ok(promo.ingested > 0 && mem.base.size > 0, `merge() promoted ${promo.ingested} records into base memory`);
+
+// 2) Probe the real removable augmentations (informational — never fails smoke).
+console.log('\n--- capability probe (optional native peers) ---');
+const rep = await probe();
+console.log(`agentic-jujutsu addon : ${rep.opLog ? 'LIVE' : 'absent'}`);
+console.log(`jj (Jujutsu) CLI      : ${rep.jjCli ? 'found' : 'absent'}`);
+console.log(`agenticow memory      : ${rep.memory ? 'LIVE' : 'absent'}`);
+console.log(`native ANN-across-br. : ${rep.annAcrossBranch ? 'shipped' : 'pending (RuVector PR #617)'}`);
+for (const n of rep.notes) console.log(`  note: ${n}`);
+
+console.log(`\n${failures === 0 ? 'SMOKE OK' : `SMOKE FAILED (${failures})`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/packages/jujutsu/src/bridge/adapters/agentic-jujutsu-op-provider.ts
+++ b/packages/jujutsu/src/bridge/adapters/agentic-jujutsu-op-provider.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+//
+// Real OpBranchProvider backed by agentic-jujutsu's JjWrapper.
+//
+// WIRED: trajectory open/finalize, op-sequence read, registerAgent (lock-free
+// QuantumDAG coordination), and branch lifecycle.
+// RUNTIME PREREQ: branch / undo / merge / op reads shell out to the `jj` CLI.
+// If jj is absent these throw at call time (not at construction) — the
+// trajectory + coordination calls still work. `available` reflects only whether
+// the native addon loaded; use probe() for the jj-CLI check.
+//
+// UPSTREAM BUG WORKAROUND (agentic-jujutsu ≤2.3.6): JjWrapper.branchCreate()
+// shells `jj branch create`, but jj ≥0.21 renamed that subcommand to
+// `jj bookmark`. Against modern jj (the bundle ships 0.35.0) branchCreate throws
+// "unrecognized subcommand 'branch'". We therefore drive branching through
+// execute(['bookmark', ...]) and only fall back to branchCreate() for old jj.
+// See ADR-202 §"Upstream bug" and the jj-source-review for the upstream fix.
+
+import { JujutsuCapability, jujutsuAvailable } from '../../capability.js';
+import type { OpDescriptor, TrajectorySummary } from '../../types.js';
+import type { OpBranchHandle, OpBranchProvider } from '../ports.js';
+
+export interface AgenticJujutsuOpOptions {
+  /** jj branch revision to base new branches on. Default: '@' (working copy). */
+  baseRevision?: string;
+  /** Agent type string for QuantumDAG registration. Default: 'coder'. */
+  agentType?: string;
+  /** Enable QuantumDAG coordination at first spawn. Default: true. */
+  coordinate?: boolean;
+}
+
+export class AgenticJujutsuOpProvider implements OpBranchProvider {
+  readonly available: boolean;
+  private readonly cap: JujutsuCapability | null;
+  private coordinated = false;
+
+  constructor(private readonly opts: AgenticJujutsuOpOptions = {}) {
+    this.available = jujutsuAvailable();
+    this.cap = this.available ? JujutsuCapability.create() : null;
+  }
+
+  async spawn(agentId: string): Promise<OpBranchHandle> {
+    const cap = this.must();
+    if ((this.opts.coordinate ?? true) && !this.coordinated) {
+      await cap.enableCoordination();
+      this.coordinated = true;
+    }
+    await cap.registerAgent(agentId, this.opts.agentType ?? 'coder');
+    const name = `agent/${agentId}`;
+    await this.createBranch(cap, name);
+    const trajectoryId = cap.startTrajectory(`agent:${agentId}`);
+    return { id: name, name, trajectoryId };
+  }
+
+  async recordOp(_handle: OpBranchHandle): Promise<void> {
+    this.must().addToTrajectory();
+  }
+
+  async finalize(handle: OpBranchHandle, successScore: number, critique?: string): Promise<TrajectorySummary> {
+    const summary = this.must().finalizeTrajectory(successScore, critique);
+    return { ...summary, trajectoryId: summary.trajectoryId || (handle.trajectoryId ?? '') };
+  }
+
+  async opSequence(_handle: OpBranchHandle): Promise<OpDescriptor[]> {
+    return this.must().userOps(1000);
+  }
+
+  async undo(_handle: OpBranchHandle): Promise<void> {
+    await this.must().raw.undo();
+  }
+
+  async merge(handle: OpBranchHandle): Promise<void> {
+    // Squash this branch's revision into its parent — jj's merge/promote
+    // primitive — then drop the now-redundant bookmark.
+    const cap = this.must();
+    await cap.raw.execute(['squash', '--from', handle.name]);
+    try {
+      await cap.raw.execute(['bookmark', 'delete', handle.name]);
+    } catch {
+      /* old jj: bookmark may not exist / different surface — non-fatal */
+    }
+  }
+
+  /**
+   * Create the agent branch as a jj bookmark, working around the agentic-jujutsu
+   * `jj branch` bug on modern jj. Falls back to the native branchCreate() for
+   * jj versions that still expose `jj branch`.
+   */
+  private async createBranch(cap: JujutsuCapability, name: string): Promise<void> {
+    const rev = this.opts.baseRevision ?? '@';
+    try {
+      await cap.raw.execute(['bookmark', 'create', '-r', rev, name]);
+    } catch (bookmarkErr) {
+      try {
+        await cap.raw.branchCreate(name, this.opts.baseRevision ?? null);
+      } catch {
+        throw bookmarkErr; // surface the modern-jj error, which is the common case
+      }
+    }
+  }
+
+  private must(): JujutsuCapability {
+    if (!this.cap) throw new Error('AgenticJujutsuOpProvider: agentic-jujutsu unavailable');
+    return this.cap;
+  }
+}

--- a/packages/jujutsu/src/bridge/adapters/agenticow-memory-provider.ts
+++ b/packages/jujutsu/src/bridge/adapters/agenticow-memory-provider.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+//
+// Real MemoryBranchProvider backed by agenticow (COW vector branching).
+//
+// WIRED (works today): branch/fork create, ingest, checkpoint, rollback,
+// promote, diff — these ride agenticow's shipped derive()/promote() primitives.
+// STUBBED elsewhere: cross-branch ANN search (see MemoryQueryProvider /
+// AgenticowQueryProvider) — agenticow's native single-index-across-COW-boundary
+// (RuVector PR #617) is in flight.
+//
+// agenticow is an OPTIONAL peer; use AgenticowMemoryProvider.create() which
+// resolves to a provider with available=false if it (or rvf-node) is absent.
+
+import { loadAgenticow } from '../../loader.js';
+import type { MemoryDelta, MemoryQueryHit, MemoryRecord } from '../../types.js';
+import type {
+  MemoryBranchHandle,
+  MemoryBranchProvider,
+  MemoryQueryProvider,
+} from '../ports.js';
+
+/** Structural view of agenticow's AgenticMemory we depend on. */
+interface AgenticMemory {
+  readonly dimension: number;
+  ingest(vectors: Float32Array, ids: number[]): { accepted: number };
+  delete(ids: number[]): { deleted: number; tombstoned: number };
+  query(vector: Float32Array, k?: number, opts?: unknown): Array<{ id: number; distance: number; branch: string }>;
+  fork(label?: string, filePath?: string): AgenticMemory;
+  branch(label?: string, filePath?: string): AgenticMemory;
+  diff(): MemoryDelta;
+  promote(target: AgenticMemory): { ingested: number; deleted: number };
+  checkpoint(label?: string): { id: string };
+  rollback(checkpointId?: string): { restoredTo: string; depth: number };
+  close(): void;
+}
+interface AgenticowModule {
+  open(filePath: string, opts?: { dimension?: number; metric?: string }): AgenticMemory;
+}
+
+export interface AgenticowOptions {
+  /** Path to the base .rvf memory file. */
+  basePath: string;
+  /** Vector dimension (must match the embedder). Default: 384. */
+  dimension?: number;
+  metric?: string;
+}
+
+interface Entry {
+  mem: AgenticMemory;
+  spawnCkpt: string;
+}
+
+export class AgenticowMemoryProvider implements MemoryBranchProvider {
+  private readonly entries = new Map<string, Entry>();
+  private bn = 0;
+
+  private constructor(
+    public readonly available: boolean,
+    private readonly base: AgenticMemory | null,
+    private readonly opts: AgenticowOptions,
+  ) {}
+
+  /** Resolve the optional peer and open the base memory. Never throws on absence. */
+  static async create(opts: AgenticowOptions): Promise<AgenticowMemoryProvider> {
+    const mod = (await loadAgenticow()) as AgenticowModule | null;
+    if (!mod) return new AgenticowMemoryProvider(false, null, opts);
+    try {
+      const base = mod.open(opts.basePath, {
+        dimension: opts.dimension ?? 384,
+        metric: opts.metric ?? 'cosine',
+      });
+      return new AgenticowMemoryProvider(true, base, opts);
+    } catch {
+      return new AgenticowMemoryProvider(false, null, opts);
+    }
+  }
+
+  /** The shared base memory (promote target). For the companion query provider. */
+  get baseMemory(): AgenticMemory | null {
+    return this.base;
+  }
+
+  async branch(label: string): Promise<MemoryBranchHandle> {
+    const base = this.must();
+    // fork() (not branch()) is the right fan-out primitive: derive many
+    // per-agent children off a base we keep read-only. ~0.5ms / 162 bytes each.
+    const child = base.fork(label);
+    // Freeze an empty post-spawn restore point so revert() can drop the delta.
+    const spawnCkpt = child.checkpoint('spawn').id;
+    const id = `mem/${label}-${++this.bn}`;
+    this.entries.set(id, { mem: child, spawnCkpt });
+    return { id, label };
+  }
+
+  async ingest(handle: MemoryBranchHandle, records: MemoryRecord[]): Promise<{ accepted: number }> {
+    const { mem } = this.entry(handle);
+    const dim = mem.dimension;
+    const flat = new Float32Array(records.length * dim);
+    const ids: number[] = [];
+    for (let i = 0; i < records.length; i++) {
+      flat.set(toF32(records[i].vector), i * dim);
+      ids.push(records[i].id);
+    }
+    return mem.ingest(flat, ids);
+  }
+
+  async checkpoint(handle: MemoryBranchHandle, label?: string): Promise<{ id: string }> {
+    return this.entry(handle).mem.checkpoint(label);
+  }
+
+  async rollback(handle: MemoryBranchHandle, checkpointId?: string): Promise<void> {
+    const { mem, spawnCkpt } = this.entry(handle);
+    mem.rollback(checkpointId ?? spawnCkpt);
+  }
+
+  async promote(handle: MemoryBranchHandle): Promise<{ ingested: number; deleted: number }> {
+    const base = this.must();
+    return this.entry(handle).mem.promote(base);
+  }
+
+  async diff(handle: MemoryBranchHandle): Promise<MemoryDelta> {
+    return this.entry(handle).mem.diff();
+  }
+
+  /** Internal accessor for the companion query provider. */
+  _memory(handle: MemoryBranchHandle): AgenticMemory {
+    return this.entry(handle).mem;
+  }
+
+  /** Close all open handles. */
+  close(): void {
+    for (const { mem } of this.entries.values()) {
+      try {
+        mem.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      this.base?.close();
+    } catch {
+      /* ignore */
+    }
+  }
+
+  private entry(handle: MemoryBranchHandle): Entry {
+    const e = this.entries.get(handle.id);
+    if (!e) throw new Error(`AgenticowMemoryProvider: no branch ${handle.id}`);
+    return e;
+  }
+  private must(): AgenticMemory {
+    if (!this.base) throw new Error('AgenticowMemoryProvider: agenticow unavailable');
+    return this.base;
+  }
+}
+
+/**
+ * Cross-branch query backed by agenticow's EXACT read-through query(). This is
+ * the honest "today" implementation: it merges parent ∪ child edits and re-ranks
+ * exactly across the COW boundary. nativeAnn=false flags that the accelerated
+ * single-index-across-branches (RuVector PR #617) is NOT yet wired.
+ */
+export class AgenticowQueryProvider implements MemoryQueryProvider {
+  readonly nativeAnn = false;
+  constructor(private readonly provider: AgenticowMemoryProvider) {}
+
+  async queryAcrossBranches(
+    handle: MemoryBranchHandle,
+    vector: Float32Array | number[],
+    k = 10,
+  ): Promise<MemoryQueryHit[]> {
+    const mem = this.provider._memory(handle);
+    return mem.query(toF32(vector), k);
+  }
+}
+
+function toF32(v: Float32Array | number[]): Float32Array {
+  return v instanceof Float32Array ? v : Float32Array.from(v);
+}

--- a/packages/jujutsu/src/bridge/adapters/mock-providers.ts
+++ b/packages/jujutsu/src/bridge/adapters/mock-providers.ts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: MIT
+//
+// In-memory mock adapters. They make the bridge fully exercisable offline (no
+// jj CLI, no native addon, no rvf-node) — used by the smoke test and unit tests,
+// and as a graceful fallback. The mock memory provider keeps real vectors so the
+// mock query provider can do honest brute-force cosine k-NN, demonstrating the
+// shape of the (eventually native) cross-branch search.
+
+import type { MemoryDelta, MemoryQueryHit, MemoryRecord, OpDescriptor, TrajectorySummary } from '../../types.js';
+import type {
+  MemoryBranchHandle,
+  MemoryBranchProvider,
+  MemoryQueryProvider,
+  OpBranchHandle,
+  OpBranchProvider,
+} from '../ports.js';
+
+interface MockTrajectory {
+  id: string;
+  ops: OpDescriptor[];
+  finalized?: { score: number; critique?: string };
+}
+
+export class MockOpProvider implements OpBranchProvider {
+  readonly available = true;
+  private seq = 0;
+  private readonly trajectories = new Map<string, MockTrajectory>();
+  /** Optional seed ops appended at spawn so learn() has something to embed. */
+  constructor(private readonly seedOps = 3) {}
+
+  async spawn(agentId: string): Promise<OpBranchHandle> {
+    const trajectoryId = `traj-${agentId}-${++this.seq}`;
+    const ops: OpDescriptor[] = [];
+    for (let i = 0; i < this.seedOps; i++) ops.push(this.mkOp(agentId, i));
+    this.trajectories.set(trajectoryId, { id: trajectoryId, ops });
+    return { id: `op/${agentId}`, name: agentId, trajectoryId };
+  }
+
+  async recordOp(handle: OpBranchHandle): Promise<void> {
+    const t = this.traj(handle);
+    t.ops.push(this.mkOp(handle.name, t.ops.length));
+  }
+
+  async finalize(handle: OpBranchHandle, successScore: number, critique?: string): Promise<TrajectorySummary> {
+    const t = this.traj(handle);
+    t.finalized = { score: successScore, critique };
+    return { trajectoryId: t.id, successScore, critique, opCount: t.ops.length };
+  }
+
+  async opSequence(handle: OpBranchHandle): Promise<OpDescriptor[]> {
+    return [...this.traj(handle).ops];
+  }
+
+  async undo(handle: OpBranchHandle): Promise<void> {
+    this.traj(handle).ops.pop();
+  }
+
+  async merge(handle: OpBranchHandle): Promise<void> {
+    this.trajectories.delete(handle.trajectoryId!);
+  }
+
+  private traj(handle: OpBranchHandle): MockTrajectory {
+    const t = this.trajectories.get(handle.trajectoryId!);
+    if (!t) throw new Error(`MockOpProvider: no trajectory for ${handle.id}`);
+    return t;
+  }
+
+  private mkOp(agent: string, i: number): OpDescriptor {
+    return {
+      id: `${agent}-op-${i}`,
+      operationId: `${agent}@host-${i}`,
+      operationType: ['commit', 'new', 'describe', 'squash'][i % 4],
+      command: `jj ${['commit', 'new', 'describe', 'squash'][i % 4]} ${agent} step ${i}`,
+      user: agent,
+      timestamp: new Date(Date.now() + i).toISOString(),
+      durationMs: 1 + i,
+      success: true,
+    };
+  }
+}
+
+interface MockBranch {
+  id: string;
+  label: string;
+  records: Map<number, Float32Array>;
+  tombstones: Set<number>;
+  checkpoints: Array<{ id: string; records: Map<number, Float32Array> }>;
+}
+
+export class MockMemoryProvider implements MemoryBranchProvider {
+  readonly available = true;
+  private bn = 0;
+  private cn = 0;
+  private readonly branches = new Map<string, MockBranch>();
+  /** Shared "base" memory that promote() writes into. */
+  readonly base = new Map<number, Float32Array>();
+
+  async branch(label: string): Promise<MemoryBranchHandle> {
+    const id = `mem/${label}-${++this.bn}`;
+    this.branches.set(id, { id, label, records: new Map(), tombstones: new Set(), checkpoints: [] });
+    return { id, label };
+  }
+
+  async ingest(handle: MemoryBranchHandle, records: MemoryRecord[]): Promise<{ accepted: number }> {
+    const b = this.br(handle);
+    for (const r of records) {
+      b.records.set(r.id, toF32(r.vector));
+      b.tombstones.delete(r.id);
+    }
+    return { accepted: records.length };
+  }
+
+  async checkpoint(handle: MemoryBranchHandle, label?: string): Promise<{ id: string }> {
+    const b = this.br(handle);
+    const id = `ckpt-${label ?? ''}-${++this.cn}`;
+    b.checkpoints.push({ id, records: new Map(b.records) });
+    return { id };
+  }
+
+  async rollback(handle: MemoryBranchHandle, checkpointId?: string): Promise<void> {
+    const b = this.br(handle);
+    if (b.checkpoints.length === 0) {
+      b.records.clear();
+      b.tombstones.clear();
+      return;
+    }
+    const ck = checkpointId
+      ? b.checkpoints.find((c) => c.id === checkpointId)
+      : b.checkpoints[b.checkpoints.length - 1];
+    if (!ck) throw new Error(`MockMemoryProvider: checkpoint ${checkpointId} not found`);
+    b.records = new Map(ck.records);
+    b.tombstones.clear();
+  }
+
+  async promote(handle: MemoryBranchHandle): Promise<{ ingested: number; deleted: number }> {
+    const b = this.br(handle);
+    for (const [id, v] of b.records) this.base.set(id, v);
+    for (const id of b.tombstones) this.base.delete(id);
+    return { ingested: b.records.size, deleted: b.tombstones.size };
+  }
+
+  async diff(handle: MemoryBranchHandle): Promise<MemoryDelta> {
+    const b = this.br(handle);
+    return {
+      added: [...b.records.keys()].sort((a, c) => a - c),
+      overridden: [],
+      deleted: [...b.tombstones].sort((a, c) => a - c),
+    };
+  }
+
+  /** Internal accessor for the mock query provider. */
+  _records(handle: MemoryBranchHandle): Map<number, Float32Array> {
+    return this.br(handle).records;
+  }
+
+  private br(handle: MemoryBranchHandle): MockBranch {
+    const b = this.branches.get(handle.id);
+    if (!b) throw new Error(`MockMemoryProvider: no branch ${handle.id}`);
+    return b;
+  }
+}
+
+/** Honest brute-force cosine k-NN over a MockMemoryProvider branch. */
+export class MockQueryProvider implements MemoryQueryProvider {
+  readonly nativeAnn = false;
+  constructor(private readonly mem: MockMemoryProvider) {}
+
+  async queryAcrossBranches(
+    handle: MemoryBranchHandle,
+    vector: Float32Array | number[],
+    k = 10,
+  ): Promise<MemoryQueryHit[]> {
+    const q = toF32(vector);
+    const hits: MemoryQueryHit[] = [];
+    for (const [id, v] of this.mem._records(handle)) {
+      hits.push({ id, distance: 1 - cosine(q, v), branch: handle.label });
+    }
+    return hits.sort((a, b) => a.distance - b.distance).slice(0, k);
+  }
+}
+
+function toF32(v: Float32Array | number[]): Float32Array {
+  return v instanceof Float32Array ? v : Float32Array.from(v);
+}
+
+function cosine(a: Float32Array, b: Float32Array): number {
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) {
+    dot += a[i] * b[i];
+    na += a[i] * a[i];
+    nb += b[i] * b[i];
+  }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) || 1);
+}

--- a/packages/jujutsu/src/bridge/bridge.ts
+++ b/packages/jujutsu/src/bridge/bridge.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+//
+// DualStateBridge — the agenticow <-> agentic-jujutsu lifecycle.
+//
+// One agent == one CODE/OP branch (jj) + one MEMORY branch (agenticow), created,
+// learned, reverted, and merged as a pair. The four lifecycle verbs from the
+// design:
+//
+//   spawn   -> create jj branch + agenticow branch together
+//   learn   -> on trajectory finalize, embed the op-sequence + write it into
+//              that agent's agenticow COW branch (ReasoningBank-as-agenticow)
+//   revert  -> roll back jj op-log + drop the agenticow delta
+//   merge   -> merge jj ops + promote the winning agenticow delta into the base
+//
+// The bridge holds only PORTS, so it works with mock or real adapters and with
+// either plane absent (degraded but coherent).
+
+import type { Embedder } from '../embed.js';
+import { HashEmbedder } from '../embed.js';
+import type { MemoryQueryHit, OpDescriptor } from '../types.js';
+import type {
+  MemoryBranchHandle,
+  MemoryBranchProvider,
+  MemoryQueryProvider,
+  OpBranchHandle,
+  OpBranchProvider,
+} from './ports.js';
+
+export interface DualBranch {
+  readonly agentId: string;
+  /** Live op handle, or null if the op plane is unavailable. */
+  readonly op: OpBranchHandle | null;
+  /** Live memory handle, or null if the memory plane is unavailable. */
+  readonly mem: MemoryBranchHandle | null;
+}
+
+export interface LearnResult {
+  trajectoryId: string;
+  successScore: number;
+  opCount: number;
+  /** Records embedded + ingested into the memory branch. */
+  ingested: number;
+  /** Sides that were actually exercised. */
+  opPlane: boolean;
+  memPlane: boolean;
+}
+
+export interface BridgeOptions {
+  embedder?: Embedder;
+  /** Optional cross-branch query provider (stubbed plane). */
+  queryProvider?: MemoryQueryProvider;
+}
+
+export class DualStateBridge {
+  private readonly embedder: Embedder;
+  private readonly branches = new Map<string, DualBranch>();
+  /** Monotonic id source for memory records (op -> vector). */
+  private nextRecordId = 1;
+
+  constructor(
+    private readonly opProvider: OpBranchProvider,
+    private readonly memProvider: MemoryBranchProvider,
+    private readonly opts: BridgeOptions = {},
+  ) {
+    this.embedder = opts.embedder ?? new HashEmbedder(384);
+  }
+
+  /** Which planes are live. */
+  status(): { opPlane: boolean; memPlane: boolean; nativeAnn: boolean } {
+    return {
+      opPlane: this.opProvider.available,
+      memPlane: this.memProvider.available,
+      nativeAnn: this.opts.queryProvider?.nativeAnn ?? false,
+    };
+  }
+
+  /** spawn -> create jj branch + agenticow branch together. */
+  async spawn(agentId: string): Promise<DualBranch> {
+    if (this.branches.has(agentId)) {
+      throw new Error(`DualStateBridge: agent "${agentId}" already spawned`);
+    }
+    const op = this.opProvider.available ? await this.opProvider.spawn(agentId) : null;
+    const mem = this.memProvider.available ? await this.memProvider.branch(agentId) : null;
+    const branch: DualBranch = { agentId, op, mem };
+    this.branches.set(agentId, branch);
+    return branch;
+  }
+
+  /**
+   * learn -> finalize the op trajectory, embed the op-sequence, and write it
+   * into the agent's COW memory branch. ReasoningBank-as-agenticow.
+   */
+  async learn(agentId: string, successScore: number, critique?: string): Promise<LearnResult> {
+    const b = this.require(agentId);
+    let trajectoryId = '';
+    let ops: OpDescriptor[] = [];
+    let opCount = 0;
+
+    if (b.op && this.opProvider.available) {
+      const summary = await this.opProvider.finalize(b.op, successScore, critique);
+      trajectoryId = summary.trajectoryId || (b.op.trajectoryId ?? '');
+      ops = await this.opProvider.opSequence(b.op);
+      opCount = ops.length;
+    }
+
+    let ingested = 0;
+    if (b.mem && this.memProvider.available && ops.length > 0) {
+      const records = ops.map((op) => ({
+        id: this.nextRecordId++,
+        vector: this.embedder.embed(opToText(op)),
+      }));
+      const res = await this.memProvider.ingest(b.mem, records);
+      ingested = res.accepted;
+    }
+
+    return {
+      trajectoryId,
+      successScore,
+      opCount,
+      ingested,
+      opPlane: Boolean(b.op),
+      memPlane: Boolean(b.mem),
+    };
+  }
+
+  /** revert -> jj undo + drop the agenticow delta. */
+  async revert(agentId: string, memoryCheckpointId?: string): Promise<void> {
+    const b = this.require(agentId);
+    if (b.op && this.opProvider.available) await this.opProvider.undo(b.op);
+    if (b.mem && this.memProvider.available) await this.memProvider.rollback(b.mem, memoryCheckpointId);
+  }
+
+  /** merge -> merge jj ops + promote the winning agenticow delta into the base. */
+  async merge(agentId: string): Promise<{ ingested: number; deleted: number }> {
+    const b = this.require(agentId);
+    if (b.op && this.opProvider.available) await this.opProvider.merge(b.op);
+    let promotion = { ingested: 0, deleted: 0 };
+    if (b.mem && this.memProvider.available) promotion = await this.memProvider.promote(b.mem);
+    this.branches.delete(agentId);
+    return promotion;
+  }
+
+  /**
+   * Cross-branch memory query. STUB-aware: delegates to the injected
+   * MemoryQueryProvider (native ANN pending — RuVector PR #617). Throws a clear
+   * error if no provider was supplied.
+   */
+  async queryMemory(
+    agentId: string,
+    vector: Float32Array | number[],
+    k = 10,
+  ): Promise<MemoryQueryHit[]> {
+    const b = this.require(agentId);
+    if (!b.mem) throw new Error('DualStateBridge: memory plane unavailable for this agent');
+    const qp = this.opts.queryProvider;
+    if (!qp) {
+      throw new Error(
+        'DualStateBridge: no MemoryQueryProvider injected. Cross-branch ANN is a ' +
+          'stubbed plane (RuVector PR #617 pending) — inject a provider to query.',
+      );
+    }
+    return qp.queryAcrossBranches(b.mem, vector, k);
+  }
+
+  /** Embed arbitrary text with the bridge's embedder (helper for callers). */
+  embed(text: string): Float32Array {
+    return this.embedder.embed(text);
+  }
+
+  private require(agentId: string): DualBranch {
+    const b = this.branches.get(agentId);
+    if (!b) throw new Error(`DualStateBridge: agent "${agentId}" not spawned`);
+    return b;
+  }
+}
+
+/** Stable textual rendering of an op for embedding. */
+function opToText(op: OpDescriptor): string {
+  return `${op.operationType} ${op.command} ${op.success ? 'ok' : 'fail'}`;
+}

--- a/packages/jujutsu/src/bridge/index.ts
+++ b/packages/jujutsu/src/bridge/index.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+//
+// @metaharness/jujutsu/bridge — the agenticow <-> agentic-jujutsu dual-state
+// bridge (ADR-202). Public surface.
+
+export { DualStateBridge } from './bridge.js';
+export type { DualBranch, LearnResult, BridgeOptions } from './bridge.js';
+
+export type {
+  OpBranchProvider,
+  OpBranchHandle,
+  MemoryBranchProvider,
+  MemoryBranchHandle,
+  MemoryQueryProvider,
+} from './ports.js';
+
+// Adapters
+export { MockOpProvider, MockMemoryProvider, MockQueryProvider } from './adapters/mock-providers.js';
+export { AgenticJujutsuOpProvider } from './adapters/agentic-jujutsu-op-provider.js';
+export type { AgenticJujutsuOpOptions } from './adapters/agentic-jujutsu-op-provider.js';
+export {
+  AgenticowMemoryProvider,
+  AgenticowQueryProvider,
+} from './adapters/agenticow-memory-provider.js';
+export type { AgenticowOptions } from './adapters/agenticow-memory-provider.js';

--- a/packages/jujutsu/src/bridge/ports.ts
+++ b/packages/jujutsu/src/bridge/ports.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+//
+// Ports for the agenticow <-> agentic-jujutsu dual-state bridge.
+//
+// The bridge depends ONLY on these interfaces (ports-and-adapters / hexagonal),
+// so it is testable offline with mock adapters and degrades cleanly when a
+// native peer is missing. Two independent state planes:
+//
+//   OpBranchProvider     -> the CODE/OP branch  (agentic-jujutsu jj op-log)
+//   MemoryBranchProvider -> the MEMORY branch   (agenticow COW vector branch)
+//
+// The memory-QUERY plane is split out (MemoryQueryProvider) and STUBBED on
+// purpose: agenticow's native ANN-across-branch (RuVector PR #617) is still in
+// flight. Branch create / ingest / rollback / promote / diff are wired to real
+// agenticow today; cross-branch search lands with that PR.
+
+import type {
+  MemoryDelta,
+  MemoryQueryHit,
+  MemoryRecord,
+  OpDescriptor,
+  TrajectorySummary,
+} from '../types.js';
+
+export interface OpBranchHandle {
+  /** Stable id for the op branch (jj bookmark/branch name). */
+  readonly id: string;
+  readonly name: string;
+  /** Active trajectory id, if a learning trajectory was opened at spawn. */
+  trajectoryId?: string;
+}
+
+/** The CODE/OP branch plane (agentic-jujutsu). */
+export interface OpBranchProvider {
+  /** Whether the underlying augmentation is live. */
+  readonly available: boolean;
+  /** Create a jj branch for an agent and open a learning trajectory. */
+  spawn(agentId: string): Promise<OpBranchHandle>;
+  /** Fold the current op(s) into the active trajectory. */
+  recordOp(handle: OpBranchHandle): Promise<void>;
+  /** Finalize the trajectory with a reward score. */
+  finalize(handle: OpBranchHandle, successScore: number, critique?: string): Promise<TrajectorySummary>;
+  /** The op-sequence produced on this branch (newest-last). */
+  opSequence(handle: OpBranchHandle): Promise<OpDescriptor[]>;
+  /** Roll back the op-log (jj undo). */
+  undo(handle: OpBranchHandle): Promise<void>;
+  /** Merge/squash this branch's ops into the base. */
+  merge(handle: OpBranchHandle): Promise<void>;
+}
+
+export interface MemoryBranchHandle {
+  readonly id: string;
+  readonly label: string;
+}
+
+/** The MEMORY branch plane (agenticow COW vector branch). */
+export interface MemoryBranchProvider {
+  readonly available: boolean;
+  /** Create a COW branch off the base memory (~O(1) in base size). */
+  branch(label: string): Promise<MemoryBranchHandle>;
+  /** Ingest embedded records into the branch's working node. */
+  ingest(handle: MemoryBranchHandle, records: MemoryRecord[]): Promise<{ accepted: number }>;
+  /** Freeze a restore point. */
+  checkpoint(handle: MemoryBranchHandle, label?: string): Promise<{ id: string }>;
+  /** Drop the branch delta back to a checkpoint (or its base). */
+  rollback(handle: MemoryBranchHandle, checkpointId?: string): Promise<void>;
+  /** Promote the branch's winning delta into the base memory. */
+  promote(handle: MemoryBranchHandle): Promise<{ ingested: number; deleted: number }>;
+  /** Git-style diff of the branch vs its ancestor. */
+  diff(handle: MemoryBranchHandle): Promise<MemoryDelta>;
+}
+
+/**
+ * The cross-branch memory QUERY plane. STUBBED interface: native ANN spanning
+ * the COW boundary (RuVector PR #617) is pending. A default impl backed by
+ * agenticow's exact read-through query() can be supplied; until the native
+ * index ships, treat results as exact-but-unaccelerated.
+ */
+export interface MemoryQueryProvider {
+  readonly nativeAnn: boolean;
+  queryAcrossBranches(
+    handle: MemoryBranchHandle,
+    vector: Float32Array | number[],
+    k?: number,
+  ): Promise<MemoryQueryHit[]>;
+}

--- a/packages/jujutsu/src/capability.ts
+++ b/packages/jujutsu/src/capability.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+//
+// JujutsuCapability — the MetaHarness-facing facade over agentic-jujutsu's
+// lock-free op-log / agent-coordination / trajectory / signing primitives.
+//
+// Honest capability reporting (kernel ethos): `probe()` tells you exactly which
+// pieces are live. Construction NEVER half-loads — `create()` throws a typed
+// CapabilityUnavailableError if the native addon is absent so callers can
+// degrade explicitly. The native addon further needs the `jj` (Jujutsu) CLI
+// for op-log/branch/diff calls; trajectory + coordination + signing work
+// without it.
+
+import { existsSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { loadAgenticJujutsu, loadAgenticow } from './loader.js';
+import {
+  CapabilityUnavailableError,
+  type CapabilityReport,
+  type JujutsuConfig,
+  type OpDescriptor,
+  type TrajectorySummary,
+} from './types.js';
+
+/** Minimal structural view of agentic-jujutsu's JjWrapper we depend on. */
+interface RawWrapper {
+  getConfig(): { jjPath: string; repoPath: string };
+  getStats(): string;
+  getOperations(limit: number): OpDescriptor[];
+  getUserOperations(limit: number): OpDescriptor[];
+  startTrajectory(task: string): string;
+  addToTrajectory(): void;
+  finalizeTrajectory(successScore: number, critique?: string | null): void;
+  getSuggestion(task: string): string;
+  getLearningStats(): string;
+  getPatterns(): string;
+  queryTrajectories(task: string, limit: number): string;
+  registerAgent(agentId: string, agentType: string): Promise<void>;
+  enableAgentCoordination(): Promise<void>;
+  registerAgentOperation(agentId: string, operationId: string, files: string[]): Promise<string>;
+  checkAgentConflicts(operationId: string, operationType: string, files: string[]): Promise<string>;
+  getCoordinationStats(): Promise<string>;
+  getCoordinationTips(): Promise<string[]>;
+  branchCreate(name: string, revision?: string | null): Promise<unknown>;
+  branchDelete(name: string): Promise<unknown>;
+  undo(): Promise<unknown>;
+  execute(args: string[]): Promise<unknown>;
+}
+
+interface RawModule {
+  JjWrapper: new () => RawWrapper;
+  QuantumSigner: unknown;
+}
+
+function asModule(m: unknown): RawModule | null {
+  if (m && typeof (m as RawModule).JjWrapper === 'function') return m as RawModule;
+  return null;
+}
+
+/** Probe which removable augmentations are live — never throws. */
+export async function probe(config: JujutsuConfig = {}): Promise<CapabilityReport> {
+  const notes: string[] = [];
+  const mod = asModule(loadAgenticJujutsu());
+  const opLog = mod !== null;
+  if (!opLog) notes.push('agentic-jujutsu native addon not loadable (not installed or no prebuilt binary for this platform).');
+
+  let jjPath = config.jjPath;
+  if (opLog && !jjPath) {
+    try {
+      jjPath = new mod!.JjWrapper().getConfig().jjPath;
+    } catch {
+      /* ignore */
+    }
+  }
+  const jjCli = resolveJjCli(jjPath);
+  if (opLog && !jjCli) notes.push('jj (Jujutsu) CLI not found — op-log/branch/diff calls will fail; trajectory + coordination + signing still work.');
+
+  const memory = (await loadAgenticow()) !== null;
+  if (!memory) notes.push('agenticow not loadable — memory-branch side of the bridge is unavailable.');
+
+  // agenticow ships an EXACT read-through query() today; the NATIVE single-index
+  // ANN spanning the COW boundary (RuVector PR #617) is still in flight.
+  const annAcrossBranch = false;
+  notes.push('cross-branch ANN search is the read-through wrapper today; native ANN-across-branch (RuVector PR #617) is pending.');
+
+  return { opLog, memory, jjCli, annAcrossBranch, notes };
+}
+
+function resolveJjCli(jjPath?: string): boolean {
+  if (jjPath && existsSync(jjPath)) return true;
+  try {
+    execFileSync(jjPath || 'jj', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** True iff the agentic-jujutsu native addon is loadable. */
+export function jujutsuAvailable(): boolean {
+  return asModule(loadAgenticJujutsu()) !== null;
+}
+
+/**
+ * Typed facade over a single JjWrapper instance. Groups the raw N-API surface
+ * into op-log / coordination / trajectory namespaces and parses the JSON-string
+ * returns into objects. JSON-returning getters are typed `unknown` — the shapes
+ * are agentic-jujutsu's and we do not re-declare them all.
+ */
+export class JujutsuCapability {
+  private constructor(private readonly w: RawWrapper) {}
+
+  /** Construct against the live native addon. Throws if unavailable. */
+  static create(): JujutsuCapability {
+    const mod = asModule(loadAgenticJujutsu());
+    if (!mod) throw new CapabilityUnavailableError('agentic-jujutsu');
+    return new JujutsuCapability(new mod.JjWrapper());
+  }
+
+  /** Escape hatch to the raw wrapper for advanced callers. */
+  get raw(): RawWrapper {
+    return this.w;
+  }
+
+  // ---- op-log (needs jj CLI at runtime) -----------------------------------
+  recentOps(limit = 50): OpDescriptor[] {
+    return this.w.getOperations(limit);
+  }
+  userOps(limit = 50): OpDescriptor[] {
+    return this.w.getUserOperations(limit);
+  }
+  stats(): unknown {
+    return JSON.parse(this.w.getStats());
+  }
+
+  // ---- trajectory / ReasoningBank (no jj CLI needed) ----------------------
+  startTrajectory(task: string): string {
+    return this.w.startTrajectory(task);
+  }
+  addToTrajectory(): void {
+    this.w.addToTrajectory();
+  }
+  finalizeTrajectory(successScore: number, critique?: string): TrajectorySummary {
+    const id = ''; // wrapper does not return the id from finalize; caller tracks startTrajectory()
+    this.w.finalizeTrajectory(successScore, critique ?? null);
+    return { trajectoryId: id, successScore, critique, opCount: this.w.getUserOperations(1000).length };
+  }
+  suggestion(task: string): unknown {
+    return safeJson(this.w.getSuggestion(task));
+  }
+  learningStats(): unknown {
+    return JSON.parse(this.w.getLearningStats());
+  }
+  patterns(): unknown {
+    return safeJson(this.w.getPatterns());
+  }
+  queryTrajectories(task: string, limit = 10): unknown {
+    return safeJson(this.w.queryTrajectories(task, limit));
+  }
+
+  // ---- lock-free agent coordination (QuantumDAG) --------------------------
+  async enableCoordination(): Promise<void> {
+    await this.w.enableAgentCoordination();
+  }
+  async registerAgent(agentId: string, agentType: string): Promise<void> {
+    await this.w.registerAgent(agentId, agentType);
+  }
+  async registerOperation(agentId: string, operationId: string, files: string[]): Promise<unknown> {
+    return safeJson(await this.w.registerAgentOperation(agentId, operationId, files));
+  }
+  async checkConflicts(operationId: string, operationType: string, files: string[]): Promise<unknown> {
+    return safeJson(await this.w.checkAgentConflicts(operationId, operationType, files));
+  }
+  async coordinationStats(): Promise<unknown> {
+    return safeJson(await this.w.getCoordinationStats());
+  }
+  async coordinationTips(): Promise<string[]> {
+    return this.w.getCoordinationTips();
+  }
+}
+
+function safeJson(s: string): unknown {
+  try {
+    return JSON.parse(s);
+  } catch {
+    return s;
+  }
+}
+
+/** Pass-through to agentic-jujutsu's QuantumSigner (ML-DSA-65). Null if absent. */
+export function quantumSigner(): unknown | null {
+  return asModule(loadAgenticJujutsu())?.QuantumSigner ?? null;
+}

--- a/packages/jujutsu/src/embed.ts
+++ b/packages/jujutsu/src/embed.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+//
+// Offline, dependency-free embedder used to turn an op-sequence into a vector
+// for the agenticow memory branch. It is deterministic and zero-cost so the
+// bridge runs with no model/network — but it is a PLACEHOLDER. Production
+// should inject a real embedder (ONNX all-MiniLM-L6-v2, etc.) via the
+// `Embedder` interface; the bridge depends only on the interface.
+
+/** Anything that turns text into a fixed-dimension vector. */
+export interface Embedder {
+  readonly dimension: number;
+  embed(text: string): Float32Array;
+}
+
+/**
+ * Deterministic hashing embedder (feature hashing + L2 normalize). Same text
+ * always yields the same vector; similar token sets yield closer vectors. Not
+ * semantically rich — swap for a real model in production.
+ */
+export class HashEmbedder implements Embedder {
+  constructor(public readonly dimension: number = 384) {
+    if (dimension <= 0) throw new Error('HashEmbedder: dimension must be > 0');
+  }
+
+  embed(text: string): Float32Array {
+    const v = new Float32Array(this.dimension);
+    const tokens = String(text)
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean);
+    for (const tok of tokens) {
+      const h = fnv1a(tok);
+      const idx = h % this.dimension;
+      // sign hashing reduces collisions cancelling vs reinforcing arbitrarily
+      const sign = (h >>> 31) & 1 ? -1 : 1;
+      v[idx] += sign;
+    }
+    // L2 normalize for cosine geometry (agenticow default metric).
+    let norm = 0;
+    for (let i = 0; i < v.length; i++) norm += v[i] * v[i];
+    norm = Math.sqrt(norm) || 1;
+    for (let i = 0; i < v.length; i++) v[i] /= norm;
+    return v;
+  }
+}
+
+/** 32-bit FNV-1a. */
+function fnv1a(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}

--- a/packages/jujutsu/src/index.ts
+++ b/packages/jujutsu/src/index.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+//
+// @metaharness/jujutsu — lock-free version-control-for-agents as a MetaHarness
+// capability, plus the agenticow dual-state bridge.
+//
+// agentic-jujutsu and agenticow are OPTIONAL peers (ADR-150 principle: removable
+// augmentation, never a required runtime dep). Everything here imports and
+// type-checks with neither installed; `probe()` reports what is actually live.
+
+// Capability facade over agentic-jujutsu.
+export { JujutsuCapability, probe, jujutsuAvailable, quantumSigner } from './capability.js';
+
+// Embedder (op-sequence -> vector) — swap HashEmbedder for a real model.
+export { HashEmbedder } from './embed.js';
+export type { Embedder } from './embed.js';
+
+// Types.
+export {
+  CapabilityUnavailableError,
+} from './types.js';
+export type {
+  CapabilityReport,
+  JujutsuConfig,
+  OpDescriptor,
+  TrajectorySummary,
+  MemoryRecord,
+  MemoryDelta,
+  MemoryQueryHit,
+} from './types.js';
+
+// The dual-state bridge (also available at the ./bridge subpath export).
+export {
+  DualStateBridge,
+  MockOpProvider,
+  MockMemoryProvider,
+  MockQueryProvider,
+  AgenticJujutsuOpProvider,
+  AgenticowMemoryProvider,
+  AgenticowQueryProvider,
+} from './bridge/index.js';
+export type {
+  DualBranch,
+  LearnResult,
+  BridgeOptions,
+  OpBranchProvider,
+  OpBranchHandle,
+  MemoryBranchProvider,
+  MemoryBranchHandle,
+  MemoryQueryProvider,
+  AgenticJujutsuOpOptions,
+  AgenticowOptions,
+} from './bridge/index.js';

--- a/packages/jujutsu/src/loader.ts
+++ b/packages/jujutsu/src/loader.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+//
+// Lazy, failure-tolerant loaders for the OPTIONAL native peers. Nothing here
+// throws on import — callers decide how to handle absence. This is the seam
+// that makes agentic-jujutsu / agenticow removable augmentations (ADR-150):
+// the package loads and type-checks with neither installed.
+
+import { createRequire } from 'node:module';
+
+/** agentic-jujutsu is a CommonJS native addon — require it, don't ESM-import it. */
+let _aj: unknown | null | undefined;
+/** agenticow is an ESM package — dynamic import. Cached promise. */
+let _cow: Promise<unknown | null> | undefined;
+
+const require_ = createRequire(import.meta.url);
+
+/**
+ * Load the agentic-jujutsu native addon. Returns the module namespace
+ * ({ JjWrapper, QuantumSigner, ... }) or null if it cannot be loaded
+ * (not installed, or no prebuilt binary for this platform).
+ */
+export function loadAgenticJujutsu(): unknown | null {
+  if (_aj !== undefined) return _aj;
+  try {
+    _aj = require_('agentic-jujutsu');
+  } catch {
+    _aj = null;
+  }
+  return _aj;
+}
+
+/**
+ * Load the agenticow ESM module. Returns the module namespace
+ * ({ open, AgenticMemory }) or null if it cannot be loaded.
+ */
+export function loadAgenticow(): Promise<unknown | null> {
+  if (_cow !== undefined) return _cow;
+  // Indirect the specifier: agenticow is an OPTIONAL peer that may be absent, so
+  // we must not let the bundler/tsc statically resolve it. A non-literal import
+  // specifier keeps this a true runtime dynamic import.
+  const spec = 'agenticow';
+  _cow = import(spec).then(
+    (m) => (m as { default?: unknown }).default ?? m,
+    () => null,
+  );
+  return _cow;
+}
+
+/** Reset cached module handles. Test-only seam. */
+export function _resetLoaderCacheForTests(): void {
+  _aj = undefined;
+  _cow = undefined;
+}

--- a/packages/jujutsu/src/types.ts
+++ b/packages/jujutsu/src/types.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+//
+// @metaharness/jujutsu — structural types.
+//
+// These mirror the public surface of `agentic-jujutsu` (v2.3.6) WITHOUT taking a
+// hard dependency on it. agentic-jujutsu is an OPTIONAL peer (ADR-150 principle:
+// removable augmentation, never a required runtime dep), so this package must
+// type-check and import even when the native addon is absent. We declare the
+// minimal structural shapes we consume and cast at the dynamic-import boundary.
+
+/** Subset of agentic-jujutsu's JjConfig we expose. */
+export interface JujutsuConfig {
+  jjPath?: string;
+  repoPath?: string;
+  timeoutMs?: number;
+  verbose?: boolean;
+  maxLogEntries?: number;
+  enableAgentdbSync?: boolean;
+}
+
+/** A single entry in the jj operation log (subset of agentic-jujutsu's JjOperation). */
+export interface OpDescriptor {
+  id: string;
+  operationId: string;
+  operationType: string;
+  command: string;
+  user: string;
+  timestamp: string;
+  durationMs: number;
+  success: boolean;
+  error?: string;
+}
+
+/** Result of finalizing a learning trajectory. */
+export interface TrajectorySummary {
+  trajectoryId: string;
+  successScore: number;
+  critique?: string;
+  opCount: number;
+}
+
+/** A vector record ingested into a memory branch. */
+export interface MemoryRecord {
+  id: number;
+  vector: Float32Array | number[];
+}
+
+/** Delta of a memory branch vs its nearest ancestor (mirrors agenticow MemoryDiff). */
+export interface MemoryDelta {
+  added: number[];
+  overridden: number[];
+  deleted: number[];
+}
+
+/** A k-NN hit from the (stubbed) cross-branch memory query. */
+export interface MemoryQueryHit {
+  id: number;
+  distance: number;
+  branch: string;
+}
+
+/** Honest capability probe result — mirrors the kernel's capability reporting. */
+export interface CapabilityReport {
+  /** agentic-jujutsu native addon loadable? */
+  opLog: boolean;
+  /** agenticow COW memory branching loadable? */
+  memory: boolean;
+  /** jj (Jujutsu) CLI resolvable on PATH or at the configured path? */
+  jjCli: boolean;
+  /** cross-branch ANN search (agenticow native, RuVector PR #617) shipped? */
+  annAcrossBranch: boolean;
+  notes: string[];
+}
+
+/** Thrown when a removable augmentation is required but not installed. */
+export class CapabilityUnavailableError extends Error {
+  constructor(
+    public readonly capability: string,
+    public readonly cause?: unknown,
+  ) {
+    super(
+      `@metaharness/jujutsu: capability "${capability}" is unavailable. ` +
+        `It is a removable augmentation (ADR-150) — install the optional peer ` +
+        `dependency and any system prerequisites to enable it.` +
+        (cause instanceof Error ? ` Underlying: ${cause.message}` : ''),
+    );
+    this.name = 'CapabilityUnavailableError';
+  }
+}

--- a/packages/jujutsu/tsconfig.json
+++ b/packages/jujutsu/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/scripts/build-ordered.mjs
+++ b/scripts/build-ordered.mjs
@@ -21,7 +21,7 @@ const PHASES = [
   // darwin-mode and projects are dependency-free (no internal imports) so they
   // build here too. weight-eft (ADR-198) is dependency-free and must build
   // BEFORE create-agent-harness (phase 3), which depends on it.
-  ['kernel-js', 'router', 'harness', 'darwin-mode', 'projects', 'redblue', 'weight-eft'],
+  ['kernel-js', 'router', 'harness', 'darwin-mode', 'projects', 'redblue', 'weight-eft', 'jujutsu'],
   // Phase 2: vertical-base — vertical-trading imports from it
   ['vertical-base'],
   // Phase 3: hosts + sdk + cli — all depend on kernel-js


### PR DESCRIPTION
## Summary

Adds **`@metaharness/jujutsu`** (`packages/jujutsu`): wraps the live npm package **`agentic-jujutsu`** (lock-free jj/Jujutsu op-log, QuantumDAG agent coordination, ReasoningBank trajectories, ML-DSA-65 signing) as a **removable** MetaHarness capability, and bridges it **1:1** to **`agenticow`** copy-on-write vector memory for dual-state (code-branch + memory-branch) agent lifecycles. See **ADR-202**.

## Removable augmentation (ADR-150 principle)
`agentic-jujutsu` and `agenticow` are **optional peer deps**. The package imports + type-checks with neither installed; `probe()` reports what's live; the bridge degrades to whichever planes exist (or runs fully mock-backed).

## Dual-state lifecycle (1:1)
| verb | code/op (agentic-jujutsu) | memory (agenticow) |
|---|---|---|
| spawn | register agent + `jj bookmark create` + trajectory | `fork()` base + `checkpoint('spawn')` |
| learn | finalize trajectory + read op-seq | embed op-seq → `ingest()` into branch |
| revert | `jj undo` | `rollback()` to spawn checkpoint |
| merge | `jj squash` into base | `promote()` winning delta to base |

Ports & adapters: `OpBranchProvider` / `MemoryBranchProvider` / `MemoryQueryProvider`, with real + mock adapters.

## Wired vs stubbed (honest)
- **Wired & verified end-to-end** with both real native peers (jj 0.35.0 bookmarks + agenticow COW): spawn/learn/revert/merge + trajectory + op-seq embedding.
- **Stubbed:** cross-branch ANN query behind `MemoryQueryProvider`. `AgenticowQueryProvider` uses agenticow's exact read-through `query()` today; native ANN-across-branch (RuVector PR #617) lands later — only the adapter swaps, `nativeAnn=false` until then.

## Real upstream bug found
`agentic-jujutsu ≤2.3.6` `branchCreate()` shells the **removed** `jj branch` subcommand (jj ≥0.21 renamed it to `jj bookmark`), so it fails against the **jj 0.35.0 it bundles** (`unrecognized subcommand 'branch'`). This package works around it (uses `bookmark`, falls back to `branchCreate` for old jj). Upstream fix to be PR'd to `ruvnet/agentic-flow` `packages/agentic-jujutsu` (warrants v2.3.7).

## Tests
- `build` clean (tsc, no native dep needed) · `test` 15/15 vitest (offline) · `smoke` offline lifecycle + capability probe · real-peer integration cycle green.

## Note for reviewer
Branched off `claude/cve-bench-era-pin-image-reuse`; if that's unmerged, rebase onto `main` before merge so only the jujutsu commit lands.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)