### PR TITLE
fix(pages): metaharness rename + fix blank Studio (relative Vite base)

### DIFF
--- a/.github/workflows/pages-monitor.yml
+++ b/.github/workflows/pages-monitor.yml
@@ -1,5 +1,5 @@
 # iter 84: daily liveness probe of the live Studio at
-# https://ruvnet.github.io/agent-harness-generator/.
+# https://ruvnet.github.io/metaharness/.
 #
 # Separate from pages.yml (which fires on push to apps/web-ui/**) so
 # the Studio is verified every 24h regardless of whether anyone

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -51,7 +51,7 @@ jobs:
       - name: E2E (desktop + mobile)
         run: npm run e2e
 
-      - name: Build (base = /agent-harness-generator/)
+      - name: Build (base = './' relative — survives repo rename)
         run: npm run build
 
       # SPA + Pages: 404 falls back to index.html so deep links work.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,7 +358,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   Next: capture the full diagnostic state for a support ticket:
     harness diag /path/to/harness --bundle > bundle.json
   (then attach bundle.json to a GitHub issue at
-   https://github.com/ruvnet/agent-harness-generator/issues — the
+   https://github.com/ruvnet/metaharness/issues — the
    bundle is sanitised; secret_/token_/key_/password_ fields are redacted)
   ```
 - **HEALTHY output is unchanged** — the bundle suggestion would be
@@ -389,7 +389,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   Next: capture the full diagnostic state for a support ticket:
     harness diag /path/to/harness --bundle > bundle.json
   (then attach bundle.json to a GitHub issue at
-   https://github.com/ruvnet/agent-harness-generator/issues — the
+   https://github.com/ruvnet/metaharness/issues — the
    bundle is sanitised; secret_/token_/key_/password_ fields are redacted)
   ```
 - **Sanitisation reassurance is load-bearing** — users hitting their
@@ -999,7 +999,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
 ### Added — Iter 72 (2026-06-14)
 
 - **`scripts/healthcheck.mjs --probe-pages`** — opt-in HTTP probe of
-  the live Studio at <https://ruvnet.github.io/agent-harness-generator/>.
+  the live Studio at <https://ruvnet.github.io/metaharness/>.
   iter-42 healthcheck was deliberately offline (file-system only); the
   Pages site has become a primary distribution surface so the daily
   driver should know how to verify it's alive.
@@ -1015,7 +1015,7 @@ All notable changes to this project are documented here. Format follows [Keep a 
   live-site verification one flag away.
 - New live output with `--probe-pages`:
   ```
-  PASS pages       https://ruvnet.github.io/agent-harness-generator/ OK + Vite bundle 200
+  PASS pages       https://ruvnet.github.io/metaharness/ OK + Vite bundle 200
   ```
 - `__tests__/healthcheck.test.ts` 7 → 9 cases (+2):
   - pages check is SKIP by default (no network)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,8 @@ Single command tells you every dev script + every `harness` subcommand + every C
 ## First-time setup
 
 ```bash
-git clone https://github.com/ruvnet/agent-harness-generator
-cd agent-harness-generator
+git clone https://github.com/ruvnet/metaharness
+cd metaharness
 
 # Rust workspace
 cargo test --workspace

--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@
 
 ### Mint a custom AI agent harness from any repo.
 
-`npx metaharness` · [open the Studio →](https://ruvnet.github.io/agent-harness-generator/)
+`npx metaharness` · [open the Studio →](https://ruvnet.github.io/metaharness/)
 
-<sub>(Repo: `ruvnet/agent-harness-generator` · CLI: `metaharness` · Library: `@ruvnet/agent-harness-generator`)</sub>
+<sub>(Repo: `ruvnet/metaharness` · CLI: `metaharness` · Library: `@ruvnet/agent-harness-generator`)</sub>
 
-[![Open the Studio](https://img.shields.io/badge/Studio-open_in_browser_↗-7c5cff?style=for-the-badge&logo=githubpages&logoColor=white)](https://ruvnet.github.io/agent-harness-generator/)
+[![Open the Studio](https://img.shields.io/badge/Studio-open_in_browser_↗-7c5cff?style=for-the-badge&logo=githubpages&logoColor=white)](https://ruvnet.github.io/metaharness/)
 [![User guide](https://img.shields.io/badge/User_guide-plain_language-22c55e?style=for-the-badge)](docs/USERGUIDE.md)
 [![Tests — 568 passing](https://img.shields.io/badge/tests-568%20passing-22c55e?style=for-the-badge)](docs/ARCHITECTURE.md)
-[![npm publish smoke](https://github.com/ruvnet/agent-harness-generator/actions/workflows/published-smoke.yml/badge.svg)](https://github.com/ruvnet/agent-harness-generator/actions/workflows/published-smoke.yml)
+[![npm publish smoke](https://github.com/ruvnet/metaharness/actions/workflows/published-smoke.yml/badge.svg)](https://github.com/ruvnet/metaharness/actions/workflows/published-smoke.yml)
 [![License MIT](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)](LICENSE)
 
-[![Agent Harness Studio](docs/web-ui/screenshot-desktop.png)](https://ruvnet.github.io/agent-harness-generator/)
+[![Agent Harness Studio](docs/web-ui/screenshot-desktop.png)](https://ruvnet.github.io/metaharness/)
 
 </div>
 
@@ -102,7 +102,7 @@ learned from your own eval logs. `npm i @metaharness/router`.
 
 ```bash
 # In the browser — zero install, nothing leaves the page
-open https://ruvnet.github.io/agent-harness-generator/
+open https://ruvnet.github.io/metaharness/
 
 # Or in the terminal — the same harness (behaviourally equivalent output)
 npx metaharness my-bot --template vertical:coding --host claude-code
@@ -272,7 +272,7 @@ across Rust × 3 OS + WASM × 3 OS + Node 20+22 × 3 OS + Bench + pack+install �
 | CI matrix | 16 jobs green |
 | Security pipeline | cargo-audit · cargo-deny · npm-audit · CodeQL · SBOM (SPDX-2.3) |
 | Publish pipeline | GCP WIF + 2 gates + 11 packages + IPFS pin |
-| Agent Harness Studio | Live at <https://ruvnet.github.io/agent-harness-generator/> |
+| Agent Harness Studio | Live at <https://ruvnet.github.io/metaharness/> |
 
 ---
 
@@ -311,8 +311,8 @@ You operate the factory. The factory produces your harness. Your users never see
 ## Developer quick-start
 
 ```bash
-git clone https://github.com/ruvnet/agent-harness-generator
-cd agent-harness-generator
+git clone https://github.com/ruvnet/metaharness
+cd metaharness
 
 cargo test --workspace
 cargo clippy --workspace --all-targets -- -D warnings
@@ -335,7 +335,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Cost-Pareto Leaderboard
 
-**[→ Live leaderboard — the cost-performance Pareto frontier](https://ruvnet.github.io/agent-harness-generator/cost-pareto.html)**
+**[→ Live leaderboard — the cost-performance Pareto frontier](https://ruvnet.github.io/metaharness/cost-pareto.html)**
 
 Which harness resolves the most benchmark per **dollar**, not just the highest raw score — ranked by a tunable
 **Value Score** that blends capability and price. Tabs: SWE-bench **Lite** / **Verified** / **Pro** / **DRACO** /

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ The project is pre-1.0. Only the **latest published `0.x` version** receives sec
 
 **Do NOT open a public issue.** Use one of these private channels:
 
-1. **GitHub Security Advisory** — preferred. Go to [Security → Report a vulnerability](https://github.com/ruvnet/agent-harness-generator/security/advisories/new). The form gives us a private repo where we collaborate on the fix without disclosing details before a coordinated release.
+1. **GitHub Security Advisory** — preferred. Go to [Security → Report a vulnerability](https://github.com/ruvnet/metaharness/security/advisories/new). The form gives us a private repo where we collaborate on the fix without disclosing details before a coordinated release.
 2. **Email** — `ruv@ruv.net` with subject `SECURITY: agent-harness-generator`. Include:
    - The affected package (`@metaharness/kernel`, `@metaharness/host-*`, `create-agent-harness`)
    - Affected versions

--- a/SUBMISSIONS.md
+++ b/SUBMISSIONS.md
@@ -1,6 +1,6 @@
 # Submit to the Cost-Pareto Leaderboard
 
-**[Live board →](https://ruvnet.github.io/agent-harness-generator/cost-pareto.html)**
+**[Live board →](https://ruvnet.github.io/metaharness/cost-pareto.html)**
 
 The leaderboard ranks coding-agent harnesses by **resolve-per-dollar** on public SWE benchmarks — the cheapest
 system that reaches each level of capability, scored by a tunable **Value Score** (capability blended with price).

--- a/apps/web-ui/index.html
+++ b/apps/web-ui/index.html
@@ -12,17 +12,17 @@
     <meta property="og:title" content="MetaHarness · Mint a custom AI agent harness from any repo" />
     <meta property="og:description" content="Paste any GitHub repo. Get a branded, npm-publishable AI agent harness with its own CLI, MCP server, memory, witness-signed releases. 100% client-side." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://ruvnet.github.io/agent-harness-generator/" />
+    <meta property="og:url" content="https://ruvnet.github.io/metaharness/" />
     <meta property="og:site_name" content="MetaHarness Studio" />
-    <meta property="og:image" content="https://ruvnet.github.io/agent-harness-generator/og.png" />
+    <meta property="og:image" content="https://ruvnet.github.io/metaharness/og.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="MetaHarness Studio — score any repo, cost-optimal model routing, multi-host runtime, npm-publishable. npx metaharness." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="MetaHarness · Mint a custom AI agent harness from any repo" />
     <meta name="twitter:description" content="Score any repo for harness fit + cost/run, then mint a branded, multi-host, npm-publishable agent harness with a cost-optimal model router. 100% client-side." />
-    <meta name="twitter:image" content="https://ruvnet.github.io/agent-harness-generator/og.png" />
-    <link rel="canonical" href="https://ruvnet.github.io/agent-harness-generator/" />
+    <meta name="twitter:image" content="https://ruvnet.github.io/metaharness/og.png" />
+    <link rel="canonical" href="https://ruvnet.github.io/metaharness/" />
     <title>MetaHarness · Mint a custom AI agent harness from any repo</title>
     <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%237c5cff'/%3E%3Cpath d='M9 21l4-10 3 7 2-4 5 7z' fill='white'/%3E%3C/svg%3E" />
   </head>

--- a/apps/web-ui/scripts/make-og.mjs
+++ b/apps/web-ui/scripts/make-og.mjs
@@ -5,7 +5,7 @@
 // (Twitter/Slack/Discord/LinkedIn/Facebook) do NOT render SVG, so we rasterise a
 // branded HTML card with the Playwright chromium already used for e2e. Output:
 // public/og.png (Vite copies public/ to the dist root → served at
-// https://ruvnet.github.io/agent-harness-generator/og.png).
+// https://ruvnet.github.io/metaharness/og.png).
 //
 // Run: node scripts/make-og.mjs   (regenerate whenever the card copy changes)
 

--- a/apps/web-ui/src/App.tsx
+++ b/apps/web-ui/src/App.tsx
@@ -37,10 +37,10 @@ export default function App() {
       <header className="mb-8 flex flex-col gap-5">
         <div className="flex items-center justify-between gap-4">
           <a
-            href="https://github.com/ruvnet/agent-harness-generator"
+            href="https://github.com/ruvnet/metaharness"
             className="inline-flex items-center gap-1.5 rounded-lg border border-ink-700 bg-ink-800/60 px-3 py-1.5 text-xs text-slate-300 transition hover:border-ink-600 hover:text-white"
           >
-            <Github size={14} /> ruvnet/agent-harness-generator
+            <Github size={14} /> ruvnet/metaharness
           </a>
           <div className="flex items-center gap-2">
             <a

--- a/apps/web-ui/src/generator/scaffold.ts
+++ b/apps/web-ui/src/generator/scaffold.ts
@@ -420,7 +420,7 @@ function readme(cfg: HarnessConfig): string {
 
 > ${cfg.description}
 
-Generated with the [agent-harness-generator](https://github.com/ruvnet/agent-harness-generator) web UI.
+Generated with the [metaharness](https://github.com/ruvnet/metaharness) web UI.
 
 - **Template:** ${tmpl?.name ?? cfg.template}
 - **Hosts:** ${hostNames}

--- a/apps/web-ui/vite.config.ts
+++ b/apps/web-ui/vite.config.ts
@@ -1,9 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// Base path for GitHub Pages: served from /agent-harness-generator/.
-// Override with VITE_BASE=/ for local root-serving or custom domains.
-const base = process.env.VITE_BASE ?? '/agent-harness-generator/';
+// Base path for GitHub Pages. Relative ('./') so emitted asset URLs resolve
+// against whatever path the site is served from — this keeps the bundle
+// working after a repo rename (e.g. /agent-harness-generator/ → /metaharness/)
+// without rebuilding. Override with VITE_BASE=/some/path/ for an absolute base.
+const base = process.env.VITE_BASE ?? './';
 
 export default defineConfig({
   base,

--- a/docs/SOTA_HORIZON.md
+++ b/docs/SOTA_HORIZON.md
@@ -2,7 +2,7 @@
 
 **Initialized**: 2026-06-22
 **Horizon key**: `horizons/horizon-darwin-sota` (ruflo memory)
-**Owner**: ruvnet/agent-harness-generator, branch `claude/darwin-mode-evolve-polyglot`
+**Owner**: ruvnet/metaharness, branch `claude/darwin-mode-evolve-polyglot`
 **Purpose**: Durable cross-session tracker for the Darwin Mode SWE-bench SOTA campaign. Each session must check this file in and update it at check-out.
 
 ---

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -36,8 +36,8 @@ No global install required. The package downloads itself on use.
 If you're working from the repo directly:
 
 ```bash
-git clone https://github.com/ruvnet/agent-harness-generator
-cd agent-harness-generator
+git clone https://github.com/ruvnet/metaharness
+cd metaharness
 npm install
 npm run build
 node packages/create-agent-harness/dist/bin.js my-bot
@@ -260,7 +260,7 @@ Honesty caveat from the underlying `@ruvector/emergent-time` package: the SDK is
 | `unknown template` | Check `npx metaharness --list` for the current template list (19 verticals at iter 96) |
 | `witness verification failed` on publish | Your `.harness/witness.json` was tampered with OR `harness sign` was never run |
 | `npm publish: 403` | Token expired — rotate via `gcloud secrets versions add NPM_TOKEN --data-file=-` |
-| `harness doctor` reports issues you don't understand | Run `harness diag <path> --bundle > bundle.json` and attach to an issue at <https://github.com/ruvnet/agent-harness-generator/issues>. The bundle is sanitised (secret/token/key/password fields redacted). |
+| `harness doctor` reports issues you don't understand | Run `harness diag <path> --bundle > bundle.json` and attach to an issue at <https://github.com/ruvnet/metaharness/issues>. The bundle is sanitised (secret/token/key/password fields redacted). |
 | `harness diag` says `MAJOR skew — APIs may have changed; expect breakage` | Your local `@metaharness/kernel` is on a different major than the version your harness was scaffolded against. Run `npm install @metaharness/kernel@<manifest-version>` (the diag output names the version). See [ADR-028](adrs/ADR-028-skew-detection-and-liveness.md). |
 | Want to share your MCP/Bash/claims config for a security review without zipping the whole harness | `harness export-config <path> > config.json` (iter 97) — emits a single sanitised JSON. |
 | Want to share npm-audit findings (machine-parseable, for grep / CI / vuln review) | `harness audit <path> --bundle > audit.json` (iter 102) — emits `{ schema, level, total, counts, offenders, failCount, exitCode }`. Error paths (no-package-json / no-lockfile / unknown-level) are also JSON. |

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -44,7 +44,7 @@ codebase, owned by you, runs on your laptop.
 
 ### 1. Paste a GitHub URL and generate a harness for it
 
-Open the Studio: <https://ruvnet.github.io/agent-harness-generator/>
+Open the Studio: <https://ruvnet.github.io/metaharness/>
 
 1. Click the **Repo → Harness** tab
 2. Paste a GitHub URL (e.g. `https://github.com/sindresorhus/ky`)
@@ -209,7 +209,7 @@ generate just the content you actually need, owned by you, branded by you.
 
 ## Next steps
 
-1. **Try the Studio:** <https://ruvnet.github.io/agent-harness-generator/>
+1. **Try the Studio:** <https://ruvnet.github.io/metaharness/>
 2. **Generate a harness for a repo you know:** the first time, pick a repo
    you're familiar with so you can sanity-check the output.
 3. **Read the agent prompts in `src/agents/*.ts`:** that's where the
@@ -222,8 +222,8 @@ generate just the content you actually need, owned by you, branded by you.
 
 ## Where to find help
 
-- Bug? <https://github.com/ruvnet/agent-harness-generator/issues>
-- Discussion? <https://github.com/ruvnet/agent-harness-generator/discussions>
+- Bug? <https://github.com/ruvnet/metaharness/issues>
+- Discussion? <https://github.com/ruvnet/metaharness/discussions>
 - Read the architecture: [`docs/ARCHITECTURE.md`](ARCHITECTURE.md)
 - Read the design decisions: [`docs/adrs/INDEX.md`](adrs/INDEX.md)
 - File a support ticket the right way: `harness diag --bundle > bundle.json`

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -32,7 +32,7 @@ const JSON_OUT = args.includes('--json');
 const PROBE_PAGES = args.includes('--probe-pages');
 const onlyCheck = args.find(a => a.startsWith('--check='))?.slice('--check='.length);
 
-const STUDIO_URL = 'https://ruvnet.github.io/agent-harness-generator/';
+const STUDIO_URL = 'https://ruvnet.github.io/metaharness/';
 
 const CHECKS = {
   async version() {


### PR DESCRIPTION
## Problem
After `ruvnet/agent-harness-generator` → `ruvnet/metaharness` rename, the Pages site at https://ruvnet.github.io/metaharness/ rendered **BLANK**.

**Root cause:** `apps/web-ui/vite.config.ts` defaulted `base` to `/agent-harness-generator/`, so Vite baked absolute asset URLs (`/agent-harness-generator/assets/*.js|css`) into `index.html`. Under the new `/metaharness/` base those 404 → React never mounts → blank screen.

## Fix
- **`vite.config.ts`**: `base` → relative `'./'` (rename-proof; assets resolve against the served path). Verified `dist/index.html` now emits `./assets/...` → resolves to `/metaharness/assets/...`.
- `index.html` SEO absolute URLs (og:url/og:image/twitter:image/canonical) → `/metaharness/`.
- `scripts/healthcheck.mjs` `STUDIO_URL` → `/metaharness/` (the live-site probe used by pages.yml verify + pages-monitor).
- `App.tsx`, `scaffold.ts`, `make-og.mjs`, workflow comments → metaharness.

## Docs (URL links only)
README, SUBMISSIONS, CONTRIBUTING, CHANGELOG, SECURITY, docs/USAGE, docs/USERGUIDE, docs/SOTA_HORIZON. The npm **library** name `@ruvnet/agent-harness-generator` is left unchanged (still published under that name; CLI is `metaharness`).

## Verification
- `npm run build` ✓ — assets now relative.
- web-ui unit tests 67/67 ✓; `healthcheck --check=workflows` ✓.
- pages.yml post-deploy probe will re-validate live HTML + bundle 200 on merge.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)