### PR TITLE
feat(apicompletions): Cognitum Fugu — tiered metered Completions API (ADR-203) — core impl, emulator-tested

### DIFF
--- a/services/apicompletions/.gitignore
+++ b/services/apicompletions/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.log
+.env

--- a/services/apicompletions/Dockerfile
+++ b/services/apicompletions/Dockerfile
@@ -1,0 +1,19 @@
+# Cognitum Fugu apicompletions — Cloud Run service (ADR-203 §7.1).
+# Mirrors the @cognitum-one/api-gateway Dockerfile (node:20-alpine, port 8080),
+# the upstream this service sits behind on api.cognitum.one.
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json tsconfig.json ./
+RUN npm ci
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+COPY package*.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=build /app/dist ./dist
+EXPOSE 8080
+USER node
+CMD ["node", "dist/index.js"]

--- a/services/apicompletions/README.md
+++ b/services/apicompletions/README.md
@@ -1,0 +1,73 @@
+# apicompletions — Cognitum Fugu
+
+OpenAI-compatible, **metered**, **tiered** completions service for `api.cognitum.one`
+(**ADR-203**). The honest analog of Sakana Fugu: tiered orchestration over a swappable
+model pool, routed by MetaHarness's heuristic difficulty signal — **not** a trained
+coordinator.
+
+> **Status: skeleton.** This is the scaffolded service shell from the ADR-203 rollout
+> (§7.4 step 3). Route handlers return `501 not_implemented`; pipeline modules are typed
+> stubs. The skeleton builds, typechecks, and tests green.
+
+## Stack
+
+TypeScript / Node 20, **Express** + `node-fetch`, `tsc` (CommonJS / ES2022), **vitest** +
+`supertest`, Docker `node:20-alpine` on **:8080** — the same stack as the
+`@cognitum-one/api-gateway` upstream this service sits behind.
+
+## Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/v1/chat/completions` | OpenAI-compatible chat completions (SSE or JSON) |
+| `POST` | `/v1/completions` | Legacy completions shape |
+| `GET`  | `/v1/models` | Lists the four `cognitum-*` aliases (not raw vendor ids) |
+| `GET`  | `/healthz` | Liveness |
+
+Model dial: `cognitum-auto` (default) · `cognitum-low|mid|high` · `cognitum-<tier>-agent`.
+Routing controls (body or `X-Cognitum-*` headers): `fallback_policy`, `min_tier`,
+`max_tier`, `escalation`. Response carries an `x_cognitum` block (`resolved_tier`,
+`escalated`, `cap_degraded`, `price_usd`, …). τ is internal/adaptive, never a public knob.
+
+## Module map (`src/`)
+
+| Dir | Responsibility (ADR §) |
+|-----|------------------------|
+| `server.ts` / `index.ts` | Express app + Cloud Run bootstrap (§7.1) |
+| `routes/` | `/v1/chat/completions`, `/v1/completions`, `/v1/models` (§3.1, §3.4) |
+| `auth/` | Real `cog_` SHA-256 → Firestore `api_keys` + `completions:<tier>` scopes (§6) |
+| `tier/` | Model-alias → tier, scope enforcement, `fallback_policy` (§3.3, §6.2) |
+| `router/` | Intrinsic difficulty signal (§3.3) + post-gen τ escalation (§6.5, non-stream only) |
+| `providers/` | `ModelProvider` (OpenRouter / direct) + `MockProvider` ($0, §7.3) |
+| `metering/` | Family-correct progressive tokenizer (§5.1) · ledger + Pub/Sub (§5.1) · pricing (§5.2) |
+| `ratelimit/` | Scatter-gather `usage_ticks` + `COUNT()` debounce (§5.3) · idempotency |
+| `midstream/` | Firewalled optional `ruvnet/midstream` inflight escalation (§3.5) — **degrades to Option B today** |
+| `firestore/` | Emulator-aware Firestore handle (§7.1, §7.3) |
+| `config/` | Env + Firestore `tier_config` pools (§3.2) |
+
+Plus `functions/aggregateUsage/` (gen2 Pub/Sub rollup, §5.1) and `terraform/` (reviewable
+module, §7.2 — **plan, never blind-apply**).
+
+## Develop ($0, emulator-first)
+
+```bash
+npm install
+npm run build            # tsc — green
+npm test                 # vitest — green
+docker compose -f docker-compose.emulators.yml up   # Firestore + Pub/Sub emulators
+USE_MOCK_PROVIDER=true npm run dev                   # whole auth→tier→route→meter loop, no spend
+```
+
+## Notable design decisions (from ADR-203)
+
+- **Streaming routes once, up front** on the intrinsic input signal (`stream_oneshot`,
+  Option B) — post-gen τ escalation applies to non-streaming only (§3.3, §6.5).
+- **Bill the resolved tier**; family-correct local token counting is the disconnect/
+  truncation billing floor (provider's authoritative count preferred when it arrives) (§5.1).
+- **`@midstream/wasm` is 404 on npm** — the inflight `escalation:"inflight"` path is dark
+  and silently degrades to `stream_oneshot`; the firewall (`src/midstream/firewall.ts`) is
+  the operative state, not an error path (§3.5).
+- **Open integration dependency**: `accountId` on `api_keys` docs (§6, §10).
+
+Deferred deps (added during Phase-1 impl, kept out of the skeleton): `firebase-admin`,
+`@google-cloud/pubsub`, `js-tiktoken` + per-family tokenizers.

--- a/services/apicompletions/docker-compose.emulators.yml
+++ b/services/apicompletions/docker-compose.emulators.yml
@@ -1,0 +1,28 @@
+# Local GCP emulators for emulator-first ($0) dev (ADR-203 §7.3; AgentBBS ADR-0012).
+# Firestore : localhost:8080  (FIRESTORE_EMULATOR_HOST)
+# Pub/Sub   : localhost:8085  (PUBSUB_EMULATOR_HOST)
+#
+#   docker compose -f docker-compose.emulators.yml up
+#   export FIRESTORE_EMULATOR_HOST=localhost:8080
+#   export PUBSUB_EMULATOR_HOST=localhost:8085
+#   curl -s -X PUT "http://localhost:8085/v1/projects/demo-project/topics/completions-usage"
+#   USE_MOCK_PROVIDER=true PORT=8090 npm run dev   # whole auth→tier→route→meter loop at $0
+services:
+  firestore-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    container_name: apicompletions-firestore-emulator
+    command: >-
+      gcloud beta emulators firestore start
+      --host-port=0.0.0.0:8080
+      --database-mode=firestore-native
+    ports:
+      - "8080:8080"
+  pubsub-emulator:
+    image: gcr.io/google.com/cloudsdktool/google-cloud-cli:latest
+    container_name: apicompletions-pubsub-emulator
+    command: >-
+      gcloud beta emulators pubsub start
+      --host-port=0.0.0.0:8085
+      --project=demo-project
+    ports:
+      - "8085:8085"

--- a/services/apicompletions/functions/aggregateUsage/README.md
+++ b/services/apicompletions/functions/aggregateUsage/README.md
@@ -1,0 +1,14 @@
+# aggregateUsage (gen2 Cloud Function)
+
+Pub/Sub-triggered rollup folder for Cognitum Fugu (ADR-203 §5.1, §7.1).
+
+```
+[Pub/Sub: completions-usage] --> aggregateUsage --> usage_rollups/{accountId}/{YYYY-MM}
+```
+
+- Trigger: `completions-usage` topic.
+- Fold: per-tier / per-model token + price totals (mirrors agentbbs-gcp `aggregateSysopReport`).
+- Ingress: `ALLOW_INTERNAL_ONLY`.
+- Separate deploy unit from the Cloud Run `apicompletions` service (rollout step 6).
+
+Skeleton stub — `firebase-functions` wiring + transactional fold land in Phase 6.

--- a/services/apicompletions/functions/aggregateUsage/README.md
+++ b/services/apicompletions/functions/aggregateUsage/README.md
@@ -11,4 +11,7 @@ Pub/Sub-triggered rollup folder for Cognitum Fugu (ADR-203 §5.1, §7.1).
 - Ingress: `ALLOW_INTERNAL_ONLY`.
 - Separate deploy unit from the Cloud Run `apicompletions` service (rollout step 6).
 
-Skeleton stub — `firebase-functions` wiring + transactional fold land in Phase 6.
+The pure `fold` / `aggregate` rollup logic (per-tier + per-model buckets + running totals,
+UTC `YYYY-MM` periods) is **implemented** (`src/index.ts`) against a structural `RollupStore`
+(in-memory for tests, firebase-admin Firestore in prod). The `firebase-functions/v2`
+`onMessagePublished('completions-usage')` trigger is a thin deploy-time wrapper (Phase 6).

--- a/services/apicompletions/functions/aggregateUsage/src/index.ts
+++ b/services/apicompletions/functions/aggregateUsage/src/index.ts
@@ -1,0 +1,20 @@
+// gen2 Cloud Function `aggregateUsage` (ADR-203 §5.1, §7.1) — Pub/Sub-triggered, folds
+// completions-usage events into usage_rollups/{accountId}/{YYYY-MM}. Mirrors the
+// agentbbs-gcp `aggregateSysopReport` shape (ALLOW_INTERNAL_ONLY). Separate deploy unit
+// from the Cloud Run service (deferred — Phase-6, rollout step 6).
+//
+// TODO(impl): firebase-functions/v2 onMessagePublished('completions-usage') →
+//             transactional fold into usage_rollups by tier/model. Stub for now.
+
+export interface UsageEvent {
+  accountId?: string;
+  tier: string;
+  resolvedModel: string;
+  totalTokens: number;
+  priceUsd: number;
+  ts: number;
+}
+
+export function fold(_event: UsageEvent): void {
+  throw new Error('not implemented: aggregateUsage.fold (ADR-203 §5.1)');
+}

--- a/services/apicompletions/functions/aggregateUsage/src/index.ts
+++ b/services/apicompletions/functions/aggregateUsage/src/index.ts
@@ -1,20 +1,119 @@
 // gen2 Cloud Function `aggregateUsage` (ADR-203 §5.1, §7.1) — Pub/Sub-triggered, folds
 // completions-usage events into usage_rollups/{accountId}/{YYYY-MM}. Mirrors the
 // agentbbs-gcp `aggregateSysopReport` shape (ALLOW_INTERNAL_ONLY). Separate deploy unit
-// from the Cloud Run service (deferred — Phase-6, rollout step 6).
+// from the Cloud Run service (rollout step 6).
 //
-// TODO(impl): firebase-functions/v2 onMessagePublished('completions-usage') →
-//             transactional fold into usage_rollups by tier/model. Stub for now.
+// The FOLD is pure + framework-free (testable at $0); the firebase-functions/v2
+// `onMessagePublished('completions-usage')` trigger is a thin wrapper bound at deploy
+// (firebase-functions is a deferred dep, kept out of the standalone build). The rollup
+// store is structurally typed so it binds to firebase-admin Firestore in production and an
+// in-memory fake in tests — the same DI posture as the Cloud Run service's metering stores.
 
 export interface UsageEvent {
   accountId?: string;
   tier: string;
   resolvedModel: string;
+  promptTokens: number;
+  completionTokens: number;
   totalTokens: number;
   priceUsd: number;
   ts: number;
 }
 
-export function fold(_event: UsageEvent): void {
-  throw new Error('not implemented: aggregateUsage.fold (ADR-203 §5.1)');
+export interface RollupBucket {
+  requests: number;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  priceUsd: number;
+}
+
+export interface RollupDoc {
+  accountId: string;
+  /** YYYY-MM (UTC). */
+  period: string;
+  byTier: Record<string, RollupBucket>;
+  byModel: Record<string, RollupBucket>;
+  totals: RollupBucket;
+  updatedAt: number;
+}
+
+const UNATTRIBUTED = '_unattributed';
+
+/** YYYY-MM (UTC) billing period for an epoch-ms timestamp. */
+export function periodOf(tsMs: number): string {
+  const d = new Date(tsMs);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+function emptyBucket(): RollupBucket {
+  return { requests: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0, priceUsd: 0 };
+}
+
+function addInto(b: RollupBucket, e: UsageEvent): void {
+  b.requests += 1;
+  b.promptTokens += e.promptTokens;
+  b.completionTokens += e.completionTokens;
+  b.totalTokens += e.totalTokens;
+  b.priceUsd += e.priceUsd;
+}
+
+/**
+ * Pure fold: accumulate one usage event into the (possibly null) prior rollup doc,
+ * returning the new doc. Totals + per-tier + per-model buckets (mirrors agentbbs-gcp).
+ */
+export function fold(prev: RollupDoc | null, event: UsageEvent): RollupDoc {
+  const accountId = event.accountId ?? UNATTRIBUTED;
+  const period = periodOf(event.ts);
+  const doc: RollupDoc = prev ?? {
+    accountId,
+    period,
+    byTier: {},
+    byModel: {},
+    totals: emptyBucket(),
+    updatedAt: 0,
+  };
+  doc.byTier[event.tier] ??= emptyBucket();
+  doc.byModel[event.resolvedModel] ??= emptyBucket();
+  addInto(doc.byTier[event.tier], event);
+  addInto(doc.byModel[event.resolvedModel], event);
+  addInto(doc.totals, event);
+  doc.updatedAt = Date.now();
+  return doc;
+}
+
+/** Structural rollup store — Firestore in production, in-memory in tests. */
+export interface RollupStore {
+  get(accountId: string, period: string): Promise<RollupDoc | null>;
+  set(doc: RollupDoc): Promise<void>;
+}
+
+/** $0 in-memory rollup store for the fold unit tests. */
+export class InMemoryRollupStore implements RollupStore {
+  private readonly byKey = new Map<string, RollupDoc>();
+  private k(accountId: string, period: string): string {
+    return `${accountId}/${period}`;
+  }
+  async get(accountId: string, period: string): Promise<RollupDoc | null> {
+    return this.byKey.get(this.k(accountId, period)) ?? null;
+  }
+  async set(doc: RollupDoc): Promise<void> {
+    this.byKey.set(this.k(doc.accountId, doc.period), doc);
+  }
+}
+
+/**
+ * Read-fold-write one event into usage_rollups. In production this runs inside a Firestore
+ * transaction (the agentbbs-gcp `aggregateSysopReport` pattern) so concurrent events for the
+ * same account/period serialize correctly; the in-memory store models the same read→write.
+ */
+export async function aggregate(store: RollupStore, event: UsageEvent): Promise<RollupDoc> {
+  const accountId = event.accountId ?? UNATTRIBUTED;
+  const period = periodOf(event.ts);
+  const prev = await store.get(accountId, period);
+  const next = fold(prev, event);
+  await store.set(next);
+  return next;
 }

--- a/services/apicompletions/package-lock.json
+++ b/services/apicompletions/package-lock.json
@@ -1,0 +1,4134 @@
+{
+  "name": "@cognitum-one/apicompletions",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@cognitum-one/apicompletions",
+      "version": "0.0.1",
+      "dependencies": {
+        "express": "^4.21.0",
+        "node-fetch": "^3.3.2"
+      },
+      "devDependencies": {
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.11.0",
+        "@types/supertest": "^6.0.2",
+        "@vitest/coverage-v8": "^2.0.0",
+        "supertest": "^7.0.0",
+        "tsx": "^4.7.0",
+        "typescript": "^5.4.0",
+        "vitest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookiejar": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
+      "integrity": "sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/methods": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/methods/-/methods-1.1.4.tgz",
+      "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/superagent": {
+      "version": "8.1.10",
+      "resolved": "https://registry.npmjs.org/@types/superagent/-/superagent-8.1.10.tgz",
+      "integrity": "sha512-nbt4IWXABhW0jGmmpRzCFNlbmwCTzZ2gTUsNIr+X+ItdqPms+PAJZbWsNzpS2USqXjcoNLQcO6nXo60zcPQiIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookiejar": "^2.1.5",
+        "@types/methods": "^1.1.4",
+        "@types/node": "*",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/@types/supertest": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-6.0.3.tgz",
+      "integrity": "sha512-8WzXq62EXFhJ7QsH3Ocb/iKQ/Ty9ZVWnVzoTKc9tyyFRRF3a74Tk2+TLFgaFFw364Ere+npzHKEJ6ga2LzIL7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/methods": "^1.1.4",
+        "@types/superagent": "^8.1.0"
+      }
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/services/apicompletions/package.json
+++ b/services/apicompletions/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@cognitum-one/apicompletions",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Cognitum Fugu (ADR-203) — OpenAI-compatible, metered, tiered /v1/chat/completions Cloud Run service behind api.cognitum.one. TS/Node sibling of @cognitum-one/api-gateway.",
+  "main": "dist/index.js",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsx watch src/index.ts",
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "emulators": "docker compose -f docker-compose.emulators.yml up"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "node-fetch": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.11.0",
+    "@types/supertest": "^6.0.2",
+    "@vitest/coverage-v8": "^2.0.0",
+    "supertest": "^7.0.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  },
+  "comments": {
+    "deferred-deps": "Wired during Phase-1 implementation (kept out of the skeleton to keep install fast + green): firebase-admin (Firestore api_keys/usage_ledger), @google-cloud/pubsub (completions-usage), js-tiktoken + per-family tokenizers (§5.1 progressive billing floor). @midstream/wasm is a FUTURE optionalDependency (404 on npm today — §3.5) loaded via the dynamic-import firewall in src/midstream/firewall.ts, never declared as a hard dep."
+  }
+}

--- a/services/apicompletions/src/anthropic/sse.ts
+++ b/services/apicompletions/src/anthropic/sse.ts
@@ -1,0 +1,87 @@
+// Anthropic SSE event synthesis (/v1/messages streaming). Pure builders that emit the
+// Anthropic event-stream frames from ANY backend — including the non-Anthropic MockProvider /
+// deepseek / glm — so a real Anthropic SDK streaming loop closes cleanly. The full sequence is:
+//
+//   message_start → content_block_start → ping
+//     → content_block_delta(text_delta) × N
+//   → content_block_stop → message_delta(stop_reason, output_tokens) → message_stop
+//
+// Each frame is `event: <name>\n data: <json>\n\n` (the Anthropic wire format). Builders return
+// the raw frame string so the sequence is unit-testable without an HTTP socket.
+import type { XCognitum } from '../types/openai';
+
+function frame(event: string, data: Record<string, unknown>): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/** message_start — opens the message; usage.output_tokens starts at 0, input_tokens is known. */
+export function messageStartEvent(args: {
+  id: string;
+  model: string;
+  inputTokens: number;
+}): string {
+  return frame('message_start', {
+    type: 'message_start',
+    message: {
+      id: args.id,
+      type: 'message',
+      role: 'assistant',
+      model: args.model, // HONESTY GUARD — real resolved model
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: args.inputTokens, output_tokens: 0 },
+    },
+  });
+}
+
+/** content_block_start — opens the single text block (index 0). */
+export function contentBlockStartEvent(): string {
+  return frame('content_block_start', {
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'text', text: '' },
+  });
+}
+
+/** ping — Anthropic emits at least one ping early in the stream; SDKs tolerate any number. */
+export function pingEvent(): string {
+  return frame('ping', { type: 'ping' });
+}
+
+/** content_block_delta — one text_delta chunk. */
+export function contentBlockDeltaEvent(text: string): string {
+  return frame('content_block_delta', {
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'text_delta', text },
+  });
+}
+
+/** content_block_stop — closes the text block. */
+export function contentBlockStopEvent(): string {
+  return frame('content_block_stop', { type: 'content_block_stop', index: 0 });
+}
+
+/**
+ * message_delta — carries the terminal stop_reason and the cumulative output_tokens. The
+ * Cognitum routing block rides along here (resolved_model / resolved_tier / price) so a
+ * streaming caller still sees the honest resolution without a custom trailer.
+ */
+export function messageDeltaEvent(args: {
+  stopReason: string;
+  outputTokens: number;
+  xCognitum?: XCognitum;
+}): string {
+  return frame('message_delta', {
+    type: 'message_delta',
+    delta: { stop_reason: args.stopReason, stop_sequence: null },
+    usage: { output_tokens: args.outputTokens },
+    ...(args.xCognitum ? { x_cognitum: args.xCognitum } : {}),
+  });
+}
+
+/** message_stop — terminates the stream (the Anthropic analog of OpenAI's [DONE]). */
+export function messageStopEvent(): string {
+  return frame('message_stop', { type: 'message_stop' });
+}

--- a/services/apicompletions/src/anthropic/translate.ts
+++ b/services/apicompletions/src/anthropic/translate.ts
@@ -1,0 +1,92 @@
+// Anthropic ↔ canonical translation adapter (/v1/messages). Pure functions, unit-testable:
+//   anthropicToCanonical : Anthropic request → the canonical ChatCompletionRequest the
+//                          existing tier/route/meter pipeline already understands.
+//   mapModelToDial       : opus*→cognitum-high, sonnet*→cognitum-mid, haiku*→cognitum-low,
+//                          cognitum-* dials pass through, anything else → cognitum-auto. The
+//                          min/max_tier + fail_fast/best_effort controls (X-Cognitum-* headers
+//                          merged onto the canonical body) are honored by resolveTier as usual.
+//   buildAnthropicResponse : canonical outcome → the Anthropic message shape, with the REAL
+//                          resolved model in the `model` field (the honesty guard).
+import type { ChatCompletionRequest, ChatMessage, Usage, XCognitum } from '../types/openai';
+import type {
+  AnthropicContent,
+  AnthropicMessageResponse,
+  AnthropicMessagesRequest,
+} from './types';
+
+/** Flatten Anthropic content (string or block array) to plain text — text blocks only. */
+export function extractText(content: AnthropicContent): string {
+  if (typeof content === 'string') return content;
+  return content
+    .filter((b) => b && b.type === 'text' && typeof b.text === 'string')
+    .map((b) => b.text as string)
+    .join('');
+}
+
+/**
+ * Map an Anthropic (or cognitum-*) model id to the Cognitum routing dial. The Claude family
+ * names map to tiers by capability (opus→high, sonnet→mid, haiku→low); a cognitum-* dial is
+ * passed through verbatim (so a client can opt into cognitum-auto/low/mid/high explicitly);
+ * an unrecognized id falls back to cognitum-auto (difficulty routing + the honesty guard).
+ */
+export function mapModelToDial(model: string): string {
+  const m = model.toLowerCase();
+  if (/^cognitum-/.test(m)) return model; // explicit cognitum dial — pass through
+  if (/opus/.test(m)) return 'cognitum-high';
+  if (/sonnet/.test(m)) return 'cognitum-mid';
+  if (/haiku/.test(m)) return 'cognitum-low';
+  return 'cognitum-auto';
+}
+
+/** Anthropic Messages request → the canonical ChatCompletionRequest. */
+export function anthropicToCanonical(req: AnthropicMessagesRequest): ChatCompletionRequest {
+  const messages: ChatMessage[] = [];
+  if (req.system !== undefined) {
+    const sys = extractText(req.system);
+    if (sys.length > 0) messages.push({ role: 'system', content: sys });
+  }
+  for (const m of req.messages) {
+    messages.push({ role: m.role, content: extractText(m.content) });
+  }
+  return {
+    model: mapModelToDial(req.model),
+    messages,
+    max_tokens: req.max_tokens,
+    temperature: req.temperature,
+    top_p: req.top_p,
+    stream: req.stream,
+    stop: req.stop_sequences,
+  };
+}
+
+/**
+ * Map an OpenAI-style finish_reason to an Anthropic stop_reason. `length`→`max_tokens`,
+ * everything that is a clean stop (including `content_filter`, `stop`, or an absent reason)
+ * → `end_turn`. `stop_sequence` is reserved for a future stop-sequence match.
+ */
+export function mapStopReason(finish: string | null | undefined): string {
+  if (finish === 'length') return 'max_tokens';
+  return 'end_turn';
+}
+
+/** Build the non-streaming Anthropic message response (model = REAL resolved model). */
+export function buildAnthropicResponse(args: {
+  requestId: string;
+  resolvedModel: string;
+  text: string;
+  usage: Usage;
+  stopReason: string;
+  xCognitum: XCognitum;
+}): AnthropicMessageResponse {
+  return {
+    id: `msg_${args.requestId}`,
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text: args.text }],
+    model: args.resolvedModel, // HONESTY GUARD — surface the real model, never the Claude alias
+    stop_reason: args.stopReason,
+    stop_sequence: null,
+    usage: { input_tokens: args.usage.prompt_tokens, output_tokens: args.usage.completion_tokens },
+    x_cognitum: args.xCognitum,
+  };
+}

--- a/services/apicompletions/src/anthropic/types.ts
+++ b/services/apicompletions/src/anthropic/types.ts
@@ -1,0 +1,55 @@
+// Anthropic Messages API wire types (/v1/messages). The subset Cognitum Fugu accepts +
+// emits — text content only (tool_use / images are accepted-and-ignored at the canonical
+// boundary in v1). Mirrors the public Anthropic Messages contract closely enough that an
+// off-the-shelf Anthropic SDK can target this endpoint, while the response model field always
+// carries the REAL resolved model (the honesty guard — never misrepresented as Claude).
+import type { XCognitum } from '../types/openai';
+
+/** An Anthropic text content block. */
+export interface AnthropicTextBlock {
+  type: 'text';
+  text: string;
+}
+
+/** Anthropic content is a bare string OR an array of typed blocks (we extract text blocks). */
+export type AnthropicContent = string | Array<{ type: string; text?: string; [k: string]: unknown }>;
+
+export interface AnthropicMessageParam {
+  role: 'user' | 'assistant';
+  content: AnthropicContent;
+}
+
+/** POST /v1/messages request body. `max_tokens` is REQUIRED by the Anthropic contract. */
+export interface AnthropicMessagesRequest {
+  model: string;
+  max_tokens: number;
+  messages: AnthropicMessageParam[];
+  system?: AnthropicContent;
+  stream?: boolean;
+  temperature?: number;
+  top_p?: number;
+  stop_sequences?: string[];
+  metadata?: unknown;
+  tools?: unknown[];
+  tool_choice?: unknown;
+}
+
+export interface AnthropicUsage {
+  input_tokens: number;
+  output_tokens: number;
+}
+
+/** Non-streaming /v1/messages response. */
+export interface AnthropicMessageResponse {
+  id: string;
+  type: 'message';
+  role: 'assistant';
+  content: AnthropicTextBlock[];
+  /** HONESTY GUARD — the REAL resolved model that served, never the requested Claude alias. */
+  model: string;
+  stop_reason: string | null;
+  stop_sequence: string | null;
+  usage: AnthropicUsage;
+  /** Cognitum routing transparency (resolved_model / resolved_tier surfaced honestly). */
+  x_cognitum?: XCognitum;
+}

--- a/services/apicompletions/src/auth/apiKey.ts
+++ b/services/apicompletions/src/auth/apiKey.ts
@@ -66,10 +66,17 @@ export class InMemoryKeyStore implements KeyStore {
   }
 }
 
-/** Result of an auth attempt — success carries the key doc, failure the wire error. */
+/**
+ * Result of an auth attempt — success carries the key doc, failure the wire error.
+ * On failure the wire `code`/`error` are deliberately OPAQUE (§6, sec-review): malformed,
+ * unknown, inactive and expired keys all collapse to a single `invalid_api_key` /
+ * 'Invalid API key.' so a caller cannot enumerate valid-but-disabled keys. The granular
+ * reason is preserved in `logCode`/`logReason` for SERVER-SIDE logs only (never sent to
+ * the client).
+ */
 export type AuthOutcome =
   | { ok: true; key: ApiKeyDoc; rawPrefix: string }
-  | { ok: false; status: number; code: string; error: string };
+  | { ok: false; status: number; code: string; error: string; logCode?: string; logReason?: string };
 
 /**
  * Extract the raw cog_ key from the request headers.
@@ -100,18 +107,28 @@ export async function verifyApiKey(
   if (!rawKey) {
     return { ok: false, status: 401, code: 'missing_api_key', error: 'Missing API key. Provide X-API-Key or Authorization: Bearer.' };
   }
+  // Opaque external response for every "this key won't authenticate" case — the granular
+  // reason rides along in logCode/logReason for server logs only (anti-enumeration, §6).
+  const invalid = (logCode: string, logReason: string): AuthOutcome => ({
+    ok: false,
+    status: 401,
+    code: 'invalid_api_key',
+    error: 'Invalid API key.',
+    logCode,
+    logReason,
+  });
   if (!isValidKeyFormat(rawKey)) {
-    return { ok: false, status: 401, code: 'invalid_api_key', error: 'Malformed API key.' };
+    return invalid('malformed', 'Malformed API key.');
   }
   const doc = await store.findByHash(hashKey(rawKey));
   if (!doc) {
-    return { ok: false, status: 401, code: 'invalid_api_key', error: 'Unknown API key.' };
+    return invalid('unknown_key', 'Unknown API key.');
   }
   if (!doc.active) {
-    return { ok: false, status: 401, code: 'key_inactive', error: 'API key is inactive.' };
+    return invalid('key_inactive', 'API key is inactive.');
   }
   if (doc.expiresAt && doc.expiresAt.getTime() <= Date.now()) {
-    return { ok: false, status: 401, code: 'key_expired', error: 'API key has expired.' };
+    return invalid('key_expired', 'API key has expired.');
   }
   return { ok: true, key: doc, rawPrefix: keyPrefix(rawKey) };
 }

--- a/services/apicompletions/src/auth/apiKey.ts
+++ b/services/apicompletions/src/auth/apiKey.ts
@@ -1,12 +1,14 @@
 // API-key auth — the REAL cognitum.one cog_ scheme (ADR-203 §6).
 // Identical to @cognitum-one/api-gateway public-api.ts verifyApiKey():
 // read X-API-Key / Authorization: Bearer cog_… → SHA-256 → Firestore api_keys
-// lookup by hash → check active, expiresAt, permissions[]. Server-side only.
+// lookup by hash → check active, expiresAt, permissions[]. Server-side only;
+// the plaintext key is NEVER logged (only the 12-char prefix, §6 logging contract).
+import { createHash } from 'crypto';
 import type { Tier } from '../types/openai';
 
 export interface ApiKeyDoc {
-  key: string;        // SHA-256 hash of the cog_ key
-  prefix: string;     // first 12 chars (cog_XXXXXXXX) for logs/dashboard
+  key: string; // SHA-256 hash (hex) of the cog_ key — indexed field in api_keys
+  prefix: string; // first 12 chars (cog_XXXXXXXX) for logs/dashboard
   permissions: string[];
   rateLimit: number;
   active: boolean;
@@ -21,9 +23,97 @@ export const COMPLETION_SCOPES = {
   high: 'completions:high',
 } as const satisfies Record<Tier, string>;
 
-/** TODO(impl): SHA-256 the header value, Firestore api_keys lookup, expiry/active check. */
-export async function verifyApiKey(_apiKeyHeader: string | undefined): Promise<ApiKeyDoc | null> {
-  throw new Error('not implemented: verifyApiKey (ADR-203 §6)');
+/** cog_ + 64 lowercase/uppercase hex chars (256-bit, crypto.randomBytes(32)). */
+const KEY_RE = /^cog_[0-9a-fA-F]{64}$/;
+
+export function isValidKeyFormat(raw: string): boolean {
+  return KEY_RE.test(raw);
+}
+
+/** SHA-256 hex of the raw key — the value stored (and indexed) in api_keys.key. */
+export function hashKey(raw: string): string {
+  return createHash('sha256').update(raw).digest('hex');
+}
+
+/** First 12 chars of the plaintext key — the only key material ever logged. */
+export function keyPrefix(raw: string): string {
+  return raw.slice(0, 12);
+}
+
+/**
+ * The key lookup backend. Production binds this to a Firestore `api_keys`
+ * lookup-by-hash (firebase-admin, deferred to the metering phase); tests and the
+ * emulator-first path use {@link InMemoryKeyStore} so the whole auth → tier →
+ * route loop runs at $0 with no GCP SDK.
+ */
+export interface KeyStore {
+  findByHash(hash: string): Promise<ApiKeyDoc | null>;
+}
+
+/** $0 emulator-first / test key store. Seed with raw cog_ keys; it hashes them. */
+export class InMemoryKeyStore implements KeyStore {
+  private readonly byHash = new Map<string, ApiKeyDoc>();
+
+  /** Register a raw cog_ key with its doc (key + prefix are derived). */
+  add(rawKey: string, doc: Omit<ApiKeyDoc, 'key' | 'prefix'>): ApiKeyDoc {
+    const full: ApiKeyDoc = { ...doc, key: hashKey(rawKey), prefix: keyPrefix(rawKey) };
+    this.byHash.set(full.key, full);
+    return full;
+  }
+
+  async findByHash(hash: string): Promise<ApiKeyDoc | null> {
+    return this.byHash.get(hash) ?? null;
+  }
+}
+
+/** Result of an auth attempt — success carries the key doc, failure the wire error. */
+export type AuthOutcome =
+  | { ok: true; key: ApiKeyDoc; rawPrefix: string }
+  | { ok: false; status: number; code: string; error: string };
+
+/**
+ * Extract the raw cog_ key from the request headers.
+ * `X-API-Key: cog_…` is preferred; `Authorization: Bearer cog_…` is the fallback
+ * (matching the production header contract, §6).
+ */
+export function extractApiKey(headers: Record<string, unknown>): string | undefined {
+  const direct = headers['x-api-key'];
+  if (typeof direct === 'string' && direct.length > 0) return direct.trim();
+  const auth = headers['authorization'];
+  if (typeof auth === 'string') {
+    const m = /^Bearer\s+(.+)$/i.exec(auth.trim());
+    if (m) return m[1].trim();
+  }
+  return undefined;
+}
+
+/**
+ * Verify a raw cog_ key against the store (ADR-203 §6 validation flow):
+ * format check → SHA-256 → lookup → active / expiresAt. Scope (permissions[])
+ * is checked later, at tier resolution, so a scope miss can return a tier-aware
+ * 403 rather than a generic one. Never logs the plaintext key.
+ */
+export async function verifyApiKey(
+  rawKey: string | undefined,
+  store: KeyStore,
+): Promise<AuthOutcome> {
+  if (!rawKey) {
+    return { ok: false, status: 401, code: 'missing_api_key', error: 'Missing API key. Provide X-API-Key or Authorization: Bearer.' };
+  }
+  if (!isValidKeyFormat(rawKey)) {
+    return { ok: false, status: 401, code: 'invalid_api_key', error: 'Malformed API key.' };
+  }
+  const doc = await store.findByHash(hashKey(rawKey));
+  if (!doc) {
+    return { ok: false, status: 401, code: 'invalid_api_key', error: 'Unknown API key.' };
+  }
+  if (!doc.active) {
+    return { ok: false, status: 401, code: 'key_inactive', error: 'API key is inactive.' };
+  }
+  if (doc.expiresAt && doc.expiresAt.getTime() <= Date.now()) {
+    return { ok: false, status: 401, code: 'key_expired', error: 'API key has expired.' };
+  }
+  return { ok: true, key: doc, rawPrefix: keyPrefix(rawKey) };
 }
 
 /** Highest tier the key is scoped for (caps auto-mode escalation, §6 item 2). */

--- a/services/apicompletions/src/auth/apiKey.ts
+++ b/services/apicompletions/src/auth/apiKey.ts
@@ -1,0 +1,39 @@
+// API-key auth — the REAL cognitum.one cog_ scheme (ADR-203 §6).
+// Identical to @cognitum-one/api-gateway public-api.ts verifyApiKey():
+// read X-API-Key / Authorization: Bearer cog_… → SHA-256 → Firestore api_keys
+// lookup by hash → check active, expiresAt, permissions[]. Server-side only.
+import type { Tier } from '../types/openai';
+
+export interface ApiKeyDoc {
+  key: string;        // SHA-256 hash of the cog_ key
+  prefix: string;     // first 12 chars (cog_XXXXXXXX) for logs/dashboard
+  permissions: string[];
+  rateLimit: number;
+  active: boolean;
+  expiresAt: Date | null;
+  /** §6 integration dependency — needed for usage_rollups attribution. */
+  accountId?: string;
+}
+
+export const COMPLETION_SCOPES = {
+  low: 'completions:low',
+  mid: 'completions:mid',
+  high: 'completions:high',
+} as const satisfies Record<Tier, string>;
+
+/** TODO(impl): SHA-256 the header value, Firestore api_keys lookup, expiry/active check. */
+export async function verifyApiKey(_apiKeyHeader: string | undefined): Promise<ApiKeyDoc | null> {
+  throw new Error('not implemented: verifyApiKey (ADR-203 §6)');
+}
+
+/** Highest tier the key is scoped for (caps auto-mode escalation, §6 item 2). */
+export function highestHeldTier(doc: ApiKeyDoc): Tier | null {
+  if (doc.permissions.includes(COMPLETION_SCOPES.high)) return 'high';
+  if (doc.permissions.includes(COMPLETION_SCOPES.mid)) return 'mid';
+  if (doc.permissions.includes(COMPLETION_SCOPES.low)) return 'low';
+  return null;
+}
+
+export function holdsTier(doc: ApiKeyDoc, tier: Tier): boolean {
+  return doc.permissions.includes(COMPLETION_SCOPES[tier]);
+}

--- a/services/apicompletions/src/budget/estimate.ts
+++ b/services/apicompletions/src/budget/estimate.ts
@@ -1,0 +1,37 @@
+// Worst-case reservation estimate (ADR-204 rev-2 §5.2). The RESERVE step reserves the
+// WORST-CASE cost block at the CEILING tier (the highest tier escalation can reach) so a
+// request is never admitted that we could not afford at its worst case:
+//
+//   estimateUsd = promptTokens · Rate_In[ceilingTier] + maxTokens · Rate_Out[ceilingTier]
+//
+// The prompt is known up front; maxTokens is the worst-case output. Over-reservation is
+// RELEASED at COMMIT (the estimate − actual gap returns to headroom), so it only transiently
+// reduces available budget — the conservative direction.
+import type { ChatMessage, Tier } from '../types/openai';
+import type { Config } from '../config';
+import { estimateTokens } from '../metering/tokenizer';
+
+/** Family-correct prompt-token floor for the model that would serve at the ceiling tier. */
+export function promptTokenFloor(config: Config, ceilingTier: Tier, messages: ChatMessage[]): number {
+  const model = config.tierPools[ceilingTier].models[0];
+  return messages.reduce((n, m) => n + estimateTokens(model, m.content ?? ''), 0);
+}
+
+/** Worst-case estimate at the ceiling tier — never under-reserves (§5.2). */
+export function worstCaseEstimateUsd(
+  config: Config,
+  ceilingTier: Tier,
+  promptTokens: number,
+  maxOutputTokens: number,
+): number {
+  const pool = config.tierPools[ceilingTier];
+  return (
+    (promptTokens * pool.rateInPer1M) / 1_000_000 +
+    (maxOutputTokens * pool.rateOutPer1M) / 1_000_000
+  );
+}
+
+/** Resolve the worst-case output bound: the request's max_tokens, else the config ceiling. */
+export function maxOutputTokens(config: Config, requested: number | undefined): number {
+  return requested && requested > 0 ? requested : config.budget.defaultMaxOutputTokens;
+}

--- a/services/apicompletions/src/budget/firestore.ts
+++ b/services/apicompletions/src/budget/firestore.ts
@@ -1,0 +1,149 @@
+// Reserve-and-Commit budget tracker — production Firestore binding (ADR-204 rev-2 §5.2/§5.5).
+//
+// Runs the SAME RESERVE/COMMIT logic as InMemoryBudgetTracker, but inside
+// `firestore.runTransaction` so the deny boundary is atomic (an overspend is impossible). It is
+// structurally typed against {@link FirestoreLike} (no hard firebase-admin import — same deferred-
+// dep posture as FirestoreLedgerStore) so the standalone build stays green; the production
+// binding is `new FirestoreBudgetTracker(admin.firestore(), config)`.
+//
+// Collections (top-level, per the ADR-204 §5.2 data model):
+//   subscriptions/{accountId}                 — account rollup (read-hot)
+//   agents/{accountId}__{agentId}_{shard}     — per-agent SHARDED tracker (txn unit; account-
+//                                               namespaced so the same agentId across accounts
+//                                               cannot collide on one doc)
+//   reservations/{resId}                      — reservation lease (carries accountId/agentId/shard
+//                                               so COMMIT resolves the shard doc from resId alone)
+//
+// RESERVE reads exactly TWO single docs (account + shard) — never scans `reservations` (§5.2 fix 2).
+import type { Config } from '../config';
+import type { FirestoreLike, TransactionLike } from '../firestore/client';
+import type {
+  AccountDoc,
+  AgentShardDoc,
+  BudgetTracker,
+  ReservationDoc,
+  ReserveInput,
+  ReserveOutcome,
+} from './types';
+
+function agentDocId(accountId: string, agentId: string, shard: number): string {
+  return `${accountId}__${agentId}_${shard}`;
+}
+
+export class FirestoreBudgetTracker implements BudgetTracker {
+  constructor(
+    private readonly db: FirestoreLike,
+    private readonly config: Config,
+  ) {}
+
+  async reserve(input: ReserveInput): Promise<ReserveOutcome> {
+    const acctRef = this.db.collection('subscriptions').doc(input.accountId);
+
+    return this.db.runTransaction(async (txn: TransactionLike): Promise<ReserveOutcome> => {
+      const acctSnap = await txn.get(acctRef);
+      if (!acctSnap.exists) return { admit: true }; // unmetered account → transparent
+      const acct = acctSnap.data() as unknown as AccountDoc;
+
+      // (1) account-wide guard — DECOUPLED, eventually-consistent flag (rev-2 fix 2). No scan.
+      if (acct.status !== 'active' || acct.headroomExhausted) {
+        return {
+          admit: false,
+          status: 402,
+          code: 'account_budget_exhausted',
+          error: 'Account budget exhausted for the current period.',
+        };
+      }
+
+      const K = acct.shardCount ?? this.config.budget.shardCount;
+      const shard = input.shard ?? Math.floor(Math.random() * K);
+      const shardRef = this.db.collection('agents').doc(agentDocId(input.accountId, input.agentId, shard));
+      const shardSnap = await txn.get(shardRef);
+      const now = Date.now();
+      const perShardCapUsd = acct.perAgentCapUsd / K;
+      const cur: AgentShardDoc = shardSnap.exists
+        ? (shardSnap.data() as unknown as AgentShardDoc)
+        : { reservedUsd: 0, committedUsd: 0, perShardCapUsd, invokeCount: 0, windowStart: now };
+
+      // Roll the per-shard loop-rate window forward if it has elapsed.
+      let invokeCount = cur.invokeCount;
+      let windowStart = cur.windowStart;
+      if (now - windowStart > this.config.budget.loopWindowMs) {
+        windowStart = now;
+        invokeCount = 0;
+      }
+      // (2a) per-shard loop-rate cap = maxLoopRate / K (cross-ref ADR-203 §3.5 terminate).
+      const perShardLoopCap = Math.max(1, Math.ceil(this.config.budget.maxLoopRatePerMin / K));
+      if (invokeCount >= perShardLoopCap) {
+        return {
+          admit: false,
+          status: 429,
+          code: 'loop_detected',
+          error: 'Agent loop-rate cap exceeded — too many reservations in the window.',
+        };
+      }
+
+      // (2b) per-agent-SHARD runaway cap — the SYNCHRONOUS hard backstop (rev-2 fix 1).
+      const cap = cur.perShardCapUsd ?? perShardCapUsd;
+      if (cur.reservedUsd + cur.committedUsd + input.estimateUsd > cap) {
+        return {
+          admit: false,
+          status: 402,
+          code: 'agent_budget_exhausted',
+          error: 'Per-agent budget cap exhausted — this agent cannot run away.',
+        };
+      }
+
+      // (3) write the shard counter + the reservation lease (the WAL-frame write).
+      txn.set(
+        shardRef,
+        {
+          reservedUsd: cur.reservedUsd + input.estimateUsd,
+          committedUsd: cur.committedUsd,
+          perShardCapUsd: cap,
+          invokeCount: invokeCount + 1,
+          windowStart,
+        },
+        { merge: true },
+      );
+      const lease =
+        input.reqType === 'streaming'
+          ? this.config.budget.leaseStreamMs
+          : this.config.budget.leaseSyncMs;
+      const res: ReservationDoc = {
+        accountId: input.accountId,
+        agentId: input.agentId,
+        shard,
+        amountUsd: input.estimateUsd,
+        ceilingTier: input.ceilingTier,
+        createdAt: now,
+        expiresAt: now + lease,
+        state: 'active',
+      };
+      txn.set(this.db.collection('reservations').doc(input.resId), { ...res });
+
+      const fairUseWarning = acct.committedUsd + acct.reservedUsd > acct.servingBudgetUsd;
+      return { admit: true, resId: input.resId, shard, fairUseWarning };
+    });
+  }
+
+  async commit(resId: string, actualUsd: number): Promise<void> {
+    const resRef = this.db.collection('reservations').doc(resId);
+    await this.db.runTransaction(async (txn: TransactionLike): Promise<void> => {
+      const resSnap = await txn.get(resRef);
+      if (!resSnap.exists) return; // unmetered / nothing reserved → no-op
+      const res = resSnap.data() as unknown as ReservationDoc;
+      if (res.state === 'committed') return; // replay / already-committed → no double-charge
+
+      const shardRef = this.db.collection('agents').doc(agentDocId(res.accountId, res.agentId, res.shard));
+      const shardSnap = await txn.get(shardRef);
+      if (shardSnap.exists) {
+        const cur = shardSnap.data() as unknown as AgentShardDoc;
+        txn.update(shardRef, {
+          reservedUsd: Math.max(0, cur.reservedUsd - res.amountUsd), // release the lease
+          committedUsd: cur.committedUsd + actualUsd, // record what was really spent
+        });
+      }
+      txn.update(resRef, { state: 'committed', actualUsd });
+    });
+  }
+}

--- a/services/apicompletions/src/budget/tracker.ts
+++ b/services/apicompletions/src/budget/tracker.ts
@@ -1,0 +1,253 @@
+// Reserve-and-Commit budget tracker — $0 in-memory implementation (ADR-204 rev-2 §5.2/§5.5).
+//
+// This is the emulator-first / test binding (same DI posture as InMemoryKeyStore /
+// InMemoryLedgerStore): it models the Firestore RESERVE/COMMIT transactions and the
+// aggregateUsage reconciler in memory so the whole reserve→invoke→commit loop runs offline at
+// $0. Production swaps in FirestoreBudgetTracker (src/budget/firestore.ts), which runs the SAME
+// logic inside `firestore.runTransaction`.
+//
+// Key invariants (mirrored exactly by the Firestore binding):
+//   • RESERVE reads ONLY the account doc + ONE agent-shard doc — never scans reservations (§5.2 fix 2).
+//   • The per-agent-SHARD cap is the SYNCHRONOUS hard backstop; `headroomExhausted` is the
+//     DECOUPLED, eventually-consistent account guard flipped by the reconciler (§5.2 fix 2).
+//   • A reservation lease holds headroom until its LOGICAL `expiresAt`; the reconciler reclaims
+//     it at expiry — NOT at native-TTL GC (§5.5). This is the crash-recovery path.
+//   • COMMIT is IDEMPOTENT on resId (late / replay COMMIT never double-charges, §5.5).
+import type { Config } from '../config';
+import type {
+  AccountDoc,
+  AccountStatus,
+  AgentShardDoc,
+  BudgetTracker,
+  ReservationDoc,
+  ReserveInput,
+  ReserveOutcome,
+} from './types';
+
+/** Account seed — caps are required; the rest default to a fresh, active, unexhausted account. */
+export interface AccountSeed {
+  servingBudgetUsd: number;
+  hardCapUsd: number;
+  perAgentCapUsd: number;
+  shardCount?: number;
+  committedUsd?: number;
+  reservedUsd?: number;
+  headroomExhausted?: boolean;
+  status?: AccountStatus;
+}
+
+export interface InMemoryBudgetOptions {
+  /** Injectable clock (ms) — lets tests advance past a lease `expiresAt` deterministically. */
+  now?: () => number;
+}
+
+function shardKey(accountId: string, agentId: string, shard: number): string {
+  return `${accountId}/${agentId}_${shard}`;
+}
+
+/**
+ * In-memory Reserve-and-Commit tracker. Unmetered by default: an account with no seeded
+ * subscription doc admits every request with no reservation (COMMIT is then a no-op), so the
+ * budget layer is transparent until an account opts in via {@link seedAccount}.
+ */
+export class InMemoryBudgetTracker implements BudgetTracker {
+  private readonly accounts = new Map<string, AccountDoc>();
+  private readonly shards = new Map<string, AgentShardDoc>();
+  private readonly reservations = new Map<string, ReservationDoc>();
+  private readonly now: () => number;
+
+  constructor(private readonly config: Config, opts: InMemoryBudgetOptions = {}) {
+    this.now = opts.now ?? Date.now;
+  }
+
+  /** Seed (or overwrite) the account budget doc — the opt-in to enforcement. */
+  seedAccount(accountId: string, seed: AccountSeed): AccountDoc {
+    const doc: AccountDoc = {
+      servingBudgetUsd: seed.servingBudgetUsd,
+      hardCapUsd: seed.hardCapUsd,
+      perAgentCapUsd: seed.perAgentCapUsd,
+      shardCount: seed.shardCount ?? this.config.budget.shardCount,
+      committedUsd: seed.committedUsd ?? 0,
+      reservedUsd: seed.reservedUsd ?? 0,
+      headroomExhausted: seed.headroomExhausted ?? false,
+      status: seed.status ?? 'active',
+    };
+    this.accounts.set(accountId, doc);
+    return doc;
+  }
+
+  getAccount(accountId: string): AccountDoc | undefined {
+    return this.accounts.get(accountId);
+  }
+  getShard(accountId: string, agentId: string, shard: number): AgentShardDoc | undefined {
+    return this.shards.get(shardKey(accountId, agentId, shard));
+  }
+  getReservation(resId: string): ReservationDoc | undefined {
+    return this.reservations.get(resId);
+  }
+
+  private shardFor(acct: AccountDoc, accountId: string, agentId: string, shard: number): AgentShardDoc {
+    const key = shardKey(accountId, agentId, shard);
+    let doc = this.shards.get(key);
+    if (!doc) {
+      doc = {
+        reservedUsd: 0,
+        committedUsd: 0,
+        perShardCapUsd: acct.perAgentCapUsd / acct.shardCount,
+        invokeCount: 0,
+        windowStart: this.now(),
+      };
+      this.shards.set(key, doc);
+    }
+    return doc;
+  }
+
+  /**
+   * RESERVE (atomic, pre-invoke) — the deny boundary (§5.2). Reads the account doc + ONE
+   * agent-shard doc only. Account guard is the decoupled `headroomExhausted`/`status` flag;
+   * the per-shard cap is the synchronous hard backstop; loop-rate is per shard.
+   */
+  async reserve(input: ReserveInput): Promise<ReserveOutcome> {
+    const acct = this.accounts.get(input.accountId);
+    if (!acct) return { admit: true }; // unmetered account → transparent (no reservation)
+
+    // (1) account-wide guard — DECOUPLED, eventually-consistent (rev-2 fix 2). NO subcollection scan.
+    if (acct.status !== 'active' || acct.headroomExhausted) {
+      return {
+        admit: false,
+        status: 402,
+        code: 'account_budget_exhausted',
+        error: 'Account budget exhausted for the current period.',
+      };
+    }
+
+    const K = acct.shardCount;
+    const shard = input.shard ?? Math.floor(Math.random() * K);
+    const shardDoc = this.shardFor(acct, input.accountId, input.agentId, shard);
+    const now = this.now();
+
+    // Roll the loop-rate window forward if it has elapsed.
+    if (now - shardDoc.windowStart > this.config.budget.loopWindowMs) {
+      shardDoc.windowStart = now;
+      shardDoc.invokeCount = 0;
+    }
+    // (2a) per-shard loop-rate cap = maxLoopRate / K (§5.2). Cross-refs ADR-203 §3.5 terminate.
+    const perShardLoopCap = Math.max(1, Math.ceil(this.config.budget.maxLoopRatePerMin / K));
+    if (shardDoc.invokeCount >= perShardLoopCap) {
+      return {
+        admit: false,
+        status: 429,
+        code: 'loop_detected',
+        error: 'Agent loop-rate cap exceeded — too many reservations in the window.',
+      };
+    }
+
+    // (2b) per-agent-SHARD runaway cap — the SYNCHRONOUS hard backstop (rev-2 fix 1).
+    if (shardDoc.reservedUsd + shardDoc.committedUsd + input.estimateUsd > shardDoc.perShardCapUsd) {
+      return {
+        admit: false,
+        status: 402,
+        code: 'agent_budget_exhausted',
+        error: 'Per-agent budget cap exhausted — this agent cannot run away.',
+      };
+    }
+
+    // (3) write the reservation lease (the WAL-frame write).
+    shardDoc.reservedUsd += input.estimateUsd;
+    shardDoc.invokeCount += 1;
+    const lease =
+      input.reqType === 'streaming'
+        ? this.config.budget.leaseStreamMs
+        : this.config.budget.leaseSyncMs;
+    const res: ReservationDoc = {
+      accountId: input.accountId,
+      agentId: input.agentId,
+      shard,
+      amountUsd: input.estimateUsd,
+      ceilingTier: input.ceilingTier,
+      createdAt: now,
+      expiresAt: now + lease,
+      state: 'active',
+    };
+    this.reservations.set(input.resId, res);
+
+    // SOFT cap is a warn, not a deny (§5.2): surfaced eventually-consistently by the rollup, but
+    // we also flag here when the rollup already knows the account is over the serving budget.
+    const fairUseWarning = acct.committedUsd + acct.reservedUsd > acct.servingBudgetUsd;
+    return { admit: true, resId: input.resId, shard, fairUseWarning };
+  }
+
+  /**
+   * COMMIT (atomic, post-invoke) — actual known (§5.2). Idempotent on resId: a replay or a
+   * late finish past the lease still books once without double-charging. Releases the lease
+   * estimate (even if it already lapsed) and records the actual on the shard.
+   */
+  async commit(resId: string, actualUsd: number): Promise<void> {
+    const res = this.reservations.get(resId);
+    if (!res) return; // unmetered / nothing reserved → no-op
+    if (res.state === 'committed') return; // replay / already-committed → no double-charge
+
+    const shardDoc = this.shards.get(shardKey(res.accountId, res.agentId, res.shard));
+    if (shardDoc) {
+      shardDoc.reservedUsd = Math.max(0, shardDoc.reservedUsd - res.amountUsd);
+      shardDoc.committedUsd += actualUsd;
+    }
+    res.state = 'committed';
+    res.actualUsd = actualUsd;
+  }
+
+  /**
+   * Reconciler — rides the aggregateUsage cadence (§5.5), NOT a separate cron. For an account:
+   *   1. recompute each shard's reservedUsd as Σ active leases WHERE expiresAt>now (excludes
+   *      lapsed leases → reclaims a crashed agent's headroom at lease expiry, the §5.5 path);
+   *   2. recompute committed+reserved and flip `headroomExhausted` on the account doc (§5.2);
+   *   3. mark lapsed leases `state:'expired'` (native TTL would later GC the row — cosmetic).
+   */
+  reconcile(accountId: string): void {
+    const acct = this.accounts.get(accountId);
+    if (!acct) return;
+    const now = this.now();
+
+    // Per-shard live reservation sum over non-expired active leases.
+    const reservedByShard = new Map<string, number>();
+    let totalReserved = 0;
+    for (const res of this.reservations.values()) {
+      if (res.accountId !== accountId || res.state !== 'active') continue;
+      if (res.expiresAt > now) {
+        const key = shardKey(res.accountId, res.agentId, res.shard);
+        reservedByShard.set(key, (reservedByShard.get(key) ?? 0) + res.amountUsd);
+        totalReserved += res.amountUsd;
+      } else {
+        res.state = 'expired'; // §5.5 — lapsed lease; row GC'd later by native TTL (cosmetic)
+      }
+    }
+
+    // Reset each of the account's shards to the recomputed active-lease sum (reclaims headroom).
+    const prefix = `${accountId}/`;
+    let totalCommitted = 0;
+    for (const [key, shardDoc] of this.shards) {
+      if (!key.startsWith(prefix)) continue;
+      shardDoc.reservedUsd = reservedByShard.get(key) ?? 0;
+      totalCommitted += shardDoc.committedUsd;
+    }
+
+    acct.committedUsd = totalCommitted;
+    acct.reservedUsd = totalReserved;
+    // §5.2 — the decoupled, eventually-consistent hot-path guard.
+    acct.headroomExhausted = totalCommitted + totalReserved >= acct.hardCapUsd;
+  }
+}
+
+/**
+ * A transparent tracker that admits everything and never reserves — the explicit "budget
+ * defense off" binding. (The default deps use {@link InMemoryBudgetTracker} with no seeded
+ * accounts, which is equivalently transparent but can be opted into per-account.)
+ */
+export class NoopBudgetTracker implements BudgetTracker {
+  async reserve(): Promise<ReserveOutcome> {
+    return { admit: true };
+  }
+  async commit(): Promise<void> {
+    /* no-op */
+  }
+}

--- a/services/apicompletions/src/budget/types.ts
+++ b/services/apicompletions/src/budget/types.ts
@@ -1,0 +1,102 @@
+// Reserve-and-Commit budget data model (ADR-204 rev-2 §5.2/§5.5).
+//
+// Three Firestore doc shapes:
+//   subscriptions/{accountId}                       — account rollup (read-hot, write-cold)
+//   subscriptions/{accountId}/agents/{agentId}_{s}  — per-agent SHARDED tracker (txn unit)
+//   subscriptions/{accountId}/reservations/{resId}  — reservation LEASE (WAL-frame analog)
+//
+// The account doc carries a DECOUPLED, eventually-consistent `headroomExhausted` flag (§5.2
+// fix 2) flipped by the async aggregateUsage rollup — the RESERVE txn reads it cheaply instead
+// of scanning the reservations subcollection. The per-agent-SHARD cap is the SYNCHRONOUS hard
+// backstop. A reservation lease carries a LOGICAL `expiresAt` the rollup RESPECTS (§5.5) so a
+// crashed agent's headroom is reclaimed at lease expiry — NOT at native-TTL GC.
+import type { Tier } from '../types/openai';
+
+export type AccountStatus = 'active' | 'throttled' | 'suspended';
+export type ReservationState = 'active' | 'committed' | 'expired';
+
+/** subscriptions/{accountId} — the account budget rollup (ADR-204 §5.2 data model). */
+export interface AccountDoc {
+  /** SOFT fair-use ceiling for the period (warn, not deny). */
+  servingBudgetUsd: number;
+  /** ABSOLUTE ceiling — committed+reserved beyond this flips `headroomExhausted`. */
+  hardCapUsd: number;
+  /** Per-agent / per-loop runaway cap; split across K shards as perShardCap = this / K. */
+  perAgentCapUsd: number;
+  /** K — number of shards the per-agent cap is spread across (§5.2 fix 1). */
+  shardCount: number;
+  /** Folded actuals (async, via the §5.1 Pub/Sub aggregateUsage fold). */
+  committedUsd: number;
+  /** Live reservation buffer = Σ active leases WHERE expiresAt>now (recomputed by the rollup). */
+  reservedUsd: number;
+  /** rev-2 fix 2: set by aggregateUsage when committed+reserved ≥ hardCap. The hot-path guard. */
+  headroomExhausted: boolean;
+  status: AccountStatus;
+}
+
+/** subscriptions/{accountId}/agents/{agentId}_{shard} — the per-agent SHARDED txn unit. */
+export interface AgentShardDoc {
+  /** Outstanding reservations on THIS shard not yet committed. */
+  reservedUsd: number;
+  /** Actuals committed on THIS shard. */
+  committedUsd: number;
+  /** perAgentCapUsd / K — the per-agent runaway cap split across K shards. */
+  perShardCapUsd: number;
+  /** Rolling-window invoke count → loop-rate detection (per shard). */
+  invokeCount: number;
+  /** Start of the current loop-rate window. */
+  windowStart: number;
+}
+
+/** subscriptions/{accountId}/reservations/{resId} — the reservation lease (§5.5). */
+export interface ReservationDoc {
+  accountId: string;
+  agentId: string;
+  shard: number;
+  /** Worst-case estimate at ceilingTier (the headroom this lease holds). */
+  amountUsd: number;
+  ceilingTier: Tier;
+  createdAt: number;
+  /** LOGICAL lease deadline the headroom rollup RESPECTS (§5.5) — not a delete timer. */
+  expiresAt: number;
+  state: ReservationState;
+  /** Set at COMMIT. */
+  actualUsd?: number;
+}
+
+/** Request class → lease window (§5.5): short for sync, long for streaming/agentic. */
+export type RequestType = 'sync' | 'streaming';
+
+export interface ReserveInput {
+  accountId: string;
+  agentId: string;
+  /** Ceiling tier escalation can reach — the worst-case estimate is priced here (§5.2). */
+  ceilingTier: Tier;
+  /** Worst-case estimateUsd = prompt·Rate_In[ceiling] + maxTokens·Rate_Out[ceiling]. */
+  estimateUsd: number;
+  reqType: RequestType;
+  /** Reservation id (one per request); ties COMMIT idempotency to the request. */
+  resId: string;
+  /** Explicit shard (tests / deterministic routing); else random/round-robin per §5.2. */
+  shard?: number;
+}
+
+/**
+ * RESERVE outcome. `admit:true` with no `resId` means the account is UNMETERED (no
+ * subscription doc) — the request proceeds and COMMIT is a no-op. A denial carries the
+ * ADR-204 wire code: 402 account/agent budget exhausted, 429 loop detected.
+ */
+export type ReserveOutcome =
+  | { admit: true; resId?: string; shard?: number; fairUseWarning?: boolean }
+  | { admit: false; status: number; code: string; error: string };
+
+/**
+ * The Reserve-and-Commit budget tracker (ADR-204 §5.2). RESERVE is the pre-invoke deny
+ * boundary (an overspend is impossible — no reservation, no invoke); COMMIT books the
+ * actual post-invoke and is IDEMPOTENT on resId.
+ */
+export interface BudgetTracker {
+  reserve(input: ReserveInput): Promise<ReserveOutcome>;
+  /** Release the estimate, record the actual. Idempotent on resId (late/replay COMMIT safe). */
+  commit(resId: string, actualUsd: number): Promise<void>;
+}

--- a/services/apicompletions/src/config/index.ts
+++ b/services/apicompletions/src/config/index.ts
@@ -1,0 +1,43 @@
+// Runtime configuration (ADR-203 §7). Emulator-first ($0) by default.
+import type { Tier } from '../types/openai';
+
+export interface TierPool {
+  /** Ordered model fallback chain within the tier (commit de512bd) — fails over WITHIN tier. */
+  models: string[];
+  rateLimitPerMin: number;
+  rateInPer1M: number;
+  rateOutPer1M: number;
+}
+
+export interface Config {
+  port: number;
+  projectId: string;
+  region: string;
+  /** Emulator hosts — when set, all GCP access goes to the local emulators ($0). */
+  firestoreEmulatorHost?: string;
+  pubsubEmulatorHost?: string;
+  usageTopic: string;
+  /** When true, route every request to the canned mock provider (no spend). */
+  useMockProvider: boolean;
+  /** Seed tier pools — production pools live in Firestore tier_config/{tier} (hot-reloadable). */
+  tierPools: Record<Tier, TierPool>;
+}
+
+// TODO(impl): hydrate from env + Firestore tier_config. Skeleton returns static defaults.
+export function loadConfig(): Config {
+  const env = process.env;
+  return {
+    port: Number(env.PORT ?? 8080),
+    projectId: env.GOOGLE_CLOUD_PROJECT ?? 'demo-project',
+    region: env.REGION ?? 'us-central1',
+    firestoreEmulatorHost: env.FIRESTORE_EMULATOR_HOST,
+    pubsubEmulatorHost: env.PUBSUB_EMULATOR_HOST,
+    usageTopic: env.USAGE_TOPIC ?? 'completions-usage',
+    useMockProvider: env.USE_MOCK_PROVIDER === 'true' || !env.OPENROUTER_API_KEY,
+    tierPools: {
+      low: { models: ['deepseek-v4-pro', 'glm-5.2'], rateLimitPerMin: 120, rateInPer1M: 0, rateOutPer1M: 0 },
+      mid: { models: ['gpt-5.5', 'gemini-3.1-pro'], rateLimitPerMin: 60, rateInPer1M: 0, rateOutPer1M: 0 },
+      high: { models: ['claude-opus-4.8', 'gpt-5.5'], rateLimitPerMin: 30, rateInPer1M: 0, rateOutPer1M: 0 },
+    },
+  };
+}

--- a/services/apicompletions/src/config/index.ts
+++ b/services/apicompletions/src/config/index.ts
@@ -9,6 +9,28 @@ export interface TierPool {
   rateOutPer1M: number;
 }
 
+/**
+ * Reserve-and-Commit budget defense knobs (ADR-204 rev-2 §5.2/§5.5). The per-agent runaway
+ * cap is split across K shards (perShardCap = perAgentCap / K) so a single agentId scaling to
+ * N parallel workers does not re-collapse onto one Firestore doc (§5.2 fix 1). Lease windows
+ * are per request TYPE (§5.5): short for a synchronous completion, long for a streaming /
+ * agentic request that legitimately runs to the step-cap.
+ */
+export interface BudgetConfig {
+  /** K — number of per-agent shards. perShardCap = perAgentCapUsd / K (§5.2). */
+  shardCount: number;
+  /** Worst-case output token bound when the request omits max_tokens (estimate ceiling). */
+  defaultMaxOutputTokens: number;
+  /** Logical lease for a synchronous completion (~60s, §5.5). */
+  leaseSyncMs: number;
+  /** Logical lease for a streaming / agentic request (~20min step-cap, §5.5). */
+  leaseStreamMs: number;
+  /** Per-agent loop-rate cap (reservations/min); the per-shard cap is this / K (§5.2). */
+  maxLoopRatePerMin: number;
+  /** Rolling window over which the loop-rate is measured. */
+  loopWindowMs: number;
+}
+
 export interface Config {
   port: number;
   projectId: string;
@@ -21,6 +43,8 @@ export interface Config {
   useMockProvider: boolean;
   /** Seed tier pools — production pools live in Firestore tier_config/{tier} (hot-reloadable). */
   tierPools: Record<Tier, TierPool>;
+  /** Reserve-and-Commit budget knobs (ADR-204 §5.2/§5.5). */
+  budget: BudgetConfig;
 }
 
 // TODO(impl): hydrate from env + Firestore tier_config. Skeleton returns static defaults.
@@ -40,6 +64,16 @@ export function loadConfig(): Config {
       low: { models: ['deepseek-v4-pro', 'glm-5.2'], rateLimitPerMin: 120, rateInPer1M: 0.1, rateOutPer1M: 0.3 },
       mid: { models: ['gpt-5.5', 'gemini-3.1-pro'], rateLimitPerMin: 60, rateInPer1M: 0.6, rateOutPer1M: 1.8 },
       high: { models: ['claude-opus-4.8', 'gpt-5.5'], rateLimitPerMin: 30, rateInPer1M: 2.5, rateOutPer1M: 7.5 },
+    },
+    // ADR-204 §5.2/§5.5 defaults. shardCount/caps are per-agent-class tuning levers; the
+    // lease windows are derived from the request-type timeouts (§5.5 — short sync, long stream).
+    budget: {
+      shardCount: Number(env.BUDGET_SHARD_COUNT ?? 4),
+      defaultMaxOutputTokens: Number(env.BUDGET_DEFAULT_MAX_OUTPUT_TOKENS ?? 4096),
+      leaseSyncMs: Number(env.BUDGET_LEASE_SYNC_MS ?? 60_000), // ~60s synchronous completion
+      leaseStreamMs: Number(env.BUDGET_LEASE_STREAM_MS ?? 1_200_000), // ~20min streaming/agentic
+      maxLoopRatePerMin: Number(env.BUDGET_MAX_LOOP_RATE_PER_MIN ?? 600),
+      loopWindowMs: Number(env.BUDGET_LOOP_WINDOW_MS ?? 60_000),
     },
   };
 }

--- a/services/apicompletions/src/config/index.ts
+++ b/services/apicompletions/src/config/index.ts
@@ -34,10 +34,12 @@ export function loadConfig(): Config {
     pubsubEmulatorHost: env.PUBSUB_EMULATOR_HOST,
     usageTopic: env.USAGE_TOPIC ?? 'completions-usage',
     useMockProvider: env.USE_MOCK_PROVIDER === 'true' || !env.OPENROUTER_API_KEY,
+    // Rates are ILLUSTRATIVE ($/1M tokens) — the shape (low ≪ mid < high) is fixed by the
+    // §4.1 DoE, the absolute numbers are a launch decision (§4.2). Asymmetric in/out per tier.
     tierPools: {
-      low: { models: ['deepseek-v4-pro', 'glm-5.2'], rateLimitPerMin: 120, rateInPer1M: 0, rateOutPer1M: 0 },
-      mid: { models: ['gpt-5.5', 'gemini-3.1-pro'], rateLimitPerMin: 60, rateInPer1M: 0, rateOutPer1M: 0 },
-      high: { models: ['claude-opus-4.8', 'gpt-5.5'], rateLimitPerMin: 30, rateInPer1M: 0, rateOutPer1M: 0 },
+      low: { models: ['deepseek-v4-pro', 'glm-5.2'], rateLimitPerMin: 120, rateInPer1M: 0.1, rateOutPer1M: 0.3 },
+      mid: { models: ['gpt-5.5', 'gemini-3.1-pro'], rateLimitPerMin: 60, rateInPer1M: 0.6, rateOutPer1M: 1.8 },
+      high: { models: ['claude-opus-4.8', 'gpt-5.5'], rateLimitPerMin: 30, rateInPer1M: 2.5, rateOutPer1M: 7.5 },
     },
   };
 }

--- a/services/apicompletions/src/core/http.ts
+++ b/services/apicompletions/src/core/http.ts
@@ -21,6 +21,31 @@ export function sendError(
   res.status(status).json(body);
 }
 
+/** The optional `Idempotency-Key` request header (§5.3). */
+export function idempotencyKeyOf(headers: Request['headers']): string | undefined {
+  const v = headers['idempotency-key'];
+  if (typeof v === 'string' && v.length > 0) return v;
+  if (Array.isArray(v) && v.length > 0) return v[0];
+  return undefined;
+}
+
+/**
+ * 429 rate-limit envelope (§5.3) — uniform error shape + the standard `Retry-After`
+ * header (whole seconds, rounded up from the limiter's ms hint).
+ */
+export function sendRateLimited(res: Response, requestId: string, retryAfterMs: number): void {
+  const seconds = Math.max(1, Math.ceil(retryAfterMs / 1000));
+  res.setHeader('Retry-After', String(seconds));
+  res.setHeader('X-Request-Id', requestId);
+  sendError(
+    res,
+    requestId,
+    429,
+    'rate_limit_exceeded',
+    `Rate limit exceeded for this API key + tier. Retry after ~${seconds}s.`,
+  );
+}
+
 function asTier(v: unknown): Tier | undefined {
   return v === 'low' || v === 'mid' || v === 'high' ? v : undefined;
 }

--- a/services/apicompletions/src/core/http.ts
+++ b/services/apicompletions/src/core/http.ts
@@ -3,6 +3,7 @@
 // as headers (mirroring the body fields); X-Cognitum-* response headers mirror x_cognitum.
 import { randomUUID } from 'crypto';
 import type { Request, Response } from 'express';
+import type { ApiKeyDoc } from '../auth/apiKey';
 import type { ChatCompletionRequest, EscalationStrategy, ErrorEnvelope, FallbackPolicy, Tier } from '../types/openai';
 
 export function requestIdOf(req: Request): string {
@@ -27,6 +28,18 @@ export function idempotencyKeyOf(headers: Request['headers']): string | undefine
   if (typeof v === 'string' && v.length > 0) return v;
   if (Array.isArray(v) && v.length > 0) return v[0];
   return undefined;
+}
+
+/**
+ * Namespace the client-chosen Idempotency-Key by the authenticated principal (§5.3,
+ * sec-review). The raw header is attacker-chosen, so keying the cache on it verbatim lets
+ * tenant B replay tenant A's cached completion (cross-tenant disclosure) AND skip
+ * rate-limit/metering (billing bypass). We compose `${keyHash}:${idemKey}` — the per-key
+ * SHA-256 hash (NOT the plaintext) — so the cache is strictly per API key and a lower-scope
+ * key can never read another key's cached output.
+ */
+export function idempotencyCacheKey(key: ApiKeyDoc, idemKey: string): string {
+  return `${key.key}:${idemKey}`;
 }
 
 /**

--- a/services/apicompletions/src/core/http.ts
+++ b/services/apicompletions/src/core/http.ts
@@ -1,0 +1,76 @@
+// Shared HTTP helpers for the OpenAI-compatible routes (ADR-203 §3.4, §6).
+// Uniform error envelope { error, code, requestId }; X-Cognitum-* routing controls accepted
+// as headers (mirroring the body fields); X-Cognitum-* response headers mirror x_cognitum.
+import { randomUUID } from 'crypto';
+import type { Request, Response } from 'express';
+import type { ChatCompletionRequest, EscalationStrategy, ErrorEnvelope, FallbackPolicy, Tier } from '../types/openai';
+
+export function requestIdOf(req: Request): string {
+  const hdr = req.headers['x-request-id'];
+  return (typeof hdr === 'string' && hdr.length > 0 ? hdr : '') || randomUUID();
+}
+
+export function sendError(
+  res: Response,
+  requestId: string,
+  status: number,
+  code: string,
+  error: string,
+): void {
+  const body: ErrorEnvelope = { error, code, requestId };
+  res.status(status).json(body);
+}
+
+function asTier(v: unknown): Tier | undefined {
+  return v === 'low' || v === 'mid' || v === 'high' ? v : undefined;
+}
+
+/**
+ * Merge the X-Cognitum-* routing-control headers onto the request body fields (§3.4).
+ * Body values take precedence; headers fill in when the body omits the field.
+ */
+export function mergeRoutingControls(body: ChatCompletionRequest, headers: Request['headers']): void {
+  const h = (name: string): string | undefined => {
+    const v = headers[name];
+    return typeof v === 'string' ? v : undefined;
+  };
+  if (body.fallback_policy === undefined) {
+    const fp = h('x-cognitum-fallback-policy');
+    if (fp === 'fail_fast' || fp === 'best_effort') body.fallback_policy = fp as FallbackPolicy;
+  }
+  if (body.min_tier === undefined) body.min_tier = asTier(h('x-cognitum-min-tier')) ?? undefined;
+  if (body.max_tier === undefined) body.max_tier = asTier(h('x-cognitum-max-tier')) ?? undefined;
+  if (body.escalation === undefined) {
+    const e = h('x-cognitum-escalation');
+    if (e === 'stream_oneshot' || e === 'post_hoc' || e === 'buffered' || e === 'inflight') {
+      body.escalation = e as EscalationStrategy;
+    }
+  }
+}
+
+export interface CognitumHeaderFields {
+  resolvedTier: Tier;
+  resolvedModel: string;
+  escalated: boolean;
+  capDegraded: boolean;
+  routingReason: string;
+}
+
+/** HTTP header values must be ASCII; the routing reason can carry unicode (τ, →) in the
+ *  JSON body but is folded to ASCII for the X-Cognitum-Routing-Reason header. */
+function asciiHeader(s: string): string {
+  return s
+    .replace(/τ/g, 'tau')
+    .replace(/[→➔➙]/g, '->')
+    .replace(/[^\x20-\x7e]/g, '');
+}
+
+/** Mirror the x_cognitum block onto X-Cognitum-* response headers (§3.4). */
+export function setCognitumHeaders(res: Response, requestId: string, f: CognitumHeaderFields): void {
+  res.setHeader('X-Request-Id', requestId);
+  res.setHeader('X-Cognitum-Resolved-Tier', f.resolvedTier);
+  res.setHeader('X-Cognitum-Resolved-Model', f.resolvedModel);
+  res.setHeader('X-Cognitum-Escalated', String(f.escalated));
+  res.setHeader('X-Cognitum-Cap-Degraded', String(f.capDegraded));
+  res.setHeader('X-Cognitum-Routing-Reason', asciiHeader(f.routingReason));
+}

--- a/services/apicompletions/src/core/http.ts
+++ b/services/apicompletions/src/core/http.ts
@@ -64,6 +64,25 @@ function asTier(v: unknown): Tier | undefined {
 }
 
 /**
+ * Resolve the per-agent / per-loop budget identity (ADR-204 §5.2). The optional
+ * `X-Cognitum-Agent-Id` header names the autonomous agent / loop so its runaway cap is
+ * tracked independently; absent it, all of a key's traffic collapses to one agent bucket
+ * keyed by the account (or the key hash when the key carries no accountId). Bounded length so
+ * an attacker-chosen header can't blow up the Firestore doc id.
+ */
+export function agentIdOf(headers: Request['headers'], key: ApiKeyDoc): string {
+  const h = headers['x-cognitum-agent-id'];
+  const raw = typeof h === 'string' ? h : Array.isArray(h) ? h[0] : undefined;
+  if (raw && raw.length > 0) return raw.slice(0, 128);
+  return key.accountId ?? key.key;
+}
+
+/** Account budget identity (ADR-204 §5.2) — the subscription doc key. */
+export function accountIdOf(key: ApiKeyDoc): string {
+  return key.accountId ?? key.key;
+}
+
+/**
  * Merge the X-Cognitum-* routing-control headers onto the request body fields (§3.4).
  * Body values take precedence; headers fill in when the body omits the field.
  */

--- a/services/apicompletions/src/core/pipeline.ts
+++ b/services/apicompletions/src/core/pipeline.ts
@@ -1,0 +1,116 @@
+// Core request pipeline (ADR-203 §3.1 d–g, §3.3, §5.2). Shared by /v1/chat/completions
+// and /v1/completions. Steps: route (tier pool + fallback chain) → infer → post-gen τ
+// escalation (non-stream/auto only) → price at the RESOLVED tier. Auth + tier resolution
+// happen in the route handler; this module owns infer/escalate/price.
+import type { ChatCompletionRequest, EscalationStrategy, Tier, Usage } from '../types/openai';
+import type { AppDeps } from '../deps';
+import { type ModelProvider, type ProviderResult, ProviderError } from '../providers/types';
+import type { TierResolution } from '../tier/resolveTier';
+import { verify, shouldEscalate } from '../router/escalation';
+import { priceUsd } from '../metering/pricing';
+
+export interface InferOutcome {
+  text: string;
+  usage: Usage;
+  resolvedTier: Tier;
+  resolvedModel: string;
+  escalated: boolean;
+  capDegraded: boolean;
+  routingReason: string;
+  priceUsd: number;
+}
+
+/** Conservative local token floor (§5.1) — used only when the provider omits usage. */
+function localUsage(req: ChatCompletionRequest, text: string): Usage {
+  const approx = (s: string) => Math.max(1, Math.ceil(s.length / 4));
+  const prompt = req.messages.reduce((n, m) => n + approx(m.content ?? ''), 0);
+  const completion = approx(text);
+  return { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion };
+}
+
+function usageOf(req: ChatCompletionRequest, r: ProviderResult): Usage {
+  return r.usage ?? localUsage(req, r.text);
+}
+
+/**
+ * Try each model in a tier's ordered fallback chain (commit de512bd). A provider
+ * 5xx/timeout fails over to the next model WITHIN the tier — never silently changing the
+ * billed tier. Throws ProviderError only when the whole chain is exhausted.
+ */
+export async function inferWithFallback(
+  provider: ModelProvider,
+  models: string[],
+  req: ChatCompletionRequest,
+): Promise<ProviderResult & { model: string }> {
+  const attempted: string[] = [];
+  let lastErr: unknown;
+  for (const model of models) {
+    attempted.push(model);
+    try {
+      const r = await provider.complete(model, req);
+      return { ...r, model };
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw new ProviderError(
+    `all models failed in tier chain: ${attempted.join(', ')}${lastErr instanceof Error ? ` (last: ${lastErr.message})` : ''}`,
+    attempted,
+  );
+}
+
+/** Resolve the effective escalation strategy. `inflight` degrades to stream_oneshot today
+ *  (the §3.5 midstream firewall: @midstream/wasm is absent → Option B). */
+export function effectiveEscalation(req: ChatCompletionRequest): EscalationStrategy {
+  const explicit = req.escalation;
+  if (explicit) return explicit === 'inflight' ? 'stream_oneshot' : explicit;
+  return req.stream ? 'stream_oneshot' : 'post_hoc';
+}
+
+/**
+ * NON-STREAMING execution with post-gen τ escalation (§3.3, §6.5).
+ * Escalation runs only for auto mode under post_hoc/buffered strategies; streams route
+ * once up front (stream_oneshot) and never reach this re-answer path.
+ */
+export async function executeNonStream(
+  deps: AppDeps,
+  req: ChatCompletionRequest,
+  resolution: TierResolution,
+): Promise<InferOutcome> {
+  const { config, provider } = deps;
+  const strategy = effectiveEscalation(req);
+
+  let tier = resolution.tier;
+  let pool = config.tierPools[tier];
+  let result = await inferWithFallback(provider, pool.models, req);
+  let usage = usageOf(req, result);
+  let escalated = false;
+  let routingReason = resolution.routingReason;
+
+  const escalationAllowed =
+    resolution.mode === 'auto' && (strategy === 'post_hoc' || strategy === 'buffered');
+
+  if (escalationAllowed) {
+    const v = verify(result.text, result.confidence);
+    const decision = shouldEscalate(v, tier, resolution.ceiling);
+    if (decision.escalate && decision.nextTier) {
+      tier = decision.nextTier;
+      pool = config.tierPools[tier];
+      result = await inferWithFallback(provider, pool.models, req);
+      usage = usageOf(req, result);
+      escalated = true;
+      routingReason = `${routingReason}; ${decision.reason}`;
+    }
+  }
+
+  return {
+    text: result.text,
+    usage,
+    resolvedTier: tier,
+    resolvedModel: result.model,
+    escalated,
+    capDegraded: resolution.capDegraded,
+    routingReason,
+    priceUsd: priceUsd(config, tier, usage),
+  };
+}

--- a/services/apicompletions/src/core/pipeline.ts
+++ b/services/apicompletions/src/core/pipeline.ts
@@ -8,6 +8,7 @@ import { type ModelProvider, type ProviderResult, ProviderError } from '../provi
 import type { TierResolution } from '../tier/resolveTier';
 import { verify, shouldEscalate } from '../router/escalation';
 import { priceUsd } from '../metering/pricing';
+import { estimateTokens } from '../metering/tokenizer';
 
 export interface InferOutcome {
   text: string;
@@ -18,18 +19,26 @@ export interface InferOutcome {
   capDegraded: boolean;
   routingReason: string;
   priceUsd: number;
+  /** §5.1 — true when usage came from the local family floor, not the provider's count. */
+  tokensFromLocalFloor: boolean;
 }
 
-/** Conservative local token floor (§5.1) — used only when the provider omits usage. */
-function localUsage(req: ChatCompletionRequest, text: string): Usage {
-  const approx = (s: string) => Math.max(1, Math.ceil(s.length / 4));
-  const prompt = req.messages.reduce((n, m) => n + approx(m.content ?? ''), 0);
-  const completion = approx(text);
+/**
+ * FAMILY-CORRECT local token floor (§5.1) — used only when the provider omits an
+ * authoritative usage block. Counts prompt + completion with the resolved model's
+ * byte→token ratio, never an OpenAI profile for a non-OpenAI model.
+ */
+function localUsage(req: ChatCompletionRequest, resolvedModel: string, text: string): Usage {
+  const prompt = req.messages.reduce(
+    (n, m) => n + estimateTokens(resolvedModel, m.content ?? ''),
+    0,
+  );
+  const completion = estimateTokens(resolvedModel, text);
   return { prompt_tokens: prompt, completion_tokens: completion, total_tokens: prompt + completion };
 }
 
-function usageOf(req: ChatCompletionRequest, r: ProviderResult): Usage {
-  return r.usage ?? localUsage(req, r.text);
+function usageOf(req: ChatCompletionRequest, resolvedModel: string, r: ProviderResult): Usage {
+  return r.usage ?? localUsage(req, resolvedModel, r.text);
 }
 
 /**
@@ -83,7 +92,8 @@ export async function executeNonStream(
   let tier = resolution.tier;
   let pool = config.tierPools[tier];
   let result = await inferWithFallback(provider, pool.models, req);
-  let usage = usageOf(req, result);
+  let usage = usageOf(req, result.model, result);
+  let fromFloor = result.usage === undefined;
   let escalated = false;
   let routingReason = resolution.routingReason;
 
@@ -97,7 +107,8 @@ export async function executeNonStream(
       tier = decision.nextTier;
       pool = config.tierPools[tier];
       result = await inferWithFallback(provider, pool.models, req);
-      usage = usageOf(req, result);
+      usage = usageOf(req, result.model, result);
+      fromFloor = result.usage === undefined;
       escalated = true;
       routingReason = `${routingReason}; ${decision.reason}`;
     }
@@ -112,5 +123,6 @@ export async function executeNonStream(
     capDegraded: resolution.capDegraded,
     routingReason,
     priceUsd: priceUsd(config, tier, usage),
+    tokensFromLocalFloor: fromFloor,
   };
 }

--- a/services/apicompletions/src/deps.ts
+++ b/services/apicompletions/src/deps.ts
@@ -17,6 +17,8 @@ import {
 } from './metering/ledger';
 import { RateLimiter, InMemoryRateLimitStore } from './ratelimit/limiter';
 import { type IdempotencyStore, InMemoryIdempotencyStore } from './ratelimit/idempotency';
+import type { BudgetTracker } from './budget/types';
+import { InMemoryBudgetTracker } from './budget/tracker';
 
 export interface AppDeps {
   config: Config;
@@ -30,6 +32,8 @@ export interface AppDeps {
   rateLimiter: RateLimiter;
   /** 24h replay cache (§5.3). */
   idempotency: IdempotencyStore;
+  /** Reserve-and-Commit budget defense (ADR-204 §5.2). Unmetered until an account opts in. */
+  budget: BudgetTracker;
 }
 
 export interface AppDepsOverrides {
@@ -40,6 +44,7 @@ export interface AppDepsOverrides {
   usagePublisher?: UsagePublisher;
   rateLimiter?: RateLimiter;
   idempotency?: IdempotencyStore;
+  budget?: BudgetTracker;
 }
 
 /**
@@ -63,5 +68,9 @@ export function defaultDeps(overrides: AppDepsOverrides = {}): AppDeps {
     usagePublisher: overrides.usagePublisher ?? new InMemoryUsagePublisher(),
     rateLimiter: overrides.rateLimiter ?? new RateLimiter(new InMemoryRateLimitStore()),
     idempotency: overrides.idempotency ?? new InMemoryIdempotencyStore(),
+    // Default to the in-memory tracker with NO seeded accounts → transparent (admits all,
+    // no reservation) until an account opts into enforcement. Production binds
+    // FirestoreBudgetTracker(admin.firestore(), config).
+    budget: overrides.budget ?? new InMemoryBudgetTracker(config),
   };
 }

--- a/services/apicompletions/src/deps.ts
+++ b/services/apicompletions/src/deps.ts
@@ -1,29 +1,52 @@
 // App dependency container (ADR-203 §2, §7.3). Dependency-injected so the whole
-// auth → tier → route loop runs at $0 in tests/emulators: a seeded in-memory key store
-// and the deterministic MockProvider by default; production swaps in a Firestore-backed
-// KeyStore and the OpenRouterProvider (metering/limiter wiring lands in a later phase).
+// auth → tier → route → meter → bill loop runs at $0 in tests/emulators: a seeded
+// in-memory key store, the deterministic MockProvider, and in-memory metering / rate-limit
+// / idempotency stores by default; production swaps in the Firestore-/PubSub-backed
+// adapters (FirestoreLedgerStore, PubSubUsagePublisher, FirestoreRateLimitStore,
+// FirestoreIdempotencyStore) and the OpenRouterProvider.
 import { type KeyStore, InMemoryKeyStore } from './auth/apiKey';
 import type { ModelProvider } from './providers/types';
 import { MockProvider } from './providers/mockProvider';
 import { OpenRouterProvider } from './providers/openrouter';
 import { type Config, loadConfig } from './config';
+import {
+  type LedgerStore,
+  type UsagePublisher,
+  InMemoryLedgerStore,
+  InMemoryUsagePublisher,
+} from './metering/ledger';
+import { RateLimiter, InMemoryRateLimitStore } from './ratelimit/limiter';
+import { type IdempotencyStore, InMemoryIdempotencyStore } from './ratelimit/idempotency';
 
 export interface AppDeps {
   config: Config;
   keyStore: KeyStore;
   provider: ModelProvider;
+  /** Billing source of truth — written on the response path (§5.1). */
+  ledger: LedgerStore;
+  /** Fire-and-forget rollup feed (§5.1). */
+  usagePublisher: UsagePublisher;
+  /** Scatter-gather per-(key,tier) rate limiter (§5.3). */
+  rateLimiter: RateLimiter;
+  /** 24h replay cache (§5.3). */
+  idempotency: IdempotencyStore;
 }
 
 export interface AppDepsOverrides {
   config?: Config;
   keyStore?: KeyStore;
   provider?: ModelProvider;
+  ledger?: LedgerStore;
+  usagePublisher?: UsagePublisher;
+  rateLimiter?: RateLimiter;
+  idempotency?: IdempotencyStore;
 }
 
 /**
  * Build the default deps. Emulator-first / $0: MockProvider unless a real
- * OPENROUTER_API_KEY is present and mock is not forced (§7.3). The key store defaults to
- * an empty in-memory store — tests seed it; production binds a Firestore-backed store.
+ * OPENROUTER_API_KEY is present and mock is not forced (§7.3); the key store, ledger,
+ * publisher, rate-limit tick store, and idempotency cache all default to in-memory fakes —
+ * tests seed/inspect them; production binds Firestore/PubSub adapters.
  */
 export function defaultDeps(overrides: AppDepsOverrides = {}): AppDeps {
   const config = overrides.config ?? loadConfig();
@@ -36,5 +59,9 @@ export function defaultDeps(overrides: AppDepsOverrides = {}): AppDeps {
     config,
     keyStore: overrides.keyStore ?? new InMemoryKeyStore(),
     provider,
+    ledger: overrides.ledger ?? new InMemoryLedgerStore(),
+    usagePublisher: overrides.usagePublisher ?? new InMemoryUsagePublisher(),
+    rateLimiter: overrides.rateLimiter ?? new RateLimiter(new InMemoryRateLimitStore()),
+    idempotency: overrides.idempotency ?? new InMemoryIdempotencyStore(),
   };
 }

--- a/services/apicompletions/src/deps.ts
+++ b/services/apicompletions/src/deps.ts
@@ -1,0 +1,40 @@
+// App dependency container (ADR-203 §2, §7.3). Dependency-injected so the whole
+// auth → tier → route loop runs at $0 in tests/emulators: a seeded in-memory key store
+// and the deterministic MockProvider by default; production swaps in a Firestore-backed
+// KeyStore and the OpenRouterProvider (metering/limiter wiring lands in a later phase).
+import { type KeyStore, InMemoryKeyStore } from './auth/apiKey';
+import type { ModelProvider } from './providers/types';
+import { MockProvider } from './providers/mockProvider';
+import { OpenRouterProvider } from './providers/openrouter';
+import { type Config, loadConfig } from './config';
+
+export interface AppDeps {
+  config: Config;
+  keyStore: KeyStore;
+  provider: ModelProvider;
+}
+
+export interface AppDepsOverrides {
+  config?: Config;
+  keyStore?: KeyStore;
+  provider?: ModelProvider;
+}
+
+/**
+ * Build the default deps. Emulator-first / $0: MockProvider unless a real
+ * OPENROUTER_API_KEY is present and mock is not forced (§7.3). The key store defaults to
+ * an empty in-memory store — tests seed it; production binds a Firestore-backed store.
+ */
+export function defaultDeps(overrides: AppDepsOverrides = {}): AppDeps {
+  const config = overrides.config ?? loadConfig();
+  const provider =
+    overrides.provider ??
+    (config.useMockProvider
+      ? new MockProvider()
+      : new OpenRouterProvider(process.env.OPENROUTER_API_KEY ?? ''));
+  return {
+    config,
+    keyStore: overrides.keyStore ?? new InMemoryKeyStore(),
+    provider,
+  };
+}

--- a/services/apicompletions/src/firestore/client.ts
+++ b/services/apicompletions/src/firestore/client.ts
@@ -3,8 +3,54 @@
 //   api_keys (reuse), audit_log (reuse), usage_ledger (new), usage_rollups (new),
 //   api_keys/{keyHash}/usage_ticks (new, TTL'd — §5.3 counter), idempotency (new),
 //   tier_config (new, hot-reloadable pools).
-// TODO(impl): lazily init firebase-admin and expose a typed handle. Kept as a stub so the
-// skeleton builds without the (heavy) GCP SDK installed.
+//
+// The production stores (metering ledger, scatter-gather rate-limit ticks, idempotency)
+// are written against the MINIMAL STRUCTURAL interfaces below rather than a hard
+// firebase-admin import. This keeps the standalone package's `tsc` build green and its
+// install fast (firebase-admin / @google-cloud/pubsub stay deferred deps, §package.json)
+// while the shape stays byte-compatible with `admin.firestore()` so the production
+// binding is a one-line `new FirestoreLedgerStore(admin.firestore())`. The same DI
+// posture as `KeyStore`/`InMemoryKeyStore` (§6) — tests inject in-memory fakes at $0.
+
+/** Structural subset of a firebase-admin `DocumentSnapshot`. */
+export interface DocSnapshotLike {
+  readonly exists: boolean;
+  data(): Record<string, unknown> | undefined;
+}
+
+/** Structural subset of a firebase-admin `AggregateQuerySnapshot` (COUNT(), §5.3). */
+export interface AggregateSnapshotLike {
+  data(): { count: number };
+}
+
+/** Structural subset of a firebase-admin `Query` supporting the COUNT() window scan. */
+export interface QueryLike {
+  where(field: string, op: string, value: unknown): QueryLike;
+  count(): { get(): Promise<AggregateSnapshotLike> };
+}
+
+/** Structural subset of a firebase-admin `DocumentReference`. */
+export interface DocRefLike {
+  set(data: Record<string, unknown>, opts?: { merge?: boolean }): Promise<unknown>;
+  get(): Promise<DocSnapshotLike>;
+  collection(path: string): CollectionRefLike;
+}
+
+/** Structural subset of a firebase-admin `CollectionReference`. */
+export interface CollectionRefLike extends QueryLike {
+  doc(id: string): DocRefLike;
+}
+
+/** Structural subset of a firebase-admin `Firestore` instance. */
+export interface FirestoreLike {
+  collection(path: string): CollectionRefLike;
+  doc(path: string): DocRefLike;
+}
+
+/** Structural subset of a `@google-cloud/pubsub` Topic.publishMessage handle. */
+export interface PubSubTopicLike {
+  publishMessage(message: { json: unknown }): Promise<string>;
+}
 
 export interface FirestoreHandle {
   /** Placeholder — replaced by the firebase-admin Firestore instance during impl. */
@@ -15,7 +61,7 @@ let handle: FirestoreHandle | null = null;
 
 export function getFirestore(): FirestoreHandle {
   if (handle) return handle;
-  // TODO(impl): admin.initializeApp(); return admin.firestore();
+  // TODO(impl): admin.initializeApp(); return admin.firestore() as unknown as FirestoreLike.
   handle = { ready: false };
   return handle;
 }

--- a/services/apicompletions/src/firestore/client.ts
+++ b/services/apicompletions/src/firestore/client.ts
@@ -41,10 +41,23 @@ export interface CollectionRefLike extends QueryLike {
   doc(id: string): DocRefLike;
 }
 
+/**
+ * Structural subset of a firebase-admin `Transaction` (ADR-204 §5.2 Reserve-and-Commit).
+ * The RESERVE/COMMIT txns read at most two single docs (account + agent-shard) and never
+ * scan a subcollection on the hot path (§5.2 fix 2 — no `sumReserved()` read lock).
+ */
+export interface TransactionLike {
+  get(ref: DocRefLike): Promise<DocSnapshotLike>;
+  set(ref: DocRefLike, data: Record<string, unknown>, opts?: { merge?: boolean }): void;
+  update(ref: DocRefLike, data: Record<string, unknown>): void;
+}
+
 /** Structural subset of a firebase-admin `Firestore` instance. */
 export interface FirestoreLike {
   collection(path: string): CollectionRefLike;
   doc(path: string): DocRefLike;
+  /** ADR-204 §5.2 — atomic Reserve / Commit transactions on the budget docs. */
+  runTransaction<T>(fn: (txn: TransactionLike) => Promise<T>): Promise<T>;
 }
 
 /** Structural subset of a `@google-cloud/pubsub` Topic.publishMessage handle. */

--- a/services/apicompletions/src/firestore/client.ts
+++ b/services/apicompletions/src/firestore/client.ts
@@ -1,0 +1,21 @@
+// Firestore access (ADR-203 §7.1). Emulator-aware: when FIRESTORE_EMULATOR_HOST is set
+// all access goes to the local emulator ($0, §7.3). Collections:
+//   api_keys (reuse), audit_log (reuse), usage_ledger (new), usage_rollups (new),
+//   api_keys/{keyHash}/usage_ticks (new, TTL'd — §5.3 counter), idempotency (new),
+//   tier_config (new, hot-reloadable pools).
+// TODO(impl): lazily init firebase-admin and expose a typed handle. Kept as a stub so the
+// skeleton builds without the (heavy) GCP SDK installed.
+
+export interface FirestoreHandle {
+  /** Placeholder — replaced by the firebase-admin Firestore instance during impl. */
+  readonly ready: boolean;
+}
+
+let handle: FirestoreHandle | null = null;
+
+export function getFirestore(): FirestoreHandle {
+  if (handle) return handle;
+  // TODO(impl): admin.initializeApp(); return admin.firestore();
+  handle = { ready: false };
+  return handle;
+}

--- a/services/apicompletions/src/index.ts
+++ b/services/apicompletions/src/index.ts
@@ -1,14 +1,18 @@
 // Cloud Run bootstrap (ADR-203 §7.1). Listens on $PORT (8080), long SSE timeouts handled
-// by Cloud Run (timeout=300s, concurrency=8).
+// by Cloud Run (timeout=300s, concurrency=8). Builds the default deps (config + key store
+// + provider) once and shares them with the app.
 import { createApp } from './server';
-import { loadConfig } from './config';
+import { defaultDeps } from './deps';
 
-const config = loadConfig();
-const app = createApp();
+const deps = defaultDeps();
+const config = deps.config;
+const app = createApp(deps);
 
 const server = app.listen(config.port, () => {
   // eslint-disable-next-line no-console
-  console.log(`apicompletions listening on :${config.port} (project=${config.projectId})`);
+  console.log(
+    `apicompletions listening on :${config.port} (project=${config.projectId}, provider=${deps.provider.name})`,
+  );
 });
 
 // Generous timeout for long-lived SSE streams.

--- a/services/apicompletions/src/index.ts
+++ b/services/apicompletions/src/index.ts
@@ -1,0 +1,17 @@
+// Cloud Run bootstrap (ADR-203 §7.1). Listens on $PORT (8080), long SSE timeouts handled
+// by Cloud Run (timeout=300s, concurrency=8).
+import { createApp } from './server';
+import { loadConfig } from './config';
+
+const config = loadConfig();
+const app = createApp();
+
+const server = app.listen(config.port, () => {
+  // eslint-disable-next-line no-console
+  console.log(`apicompletions listening on :${config.port} (project=${config.projectId})`);
+});
+
+// Generous timeout for long-lived SSE streams.
+server.timeout = 300_000;
+
+export { app, server, config };

--- a/services/apicompletions/src/metering/ledger.ts
+++ b/services/apicompletions/src/metering/ledger.ts
@@ -2,7 +2,14 @@
 //   apicompletions --publish--> [Pub/Sub completions-usage] --> gen2 aggregateUsage
 //        |-- write --> usage_ledger/{requestId}   (append-only, billing source of truth)
 // Ledger write is on the response path (truth); Pub/Sub publish is fire-and-forget (rollup).
+//
+// Both surfaces are dependency-injected behind small interfaces (the same DI posture as
+// `KeyStore`): in-memory fakes run the whole meter→bill loop at $0 in tests/emulators;
+// production binds the Firestore-/PubSub-backed adapters. A metering failure LOGS but
+// NEVER fails the customer's completion — the ledger write is awaited on the response path
+// so billing is not lost, the publish is fire-and-forget (the rollup is reconstructable).
 import type { Tier } from '../types/openai';
+import type { FirestoreLike, PubSubTopicLike } from '../firestore/client';
 
 export interface UsageRecord {
   requestId: string;
@@ -19,17 +26,88 @@ export interface UsageRecord {
   discardedPrefixTokens?: number;
   /** §5.1 — set when the client dropped the stream before the final usage frame. */
   truncated?: boolean;
+  /** §5.1 — true when the count came from the local family floor, not the provider. */
+  tokensFromLocalFloor?: boolean;
   latencyMs: number;
   idempotencyKey?: string;
   ts: number;
 }
 
-/** TODO(impl): write usage_ledger/{requestId} (firebase-admin). */
-export async function writeLedger(_record: UsageRecord): Promise<void> {
-  throw new Error('not implemented: writeLedger (ADR-203 §5.1)');
+/** The billing source of truth (§5.1). Append-only by request id; reconcilable. */
+export interface LedgerStore {
+  /** Write usage_ledger/{requestId}. Awaited on the response path so billing is not lost. */
+  write(record: UsageRecord): Promise<void>;
 }
 
-/** TODO(impl): publish to completions-usage (fire-and-forget; failure logs, never fails the completion). */
-export async function publishUsage(_record: UsageRecord): Promise<void> {
-  throw new Error('not implemented: publishUsage (ADR-203 §5.1)');
+/** Fire-and-forget rollup feed (§5.1). publish() must NEVER throw to the caller. */
+export interface UsagePublisher {
+  publish(record: UsageRecord): Promise<void>;
+}
+
+/** $0 emulator-first / test ledger. Append-only keyed by requestId; later writes (provider
+ *  reconcile) overwrite the floor row for the same request. */
+export class InMemoryLedgerStore implements LedgerStore {
+  private readonly byRequest = new Map<string, UsageRecord>();
+
+  async write(record: UsageRecord): Promise<void> {
+    this.byRequest.set(record.requestId, { ...record });
+  }
+
+  /** Test/inspection helpers — not part of the production interface. */
+  all(): UsageRecord[] {
+    return [...this.byRequest.values()];
+  }
+  get(requestId: string): UsageRecord | undefined {
+    return this.byRequest.get(requestId);
+  }
+  get size(): number {
+    return this.byRequest.size;
+  }
+}
+
+/** $0 in-memory publisher. Records every published event; never throws (fire-and-forget). */
+export class InMemoryUsagePublisher implements UsagePublisher {
+  readonly published: UsageRecord[] = [];
+
+  async publish(record: UsageRecord): Promise<void> {
+    this.published.push({ ...record });
+  }
+}
+
+/**
+ * Production ledger — writes usage_ledger/{requestId} via firebase-admin (structurally
+ * typed against {@link FirestoreLike} so the SDK stays a deferred dep). `merge:true` lets
+ * a later provider-authoritative reconcile update the floor row idempotently.
+ */
+export class FirestoreLedgerStore implements LedgerStore {
+  constructor(private readonly db: FirestoreLike) {}
+
+  async write(record: UsageRecord): Promise<void> {
+    await this.db
+      .collection('usage_ledger')
+      .doc(record.requestId)
+      .set({ ...record }, { merge: true });
+  }
+}
+
+/**
+ * Production publisher — publishes to the `completions-usage` Pub/Sub topic (agentbbs-gcp
+ * async-HTTP bridge shape, §5.1). Swallows + logs on failure: the rollup is reconstructable
+ * from the ledger, so a publish error must never surface to the customer.
+ */
+export class PubSubUsagePublisher implements UsagePublisher {
+  constructor(private readonly topic: PubSubTopicLike) {}
+
+  async publish(record: UsageRecord): Promise<void> {
+    try {
+      await this.topic.publishMessage({ json: record });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[metering] completions-usage publish failed (rollup only, billing safe): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
 }

--- a/services/apicompletions/src/metering/ledger.ts
+++ b/services/apicompletions/src/metering/ledger.ts
@@ -1,0 +1,35 @@
+// Usage ledger + Pub/Sub rollup (ADR-203 §5.1, agentbbs-gcp pattern).
+//   apicompletions --publish--> [Pub/Sub completions-usage] --> gen2 aggregateUsage
+//        |-- write --> usage_ledger/{requestId}   (append-only, billing source of truth)
+// Ledger write is on the response path (truth); Pub/Sub publish is fire-and-forget (rollup).
+import type { Tier } from '../types/openai';
+
+export interface UsageRecord {
+  requestId: string;
+  keyPrefix: string;
+  accountId?: string;
+  tier: Tier;
+  resolvedModel: string;
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  priceUsd: number;
+  escalated: boolean;
+  /** §3.5 — honest record of low-tier tokens thrown away by an inflight escalation. */
+  discardedPrefixTokens?: number;
+  /** §5.1 — set when the client dropped the stream before the final usage frame. */
+  truncated?: boolean;
+  latencyMs: number;
+  idempotencyKey?: string;
+  ts: number;
+}
+
+/** TODO(impl): write usage_ledger/{requestId} (firebase-admin). */
+export async function writeLedger(_record: UsageRecord): Promise<void> {
+  throw new Error('not implemented: writeLedger (ADR-203 §5.1)');
+}
+
+/** TODO(impl): publish to completions-usage (fire-and-forget; failure logs, never fails the completion). */
+export async function publishUsage(_record: UsageRecord): Promise<void> {
+  throw new Error('not implemented: publishUsage (ADR-203 §5.1)');
+}

--- a/services/apicompletions/src/metering/pricing.ts
+++ b/services/apicompletions/src/metering/pricing.ts
@@ -1,0 +1,13 @@
+// Pricing computation (ADR-203 §5.2). Strictly linear pass on the RESOLVED tier —
+// escalation low→high bills at high. Asymmetric in/out rates per tier. No vendor quirks.
+//   Price_USD = in_tokens × Rate_In[resolved_tier] + out_tokens × Rate_Out[resolved_tier]
+import type { Tier, Usage } from '../types/openai';
+import type { Config } from '../config';
+
+export function priceUsd(config: Config, resolvedTier: Tier, usage: Usage): number {
+  const pool = config.tierPools[resolvedTier];
+  return (
+    (usage.prompt_tokens * pool.rateInPer1M) / 1_000_000 +
+    (usage.completion_tokens * pool.rateOutPer1M) / 1_000_000
+  );
+}

--- a/services/apicompletions/src/metering/record.ts
+++ b/services/apicompletions/src/metering/record.ts
@@ -1,0 +1,67 @@
+// Metering write helper (ADR-203 §5.1). Assembles the UsageRecord, writes it to the
+// ledger (TRUTH — awaited on the response path so billing is never lost), then fires the
+// Pub/Sub publish (rollup — fire-and-forget). A failure on EITHER surface logs but never
+// fails the customer's completion: the ledger write is wrapped so a Firestore blip downgrades
+// to a logged error rather than a 5xx, and the publish is detached.
+import type { AppDeps } from '../deps';
+import type { ApiKeyDoc } from '../auth/apiKey';
+import type { Tier, Usage } from '../types/openai';
+import type { UsageRecord } from './ledger';
+
+export interface MeterInput {
+  requestId: string;
+  key: ApiKeyDoc;
+  keyPrefix: string;
+  tier: Tier;
+  resolvedModel: string;
+  usage: Usage;
+  priceUsd: number;
+  escalated: boolean;
+  latencyMs: number;
+  tokensFromLocalFloor: boolean;
+  idempotencyKey?: string;
+  truncated?: boolean;
+  discardedPrefixTokens?: number;
+}
+
+export function buildRecord(input: MeterInput): UsageRecord {
+  return {
+    requestId: input.requestId,
+    keyPrefix: input.keyPrefix,
+    accountId: input.key.accountId,
+    tier: input.tier,
+    resolvedModel: input.resolvedModel,
+    promptTokens: input.usage.prompt_tokens,
+    completionTokens: input.usage.completion_tokens,
+    totalTokens: input.usage.total_tokens,
+    priceUsd: input.priceUsd,
+    escalated: input.escalated,
+    truncated: input.truncated,
+    discardedPrefixTokens: input.discardedPrefixTokens,
+    tokensFromLocalFloor: input.tokensFromLocalFloor,
+    latencyMs: input.latencyMs,
+    idempotencyKey: input.idempotencyKey,
+    ts: Date.now(),
+  };
+}
+
+/**
+ * Write the ledger row (truth, awaited) and publish the rollup event (fire-and-forget).
+ * Never throws to the caller — a metering failure must not fail the completion (§5.1).
+ */
+export async function meter(deps: AppDeps, input: MeterInput): Promise<UsageRecord> {
+  const record = buildRecord(input);
+  try {
+    await deps.ledger.write(record);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `[metering] usage_ledger write failed for ${record.requestId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  // Detached — publish() swallows its own errors; .catch() guards a rejected promise too.
+  void deps.usagePublisher.publish(record).catch(() => undefined);
+  return record;
+}

--- a/services/apicompletions/src/metering/tokenizer.ts
+++ b/services/apicompletions/src/metering/tokenizer.ts
@@ -3,27 +3,86 @@
 // so a dropped TCP connection is still billed for what was generated.
 // CRITICAL: never count non-OpenAI (deepseek/glm) output with an OpenAI tokenizer —
 // 15–30% drift. Select the tokenizer (or byte→token ratio floor) by resolved_model family.
+//
+// This service ships the conservative, model-family-specific byte→token RATIO fallback
+// (§5.1) rather than bundling multiple heavy WASM tokenizers into the Cloud Run image.
+// Per-family ratios — never one global constant — keep the cheap tier from being mis-billed
+// with an OpenAI profile. In all cases the provider's authoritative final count is preferred
+// when it arrives; this local estimate is only the FLOOR / disconnect-fallback.
 import type { Tier } from '../types/openai';
 
 export type ModelFamily = 'openai' | 'deepseek' | 'glm' | 'gemini' | 'anthropic' | 'unknown';
 
-/** Resolve the BPE family of the model that actually served the request. TODO(impl). */
-export function familyOf(_resolvedModel: string): ModelFamily {
-  throw new Error('not implemented: familyOf (ADR-203 §5.1)');
+/**
+ * UTF-8 bytes per token, per family. Distinct per family by design: deepseek-v4 / glm-5.2
+ * use larger-vocabulary BPE schemes than OpenAI's cl100k/o200k, so their average token
+ * packs more bytes — counting their output with the OpenAI ratio would over-count ~15–30%
+ * (§5.1). `unknown` falls back to the conservative OpenAI-ish ratio.
+ */
+const BYTES_PER_TOKEN: Record<ModelFamily, number> = {
+  openai: 4.0,
+  deepseek: 4.7,
+  glm: 4.7,
+  gemini: 4.2,
+  anthropic: 3.8,
+  unknown: 4.0,
+};
+
+/** Resolve the BPE family of the model that actually served the request (§5.1). */
+export function familyOf(resolvedModel: string): ModelFamily {
+  const m = resolvedModel.toLowerCase();
+  if (/deepseek/.test(m)) return 'deepseek';
+  if (/\bglm\b|^glm[-\d]|zhipu|chatglm/.test(m)) return 'glm';
+  if (/gpt|^o[134]\b|openai|davinci|text-embedding/.test(m)) return 'openai';
+  if (/gemini|palm|bison/.test(m)) return 'gemini';
+  if (/claude|anthropic/.test(m)) return 'anthropic';
+  return 'unknown';
+}
+
+/** UTF-8 byte length (the local floor counts BYTES, not JS UTF-16 chars, per §5.1). */
+function byteLen(text: string): number {
+  return Buffer.byteLength(text, 'utf8');
+}
+
+/** Estimate tokens for a given family over a complete string (the byte→token floor). */
+export function estimateTokensForFamily(family: ModelFamily, text: string): number {
+  const bytes = byteLen(text);
+  if (bytes === 0) return 0;
+  return Math.max(1, Math.ceil(bytes / BYTES_PER_TOKEN[family]));
+}
+
+/** Family-correct token estimate for the model that served the request (§5.1 floor). */
+export function estimateTokens(resolvedModel: string, text: string): number {
+  return estimateTokensForFamily(familyOf(resolvedModel), text);
 }
 
 /** A running, incremental token counter fed each outbound delta chunk. */
 export interface ProgressiveCounter {
   readonly tier: Tier;
+  readonly family: ModelFamily;
   pushDelta(text: string): void;
   /** Local floor estimate — used on disconnect; provider's final count preferred when it arrives. */
   completionTokens(): number;
 }
 
 /**
- * Build a family-correct progressive counter. Falls back to a conservative,
- * per-family byte→token ratio when a WASM tokenizer bundle is too heavy (§5.1). TODO(impl).
+ * Build a family-correct progressive counter. Accumulates BYTES across deltas and divides
+ * by the resolved family's byte→token ratio (the conservative §5.1 fallback). Dividing the
+ * accumulated byte total once (rather than summing per-delta ceilings) avoids per-chunk
+ * rounding inflation — the floor stays tight to the true token count.
  */
-export function makeCounter(_resolvedModel: string, _tier: Tier): ProgressiveCounter {
-  throw new Error('not implemented: makeCounter (ADR-203 §5.1)');
+export function makeCounter(resolvedModel: string, tier: Tier): ProgressiveCounter {
+  const family = familyOf(resolvedModel);
+  const ratio = BYTES_PER_TOKEN[family];
+  let bytes = 0;
+  return {
+    tier,
+    family,
+    pushDelta(text: string): void {
+      bytes += byteLen(text);
+    },
+    completionTokens(): number {
+      return bytes === 0 ? 0 : Math.max(1, Math.ceil(bytes / ratio));
+    },
+  };
 }

--- a/services/apicompletions/src/metering/tokenizer.ts
+++ b/services/apicompletions/src/metering/tokenizer.ts
@@ -1,0 +1,29 @@
+// Progressive, FAMILY-CORRECT local token accounting (ADR-203 §5.1).
+// Closes the truncation/disconnect billing hole: tokenize every outbound delta locally
+// so a dropped TCP connection is still billed for what was generated.
+// CRITICAL: never count non-OpenAI (deepseek/glm) output with an OpenAI tokenizer —
+// 15–30% drift. Select the tokenizer (or byte→token ratio floor) by resolved_model family.
+import type { Tier } from '../types/openai';
+
+export type ModelFamily = 'openai' | 'deepseek' | 'glm' | 'gemini' | 'anthropic' | 'unknown';
+
+/** Resolve the BPE family of the model that actually served the request. TODO(impl). */
+export function familyOf(_resolvedModel: string): ModelFamily {
+  throw new Error('not implemented: familyOf (ADR-203 §5.1)');
+}
+
+/** A running, incremental token counter fed each outbound delta chunk. */
+export interface ProgressiveCounter {
+  readonly tier: Tier;
+  pushDelta(text: string): void;
+  /** Local floor estimate — used on disconnect; provider's final count preferred when it arrives. */
+  completionTokens(): number;
+}
+
+/**
+ * Build a family-correct progressive counter. Falls back to a conservative,
+ * per-family byte→token ratio when a WASM tokenizer bundle is too heavy (§5.1). TODO(impl).
+ */
+export function makeCounter(_resolvedModel: string, _tier: Tier): ProgressiveCounter {
+  throw new Error('not implemented: makeCounter (ADR-203 §5.1)');
+}

--- a/services/apicompletions/src/midstream/firewall.ts
+++ b/services/apicompletions/src/midstream/firewall.ts
@@ -1,0 +1,38 @@
+// Optional-dependency firewall for ruvnet/midstream (ADR-203 §3.5, ADR-150 removable
+// augmentation). midstream is a REAL Rust/WASM inflight LLM-stream-analysis toolkit, but
+// @midstream/wasm is NOT on npm today (404 verified 2026-06-29) — so this dynamic import
+// fails and the service ALWAYS degrades to Option B (escalation:"stream_oneshot").
+//
+// The inflight path (Option C′: scan stream → early failure signal → SDK-safe truncation →
+// higher-tier continuation) runs ONLY if `load()` returns non-null. Until the WASM is
+// vendored from the repo's npm-wasm/ / wasm/ dir or published upstream, it stays dark.
+//
+// NOTE: the specifier is a runtime variable (not a string literal) so the TypeScript
+// compiler does not try to resolve the (currently non-existent) module — this is the
+// firewall: absence is the expected, non-error default state.
+
+export interface MidstreamModule {
+  // Written against midstream's ACTUAL API as a contract (inflight scan → escalation
+  // signal → SDK-safe truncation → higher-tier continuation). Crate names in the proposal
+  // (temporal-compare, midstreamer-scheduler, …) are UNVERIFIED / illustrative (§3.5 item 6).
+  scanInflight?: unknown;
+}
+
+let cached: MidstreamModule | null | undefined;
+
+/** Returns the midstream module if present, else null (→ degrade to Option B). */
+export async function loadMidstream(): Promise<MidstreamModule | null> {
+  if (cached !== undefined) return cached;
+  try {
+    const specifier = '@midstream/wasm'; // variable, not literal — see header note
+    cached = (await import(specifier)) as MidstreamModule;
+  } catch {
+    cached = null; // 404 today → Option B is the operative state
+  }
+  return cached;
+}
+
+/** True only when inflight Option C′ is actually available. */
+export async function inflightAvailable(): Promise<boolean> {
+  return (await loadMidstream()) !== null;
+}

--- a/services/apicompletions/src/midstream/inflight.ts
+++ b/services/apicompletions/src/midstream/inflight.ts
@@ -1,0 +1,340 @@
+// Inflight streaming escalation — Option C′ (ADR-203 §3.5). midstream-only, firewalled.
+//
+// rev-3 §3.3 REJECTED Option C (speculative-stream-then-error) because, with no inflight
+// analysis, the only recovery from a bad streamed `low` answer was to corrupt the SSE
+// contract and force a restart. `ruvnet/midstream` (a REAL Rust/WASM inflight LLM-stream
+// analyser) changes that calculus: scan the output AS IT IS GENERATED and, on an EARLY
+// failure signal, escalate mid-stream WITHOUT killing TTFT (the first tokens already flowed).
+//
+// CRITICAL FIREWALL (ADR-150 removable augmentation): this path runs ONLY when the midstream
+// scanner is present. `@midstream/wasm` is NOT on npm today (404 verified 2026-06-29), so
+// `loadInflightScanner()` returns null and the route DEGRADES to Option B (stream_oneshot).
+// Everything here is OFF-BY-DEFAULT and the service is FULLY OPERATIONAL without it.
+//
+// Phase discipline (§3.5 item 5, HONEST): the scanner contract is scoped to EARLY-DETECTABLE
+// failure modes only (loops / explicit refusals / structural errors) — NOT a "first-N-tokens
+// confidence" magic number, which is deferred (Phase 3) until usage_ledger data shows it
+// predicts escalation outcomes. Crate names in the proposal are illustrative (§3.5 item 6);
+// this is written against midstream's API as a CONTRACT, not its (unverified) symbol names.
+import type { Response } from 'express';
+import type { AppDeps } from '../deps';
+import type { ApiKeyDoc } from '../auth/apiKey';
+import type { ChatCompletionRequest, Tier } from '../types/openai';
+import type { TierResolution } from '../tier/resolveTier';
+import { nextTierUp, tierRank } from '../tier/resolveTier';
+import { loadMidstream } from './firewall';
+import { makeCounter } from '../metering/tokenizer';
+import { priceUsd } from '../metering/pricing';
+import { meter } from '../metering/record';
+
+/** An early-detectable failure signal raised by the inflight scanner (§3.5 item 5). */
+export interface EscalationSignal {
+  /** Human-readable cause (loop / refusal / structural error) — surfaced in routing_reason. */
+  reason: string;
+  /**
+   * SDK-safe terminal stop value (§3.5 item 3). MUST be a value existing SDKs already treat
+   * as a clean stop — `content_filter` (default) or `length` — never a custom token, so the
+   * SDK closes its stream loop gracefully instead of hitting `Unexpected end of JSON input`.
+   */
+  finishReason: 'content_filter' | 'length';
+}
+
+/**
+ * The inflight scanner contract (written against midstream's ACTUAL API as a contract,
+ * §3.5 item 6). `push()` is fed each outbound delta as it is generated and returns an
+ * `EscalationSignal` on an early failure, else null. Stateful across a single stream.
+ */
+export interface InflightScanner {
+  push(delta: string): EscalationSignal | null;
+}
+
+/** Shape midstream is expected to expose once vendored/published — adapted to InflightScanner. */
+interface MidstreamWithScan {
+  scanInflight?: (req: ChatCompletionRequest) => InflightScanner;
+}
+
+/**
+ * Firewall-gated scanner factory (§3.5 item 2). Returns a scanner ONLY when midstream is
+ * present and exposes a `scanInflight` factory; otherwise null → the caller degrades to
+ * Option B (stream_oneshot). **null is the operative state today** (`@midstream/wasm` 404).
+ */
+export async function loadInflightScanner(
+  req: ChatCompletionRequest,
+): Promise<InflightScanner | null> {
+  const mod = (await loadMidstream()) as MidstreamWithScan | null;
+  if (!mod || typeof mod.scanInflight !== 'function') return null;
+  try {
+    return mod.scanInflight(req);
+  } catch {
+    return null; // a faulty optional dep must never break the request — degrade to Option B
+  }
+}
+
+/** Highest tier we may escalate to: the next tier up, capped at the resolution ceiling. */
+function escalateTarget(current: Tier, ceiling: Tier): Tier | null {
+  const next = nextTierUp(current);
+  if (!next) return null;
+  return tierRank(next) > tierRank(ceiling) ? null : next;
+}
+
+/**
+ * The SDK-safe truncation chunk (§3.5 item 3). ONE OpenAI-event-stream-conformant terminal
+ * chunk: a clean `finish_reason` every SDK already handles, plus the namespaced escalation
+ * block carrying the continuation handle. Emitting this (then `data: [DONE]`) lets a strict
+ * SDK close its loop with NO dangling JSON; a bridging service then continues the answer at
+ * the higher tier under the same `request_id` (§3.5 item 4).
+ */
+export function buildTruncationChunk(args: {
+  id: string;
+  created: number;
+  model: string;
+  signal: EscalationSignal;
+  resolvedTier: Tier;
+  nextContext: string;
+}): Record<string, unknown> {
+  return {
+    id: args.id,
+    object: 'chat.completion.chunk',
+    created: args.created,
+    model: args.model,
+    choices: [{ index: 0, delta: {}, finish_reason: args.signal.finishReason }],
+    x_cognitum: {
+      escalated: true,
+      resolved_tier: args.resolvedTier,
+      next_context: args.nextContext,
+      routing_reason: `inflight: ${args.signal.reason}`,
+    },
+  };
+}
+
+export interface InflightContext {
+  deps: AppDeps;
+  res: Response;
+  requestId: string;
+  body: ChatCompletionRequest;
+  resolution: TierResolution;
+  key: ApiKeyDoc;
+  keyPrefix: string;
+  startedAt: number;
+  scanner: InflightScanner;
+}
+
+/**
+ * Run the inflight (Option C′) streaming path with a PRESENT scanner. Streams the
+ * starting-tier answer while feeding every delta to the scanner; on an early signal it
+ * emits the SDK-safe truncation chunk and BRIDGES to the higher tier under the same
+ * request_id (§3.5 item 4, service-bridge variant). Billing follows §3.5: the delivered
+ * answer is billed at the escalated tier, and the discarded low-tier prefix is recorded
+ * honestly in `discarded_prefix_tokens` (the inflight signal MINIMIZES that prefix — the
+ * earlier the catch, the fewer tokens thrown away).
+ *
+ * This is the future-enabled path; today it is never reached (scanner is always null).
+ */
+export async function streamInflight(ctx: InflightContext): Promise<void> {
+  const { deps, res, requestId, body, resolution, key, keyPrefix, startedAt, scanner } = ctx;
+  const created = Math.floor(Date.now() / 1000);
+  const id = `chatcmpl-${requestId}`;
+  const writeChunk = (obj: unknown): void => {
+    res.write(`data: ${JSON.stringify(obj)}\n\n`);
+  };
+
+  const startTier = resolution.tier;
+  const startModel = deps.config.tierPools[startTier].models[0];
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('X-Request-Id', requestId);
+
+  // Family-correct progressive counters (§5.1): one for the discarded low-tier prefix, one
+  // for whatever tier ultimately delivers the billed answer.
+  const prefixCounter = makeCounter(startModel, startTier);
+
+  // Truncation/disconnect guard (§5.1): a dropped TCP connection before [DONE] still bills
+  // the prefix generated so far (truncated:true) rather than losing the usage.
+  let finalized = false;
+  res.on('close', () => {
+    if (finalized) return;
+    finalized = true;
+    const completion = prefixCounter.completionTokens();
+    const promptFloor = body.messages.reduce(
+      (n, m) => n + estimatePrompt(startModel, m.content ?? ''),
+      0,
+    );
+    const usage = {
+      prompt_tokens: promptFloor,
+      completion_tokens: completion,
+      total_tokens: promptFloor + completion,
+    };
+    void meter(deps, {
+      requestId,
+      key,
+      keyPrefix,
+      tier: startTier,
+      resolvedModel: startModel,
+      usage,
+      priceUsd: priceUsd(deps.config, startTier, usage),
+      escalated: false,
+      latencyMs: Date.now() - startedAt,
+      tokensFromLocalFloor: true,
+      truncated: true,
+    });
+  });
+
+  // --- Stream the starting tier, scanning each delta for an early failure signal. ---
+  let signal: EscalationSignal | null = null;
+  for await (const delta of deps.provider.stream(startModel, body)) {
+    if (finalized) return; // client disconnected → close handler already billed (truncated)
+    if (delta.content) {
+      prefixCounter.pushDelta(delta.content);
+      signal = scanner.push(delta.content);
+    }
+    writeChunk({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: body.model,
+      choices: [
+        {
+          index: 0,
+          delta: delta.content ? { content: delta.content } : {},
+          finish_reason: delta.finishReason ?? null,
+        },
+      ],
+    });
+    if (signal) break; // early failure → stop the low-tier stream and hand off
+  }
+  if (finalized) return;
+
+  const target = signal ? escalateTarget(startTier, resolution.ceiling) : null;
+
+  // No signal (or already at the ceiling) → finish like Option B at the starting tier.
+  if (!signal || !target) {
+    finishAtTier(ctx, {
+      id,
+      created,
+      tier: startTier,
+      model: startModel,
+      completionTokens: prefixCounter.completionTokens(),
+      escalated: false,
+      routingReason: resolution.routingReason,
+      discardedPrefixTokens: undefined,
+    });
+    finalized = true;
+    return;
+  }
+
+  // --- SDK-safe truncation handoff + higher-tier continuation (§3.5 items 3–4). ---
+  const targetModel = deps.config.tierPools[target].models[0];
+  const nextContext = `${requestId}:${target}`;
+  writeChunk(
+    buildTruncationChunk({ id, created, model: body.model, signal, resolvedTier: target, nextContext }),
+  );
+
+  const contCounter = makeCounter(targetModel, target);
+  for await (const delta of deps.provider.stream(targetModel, body)) {
+    if (finalized) return; // client disconnected during continuation → close handler billed
+    if (delta.content) contCounter.pushDelta(delta.content);
+    writeChunk({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: body.model,
+      choices: [
+        {
+          index: 0,
+          delta: delta.content ? { content: delta.content } : {},
+          finish_reason: delta.finishReason ?? null,
+        },
+      ],
+    });
+  }
+  if (finalized) return;
+
+  finishAtTier(ctx, {
+    id,
+    created,
+    tier: target,
+    model: targetModel,
+    completionTokens: contCounter.completionTokens(),
+    escalated: true,
+    routingReason: `${resolution.routingReason}; inflight ${startTier}->${target}: ${signal.reason}`,
+    discardedPrefixTokens: prefixCounter.completionTokens(),
+  });
+  finalized = true;
+}
+
+/** Prompt-token floor for one message, family-correct for the resolved model (§5.1). */
+function estimatePrompt(model: string, content: string): number {
+  return makeCounterPrompt(model, content);
+}
+
+/** Tiny wrapper so the prompt floor reuses the SAME family ratio as the delta counter. */
+function makeCounterPrompt(model: string, content: string): number {
+  const c = makeCounter(model, 'low');
+  c.pushDelta(content);
+  return c.completionTokens();
+}
+
+/** Emit the final usage + x_cognitum trailing chunk, send [DONE], end, and meter the row. */
+function finishAtTier(
+  ctx: InflightContext,
+  f: {
+    id: string;
+    created: number;
+    tier: Tier;
+    model: string;
+    completionTokens: number;
+    escalated: boolean;
+    routingReason: string;
+    discardedPrefixTokens?: number;
+  },
+): void {
+  const { deps, res, requestId, body, resolution, key, keyPrefix, startedAt } = ctx;
+  const promptTokens = body.messages.reduce(
+    (n, m) => n + estimatePrompt(f.model, m.content ?? ''),
+    0,
+  );
+  const usage = {
+    prompt_tokens: promptTokens,
+    completion_tokens: f.completionTokens,
+    total_tokens: promptTokens + f.completionTokens,
+  };
+  const price = priceUsd(deps.config, f.tier, usage);
+  res.write(
+    `data: ${JSON.stringify({
+      id: f.id,
+      object: 'chat.completion.chunk',
+      created: f.created,
+      model: body.model,
+      choices: [],
+      usage,
+      x_cognitum: {
+        request_id: requestId,
+        resolved_tier: f.tier,
+        resolved_model: f.model,
+        escalated: f.escalated,
+        cap_degraded: resolution.capDegraded,
+        routing_reason: f.routingReason,
+        price_usd: price,
+        ...(f.discardedPrefixTokens !== undefined
+          ? { discarded_prefix_tokens: f.discardedPrefixTokens }
+          : {}),
+      },
+    })}\n\n`,
+  );
+  res.write('data: [DONE]\n\n');
+  res.end();
+
+  void meter(deps, {
+    requestId,
+    key,
+    keyPrefix,
+    tier: f.tier,
+    resolvedModel: f.model,
+    usage,
+    priceUsd: price,
+    escalated: f.escalated,
+    latencyMs: Date.now() - startedAt,
+    tokensFromLocalFloor: true,
+    discardedPrefixTokens: f.discardedPrefixTokens,
+  });
+}

--- a/services/apicompletions/src/providers/mockProvider.ts
+++ b/services/apicompletions/src/providers/mockProvider.ts
@@ -1,0 +1,18 @@
+// Canned mock provider (ADR-203 §7.3) — emulator-first $0 dev. Exercises the whole
+// auth → tier → route → meter → bill loop offline with a deterministic token stream.
+import type { ChatCompletionRequest } from '../types/openai';
+import type { ModelProvider, ProviderDelta, ProviderResult } from './types';
+
+export class MockProvider implements ModelProvider {
+  readonly name = 'mock';
+
+  async complete(_model: string, _req: ChatCompletionRequest): Promise<ProviderResult> {
+    // TODO(impl): return a canned answer + synthetic usage.
+    throw new Error('not implemented: MockProvider.complete (ADR-203 §7.3)');
+  }
+
+  async *stream(_model: string, _req: ChatCompletionRequest): AsyncIterable<ProviderDelta> {
+    // TODO(impl): yield canned deltas, then a terminal chunk.
+    throw new Error('not implemented: MockProvider.stream (ADR-203 §7.3)');
+  }
+}

--- a/services/apicompletions/src/providers/mockProvider.ts
+++ b/services/apicompletions/src/providers/mockProvider.ts
@@ -1,18 +1,75 @@
 // Canned mock provider (ADR-203 §7.3) — emulator-first $0 dev. Exercises the whole
-// auth → tier → route → meter → bill loop offline with a deterministic token stream.
+// auth → tier → route → meter → bill loop offline with a DETERMINISTIC token stream:
+// no network, no spend, repeatable. The mock also models the realistic escalation case
+// — a cheap-tier model returning a hedged answer to a request that looked easy — so the
+// §6.5 post-gen τ escalation path is testable without a real provider.
 import type { ChatCompletionRequest } from '../types/openai';
 import type { ModelProvider, ProviderDelta, ProviderResult } from './types';
+
+/** Models in the low tier pool (config seed); the mock hedges here on sentinel prompts. */
+const LOW_POOL = new Set(['deepseek-v4-pro', 'glm-5.2']);
+
+function lastUserContent(req: ChatCompletionRequest): string {
+  for (let i = req.messages.length - 1; i >= 0; i--) {
+    if (req.messages[i].role === 'user') return req.messages[i].content ?? '';
+  }
+  return req.messages[req.messages.length - 1]?.content ?? '';
+}
+
+/** ~chars/4 token estimate — the mock's synthetic count (real providers send authoritative usage). */
+function approxTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.length / 4));
+}
+
+function promptTokens(req: ChatCompletionRequest): number {
+  return req.messages.reduce((n, m) => n + approxTokens(m.content ?? ''), 0);
+}
+
+/**
+ * Build the canned answer for (model, request). A low-pool model facing a prompt that
+ * contains the `tricky` sentinel returns a deliberately hedged answer (low confidence →
+ * τ fires → escalation); every other case returns a confident answer.
+ */
+function cannedAnswer(model: string, req: ChatCompletionRequest): { text: string; confidence: number } {
+  const user = lastUserContent(req);
+  const hedge = LOW_POOL.has(model) && /\btricky\b/i.test(user);
+  if (hedge) {
+    return {
+      text: "I'm not entirely sure, but it might be one of a few possibilities.",
+      confidence: 0.4,
+    };
+  }
+  return {
+    text: `mock(${model}): ${user.slice(0, 120)}`.trim(),
+    confidence: 0.9,
+  };
+}
 
 export class MockProvider implements ModelProvider {
   readonly name = 'mock';
 
-  async complete(_model: string, _req: ChatCompletionRequest): Promise<ProviderResult> {
-    // TODO(impl): return a canned answer + synthetic usage.
-    throw new Error('not implemented: MockProvider.complete (ADR-203 §7.3)');
+  async complete(model: string, req: ChatCompletionRequest): Promise<ProviderResult> {
+    const { text, confidence } = cannedAnswer(model, req);
+    const prompt = promptTokens(req);
+    const completion = approxTokens(text);
+    return {
+      text,
+      confidence,
+      usage: {
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        total_tokens: prompt + completion,
+      },
+    };
   }
 
-  async *stream(_model: string, _req: ChatCompletionRequest): AsyncIterable<ProviderDelta> {
-    // TODO(impl): yield canned deltas, then a terminal chunk.
-    throw new Error('not implemented: MockProvider.stream (ADR-203 §7.3)');
+  async *stream(model: string, req: ChatCompletionRequest): AsyncIterable<ProviderDelta> {
+    const { text } = cannedAnswer(model, req);
+    // Split into word-sized deltas so the SSE path is exercised like a real token stream.
+    const parts = text.match(/\S+\s*/g) ?? [text];
+    for (const part of parts) {
+      yield { content: part, finishReason: null };
+    }
+    yield { content: '', finishReason: 'stop' };
   }
 }

--- a/services/apicompletions/src/providers/openrouter.ts
+++ b/services/apicompletions/src/providers/openrouter.ts
@@ -1,19 +1,73 @@
 // OpenRouter / direct provider (ADR-203 §3.1 step e). Key bound via Secret Manager
 // (OPENROUTER_API_KEY, §7.1), never forwarded to clients, never logged. Only a
-// deliberate, budgeted smoke test ever hits a real provider.
+// deliberate, budgeted smoke test ever hits a real provider — tests use the MockProvider.
+//
+// Uses Node 20's built-in global fetch (no node-fetch import needed; sidesteps the
+// ESM/CommonJS interop with node-fetch v3 under tsc module=commonjs).
 import type { ChatCompletionRequest } from '../types/openai';
-import type { ModelProvider, ProviderDelta, ProviderResult } from './types';
+import { type ModelProvider, type ProviderDelta, type ProviderResult, ProviderError } from './types';
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+
+interface OpenRouterChoice {
+  message?: { content?: string };
+  text?: string;
+}
+interface OpenRouterResponse {
+  choices?: OpenRouterChoice[];
+  usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+}
 
 export class OpenRouterProvider implements ModelProvider {
   readonly name = 'openrouter';
 
-  constructor(private readonly apiKey: string) {}
+  constructor(
+    private readonly apiKey: string,
+    private readonly baseUrl: string = OPENROUTER_URL,
+  ) {}
 
-  async complete(_model: string, _req: ChatCompletionRequest): Promise<ProviderResult> {
-    throw new Error('not implemented: OpenRouterProvider.complete (ADR-203 §3.1e)');
+  async complete(model: string, req: ChatCompletionRequest): Promise<ProviderResult> {
+    const res = await fetch(this.baseUrl, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model,
+        messages: req.messages,
+        temperature: req.temperature,
+        top_p: req.top_p,
+        max_tokens: req.max_tokens,
+        stop: req.stop,
+        stream: false,
+      }),
+    });
+    if (!res.ok) {
+      throw new ProviderError(`openrouter ${model} → HTTP ${res.status}`, [model]);
+    }
+    const data = (await res.json()) as OpenRouterResponse;
+    const choice = data.choices?.[0];
+    const text = choice?.message?.content ?? choice?.text ?? '';
+    const usage = data.usage
+      ? {
+          prompt_tokens: data.usage.prompt_tokens ?? 0,
+          completion_tokens: data.usage.completion_tokens ?? 0,
+          total_tokens:
+            data.usage.total_tokens ??
+            (data.usage.prompt_tokens ?? 0) + (data.usage.completion_tokens ?? 0),
+        }
+      : undefined;
+    return { text, usage };
   }
 
-  async *stream(_model: string, _req: ChatCompletionRequest): AsyncIterable<ProviderDelta> {
-    throw new Error('not implemented: OpenRouterProvider.stream (ADR-203 §3.1e)');
+  // True token-level streaming is deferred to the streaming phase (§3.3 stream_oneshot).
+  // For now the streaming surface is served by buffering complete() and emitting it as a
+  // single delta, so the SSE contract holds even against a real provider without a
+  // bespoke SSE parser. The mock provider yields real word-sized deltas for tests.
+  async *stream(model: string, req: ChatCompletionRequest): AsyncIterable<ProviderDelta> {
+    const result = await this.complete(model, req);
+    yield { content: result.text, finishReason: null };
+    yield { content: '', finishReason: 'stop' };
   }
 }

--- a/services/apicompletions/src/providers/openrouter.ts
+++ b/services/apicompletions/src/providers/openrouter.ts
@@ -1,0 +1,19 @@
+// OpenRouter / direct provider (ADR-203 §3.1 step e). Key bound via Secret Manager
+// (OPENROUTER_API_KEY, §7.1), never forwarded to clients, never logged. Only a
+// deliberate, budgeted smoke test ever hits a real provider.
+import type { ChatCompletionRequest } from '../types/openai';
+import type { ModelProvider, ProviderDelta, ProviderResult } from './types';
+
+export class OpenRouterProvider implements ModelProvider {
+  readonly name = 'openrouter';
+
+  constructor(private readonly apiKey: string) {}
+
+  async complete(_model: string, _req: ChatCompletionRequest): Promise<ProviderResult> {
+    throw new Error('not implemented: OpenRouterProvider.complete (ADR-203 §3.1e)');
+  }
+
+  async *stream(_model: string, _req: ChatCompletionRequest): AsyncIterable<ProviderDelta> {
+    throw new Error('not implemented: OpenRouterProvider.stream (ADR-203 §3.1e)');
+  }
+}

--- a/services/apicompletions/src/providers/types.ts
+++ b/services/apicompletions/src/providers/types.ts
@@ -11,6 +11,8 @@ export interface ProviderDelta {
 export interface ProviderResult {
   text: string;
   usage?: Usage; // provider's authoritative count when present (§5.1)
+  /** Optional self-confidence in [0,1]; when present it pre-empts the heuristic verifier (§6.5). */
+  confidence?: number;
 }
 
 export interface ModelProvider {
@@ -19,4 +21,15 @@ export interface ModelProvider {
   complete(model: string, req: ChatCompletionRequest): Promise<ProviderResult>;
   /** Streaming completion — async iterator of deltas (mapped to OpenAI SSE upstream). */
   stream(model: string, req: ChatCompletionRequest): AsyncIterable<ProviderDelta>;
+}
+
+/** Thrown when every model in a tier's fallback chain fails (§3.2). Maps to 502 upstream. */
+export class ProviderError extends Error {
+  constructor(
+    message: string,
+    readonly attempted: string[],
+  ) {
+    super(message);
+    this.name = 'ProviderError';
+  }
 }

--- a/services/apicompletions/src/providers/types.ts
+++ b/services/apicompletions/src/providers/types.ts
@@ -1,0 +1,22 @@
+// Model provider abstraction (ADR-203 §3.2, §3.5). A provider serves one resolved model;
+// the per-tier fallback chain (commit de512bd) fails over WITHIN a tier on 5xx/timeout
+// without silently changing the billed tier.
+import type { ChatCompletionRequest, Usage } from '../types/openai';
+
+export interface ProviderDelta {
+  content: string;
+  finishReason?: string | null;
+}
+
+export interface ProviderResult {
+  text: string;
+  usage?: Usage; // provider's authoritative count when present (§5.1)
+}
+
+export interface ModelProvider {
+  readonly name: string;
+  /** Non-streaming completion. */
+  complete(model: string, req: ChatCompletionRequest): Promise<ProviderResult>;
+  /** Streaming completion — async iterator of deltas (mapped to OpenAI SSE upstream). */
+  stream(model: string, req: ChatCompletionRequest): AsyncIterable<ProviderDelta>;
+}

--- a/services/apicompletions/src/ratelimit/idempotency.ts
+++ b/services/apicompletions/src/ratelimit/idempotency.ts
@@ -1,0 +1,19 @@
+// Idempotency (ADR-203 §5.3). Optional Idempotency-Key header → idempotency/{key} doc
+// caching the response + status for 24h. Replays return the stored result and are NOT
+// re-billed. Critical for streaming retries.
+import type { ChatCompletionResponse } from '../types/openai';
+
+export interface CachedResponse {
+  status: number;
+  body: ChatCompletionResponse;
+}
+
+/** TODO(impl): lookup idempotency/{key}. */
+export async function lookup(_key: string): Promise<CachedResponse | null> {
+  throw new Error('not implemented: idempotency.lookup (ADR-203 §5.3)');
+}
+
+/** TODO(impl): store with a 24h TTL. */
+export async function store(_key: string, _resp: CachedResponse): Promise<void> {
+  throw new Error('not implemented: idempotency.store (ADR-203 §5.3)');
+}

--- a/services/apicompletions/src/ratelimit/idempotency.ts
+++ b/services/apicompletions/src/ratelimit/idempotency.ts
@@ -1,19 +1,71 @@
 // Idempotency (ADR-203 §5.3). Optional Idempotency-Key header → idempotency/{key} doc
 // caching the response + status for 24h. Replays return the stored result and are NOT
-// re-billed. Critical for streaming retries.
+// re-billed (the route short-circuits before rate-limit + metering). Critical for
+// streaming retries. DI'd behind a store interface like the rest of the metering surface.
 import type { ChatCompletionResponse } from '../types/openai';
+import type { FirestoreLike } from '../firestore/client';
 
 export interface CachedResponse {
   status: number;
   body: ChatCompletionResponse;
 }
 
-/** TODO(impl): lookup idempotency/{key}. */
-export async function lookup(_key: string): Promise<CachedResponse | null> {
-  throw new Error('not implemented: idempotency.lookup (ADR-203 §5.3)');
+/** 24h cache window (§5.3). */
+export const IDEMPOTENCY_TTL_MS = 24 * 60 * 60 * 1000;
+
+export interface IdempotencyStore {
+  lookup(key: string): Promise<CachedResponse | null>;
+  store(key: string, resp: CachedResponse): Promise<void>;
 }
 
-/** TODO(impl): store with a 24h TTL. */
-export async function store(_key: string, _resp: CachedResponse): Promise<void> {
-  throw new Error('not implemented: idempotency.store (ADR-203 §5.3)');
+interface Entry {
+  resp: CachedResponse;
+  expireAt: number;
+}
+
+/** $0 emulator-first / test idempotency store with a 24h TTL. */
+export class InMemoryIdempotencyStore implements IdempotencyStore {
+  private readonly byKey = new Map<string, Entry>();
+
+  async lookup(key: string): Promise<CachedResponse | null> {
+    const e = this.byKey.get(key);
+    if (!e) return null;
+    if (e.expireAt <= Date.now()) {
+      this.byKey.delete(key);
+      return null;
+    }
+    // Return a deep-ish clone so callers can't mutate the cached row.
+    return { status: e.resp.status, body: { ...e.resp.body } };
+  }
+
+  async store(key: string, resp: CachedResponse): Promise<void> {
+    this.byKey.set(key, {
+      resp: { status: resp.status, body: { ...resp.body } },
+      expireAt: Date.now() + IDEMPOTENCY_TTL_MS,
+    });
+  }
+}
+
+/**
+ * Production idempotency — idempotency/{key} via firebase-admin (structurally typed,
+ * SDK deferred). `expireAt` carries the Firestore TTL-policy field for the 24h reap.
+ */
+export class FirestoreIdempotencyStore implements IdempotencyStore {
+  constructor(private readonly db: FirestoreLike) {}
+
+  async lookup(key: string): Promise<CachedResponse | null> {
+    const snap = await this.db.collection('idempotency').doc(key).get();
+    if (!snap.exists) return null;
+    const data = snap.data();
+    if (!data) return null;
+    if (typeof data.expireAt === 'number' && data.expireAt <= Date.now()) return null;
+    return { status: data.status as number, body: data.body as ChatCompletionResponse };
+  }
+
+  async store(key: string, resp: CachedResponse): Promise<void> {
+    await this.db
+      .collection('idempotency')
+      .doc(key)
+      .set({ status: resp.status, body: resp.body, expireAt: Date.now() + IDEMPOTENCY_TTL_MS });
+  }
 }

--- a/services/apicompletions/src/ratelimit/idempotency.ts
+++ b/services/apicompletions/src/ratelimit/idempotency.ts
@@ -2,12 +2,19 @@
 // caching the response + status for 24h. Replays return the stored result and are NOT
 // re-billed (the route short-circuits before rate-limit + metering). Critical for
 // streaming retries. DI'd behind a store interface like the rest of the metering surface.
-import type { ChatCompletionResponse } from '../types/openai';
 import type { FirestoreLike } from '../firestore/client';
+
+/**
+ * Cached body — a serialized JSON response object. Broadened from the OpenAI response shape to
+ * a generic JSON record so the SAME cache serves both /v1/chat/completions (ChatCompletionResponse)
+ * and /v1/messages (AnthropicMessageResponse); the value is only ever re-serialized, never read
+ * field-by-field, so the concrete shape does not matter here.
+ */
+export type CachedBody = object;
 
 export interface CachedResponse {
   status: number;
-  body: ChatCompletionResponse;
+  body: CachedBody;
 }
 
 /** 24h cache window (§5.3). */
@@ -59,7 +66,7 @@ export class FirestoreIdempotencyStore implements IdempotencyStore {
     const data = snap.data();
     if (!data) return null;
     if (typeof data.expireAt === 'number' && data.expireAt <= Date.now()) return null;
-    return { status: data.status as number, body: data.body as ChatCompletionResponse };
+    return { status: data.status as number, body: data.body as CachedBody };
   }
 
   async store(key: string, resp: CachedResponse): Promise<void> {

--- a/services/apicompletions/src/ratelimit/limiter.ts
+++ b/services/apicompletions/src/ratelimit/limiter.ts
@@ -5,19 +5,161 @@
 // per-instance Map bug) without a hot-spot.
 // Cost guards (§5.3): instance-local ≈500ms–1s debounce on the per-key COUNT +
 // 1-minute bucketed ticks. Memorystore is the at-scale option (not the serverless default).
+import { randomBytes } from 'crypto';
 import type { Tier } from '../types/openai';
+import type { FirestoreLike } from '../firestore/client';
 
 export interface RateDecision {
   allowed: boolean;
-  /** When false, the 429 retry hint. */
+  /** Observed window count at decision time (post-debounce). */
+  count: number;
+  /** When false, the 429 retry hint (ms). */
   retryAfterMs?: number;
 }
 
-/** TODO(impl): append a TTL'd tick, then COUNT() the window (debounced). */
-export async function checkAndRecord(
-  _keyHash: string,
-  _tier: Tier,
-  _limitPerMin: number,
-): Promise<RateDecision> {
-  throw new Error('not implemented: checkAndRecord (ADR-203 §5.3)');
+/** One append-only tick. `bucketMinute` groups ticks into 1-minute docs (§5.3 bucketing). */
+export interface UsageTick {
+  tier: Tier;
+  ts: number;
+  bucketMinute: number;
+  /** Absolute epoch-ms at which Firestore's TTL policy reaps the tick. */
+  expireAt: number;
+}
+
+/**
+ * The tick store: append-only writes + a COUNT() window scan. Production binds Firestore
+ * subcollections + an aggregation query; tests/emulators use the in-memory fake. The
+ * window is GLOBAL across instances (the §5.3 fix for the per-instance `Map` bug).
+ */
+export interface RateLimitStore {
+  appendTick(keyHash: string, tick: UsageTick): Promise<void>;
+  /** COUNT() of this key's ticks for `tier` with `ts >= sinceMs`. */
+  countWindow(keyHash: string, tier: Tier, sinceMs: number): Promise<number>;
+}
+
+const MINUTE_MS = 60_000;
+function tickId(bucketMinute: number): string {
+  return `${bucketMinute}-${randomBytes(8).toString('hex')}`;
+}
+
+/** $0 emulator-first / test tick store. Reaps expired ticks lazily on each count. */
+export class InMemoryRateLimitStore implements RateLimitStore {
+  private readonly byKey = new Map<string, UsageTick[]>();
+
+  async appendTick(keyHash: string, tick: UsageTick): Promise<void> {
+    const arr = this.byKey.get(keyHash) ?? [];
+    arr.push(tick);
+    this.byKey.set(keyHash, arr);
+  }
+
+  async countWindow(keyHash: string, tier: Tier, sinceMs: number): Promise<number> {
+    const now = Date.now();
+    const arr = this.byKey.get(keyHash);
+    if (!arr) return 0;
+    // Reap TTL-expired ticks (mirrors Firestore's TTL policy auto-reap).
+    const live = arr.filter((t) => t.expireAt > now);
+    if (live.length !== arr.length) this.byKey.set(keyHash, live);
+    return live.reduce((n, t) => (t.tier === tier && t.ts >= sinceMs ? n + 1 : n), 0);
+  }
+}
+
+/**
+ * Production tick store — append-only subcollection creates + a Firestore COUNT()
+ * aggregation over the window. Subcollection creates avoid the single-doc transactional
+ * counter hot-spot (§5.3); `expireAt` carries the Firestore TTL-policy field.
+ */
+export class FirestoreRateLimitStore implements RateLimitStore {
+  constructor(private readonly db: FirestoreLike) {}
+
+  async appendTick(keyHash: string, tick: UsageTick): Promise<void> {
+    await this.db
+      .collection('api_keys')
+      .doc(keyHash)
+      .collection('usage_ticks')
+      .doc(tickId(tick.bucketMinute))
+      .set({ ...tick });
+  }
+
+  async countWindow(keyHash: string, tier: Tier, sinceMs: number): Promise<number> {
+    const snap = await this.db
+      .collection('api_keys')
+      .doc(keyHash)
+      .collection('usage_ticks')
+      .where('tier', '==', tier)
+      .where('ts', '>=', sinceMs)
+      .count()
+      .get();
+    return snap.data().count;
+  }
+}
+
+export interface RateLimiterOptions {
+  /** Sliding window (default 60s — per-minute limits, §4.2). */
+  windowMs?: number;
+  /** Instance-local COUNT() debounce TTL (≈500ms–1s, §5.3). Soft over-admit within it. */
+  debounceMs?: number;
+}
+
+interface CacheEntry {
+  count: number;
+  fetchedAt: number;
+}
+
+/**
+ * Scatter-gather rate limiter (§5.3). Per (keyHash, tier): append a TTL'd tick, COUNT() the
+ * window, compare to the per-tier limit. A short instance-local debounce cache bounds
+ * aggregation reads to ~1–2/sec/instance/key regardless of request rate. The debounce makes
+ * the limiter intentionally SOFT — a burst arriving inside the cache TTL is admitted against
+ * a stale (optimistically-incremented) count; this bounded over-admission is the documented
+ * §5.3 cost/latency trade and is absorbed by the per-tier burst allowance (§4.2).
+ */
+export class RateLimiter {
+  private readonly windowMs: number;
+  private readonly debounceMs: number;
+  private readonly cache = new Map<string, CacheEntry>();
+
+  constructor(
+    private readonly store: RateLimitStore,
+    opts: RateLimiterOptions = {},
+  ) {
+    this.windowMs = opts.windowMs ?? MINUTE_MS;
+    this.debounceMs = opts.debounceMs ?? 1_000;
+  }
+
+  async checkAndRecord(keyHash: string, tier: Tier, limitPerMin: number): Promise<RateDecision> {
+    const now = Date.now();
+    const cacheKey = `${keyHash}:${tier}`;
+    const sinceMs = now - this.windowMs;
+
+    // 1. Resolve the window count — debounced to the instance-local cache when fresh.
+    const cached = this.cache.get(cacheKey);
+    let count: number;
+    if (cached && now - cached.fetchedAt < this.debounceMs) {
+      count = cached.count;
+    } else {
+      count = await this.store.countWindow(keyHash, tier, sinceMs);
+      this.cache.set(cacheKey, { count, fetchedAt: now });
+    }
+
+    // 2. Enforce the per-tier limit.
+    if (limitPerMin > 0 && count >= limitPerMin) {
+      // Spacing at the limit is a cheap, monotone retry hint (no extra read for oldest tick).
+      const retryAfterMs = Math.min(this.windowMs, Math.ceil(this.windowMs / limitPerMin));
+      return { allowed: false, count, retryAfterMs };
+    }
+
+    // 3. Admit: append the tick (global, append-only) + optimistically bump the cached count.
+    const bucketMinute = Math.floor(now / MINUTE_MS);
+    await this.store.appendTick(keyHash, {
+      tier,
+      ts: now,
+      bucketMinute,
+      expireAt: now + this.windowMs,
+    });
+    const entry = this.cache.get(cacheKey);
+    if (entry) entry.count += 1;
+    else this.cache.set(cacheKey, { count: count + 1, fetchedAt: now });
+
+    return { allowed: true, count: count + 1 };
+  }
 }

--- a/services/apicompletions/src/ratelimit/limiter.ts
+++ b/services/apicompletions/src/ratelimit/limiter.ts
@@ -1,0 +1,23 @@
+// Rate limit / quota — scatter-gather, append-only (ADR-203 §5.3).
+// NOT a single-doc transactional counter (would hit Firestore's ~1 write/sec/doc wall).
+// Each request writes an ephemeral TTL'd tick api_keys/{keyHash}/usage_ticks/{tickId};
+// the check is a COUNT() aggregation over the window. GLOBAL (fixes sec-review §1
+// per-instance Map bug) without a hot-spot.
+// Cost guards (§5.3): instance-local ≈500ms–1s debounce on the per-key COUNT +
+// 1-minute bucketed ticks. Memorystore is the at-scale option (not the serverless default).
+import type { Tier } from '../types/openai';
+
+export interface RateDecision {
+  allowed: boolean;
+  /** When false, the 429 retry hint. */
+  retryAfterMs?: number;
+}
+
+/** TODO(impl): append a TTL'd tick, then COUNT() the window (debounced). */
+export async function checkAndRecord(
+  _keyHash: string,
+  _tier: Tier,
+  _limitPerMin: number,
+): Promise<RateDecision> {
+  throw new Error('not implemented: checkAndRecord (ADR-203 §5.3)');
+}

--- a/services/apicompletions/src/router/difficulty.ts
+++ b/services/apicompletions/src/router/difficulty.ts
@@ -1,0 +1,15 @@
+// Intrinsic difficulty signal (ADR-203 §3.3, PLACEMENT §7). Heuristic, NOT a trained
+// head — prompt length, code/diff presence, reasoning markers, max_tokens, tool use.
+// Applied at REQUEST granularity to pick the starting (and, for streams, the only) tier.
+import type { ChatCompletionRequest, Tier } from '../types/openai';
+
+export interface DifficultySignal {
+  tier: Tier;
+  score: number;
+  reason: string;
+}
+
+/** TODO(impl): compute intrinsic signal from the request alone (no oracle, §8 firewall). */
+export function computeDifficulty(_req: ChatCompletionRequest): DifficultySignal {
+  throw new Error('not implemented: computeDifficulty (ADR-203 §3.3)');
+}

--- a/services/apicompletions/src/router/difficulty.ts
+++ b/services/apicompletions/src/router/difficulty.ts
@@ -1,6 +1,7 @@
 // Intrinsic difficulty signal (ADR-203 §3.3, PLACEMENT §7). Heuristic, NOT a trained
 // head — prompt length, code/diff presence, reasoning markers, max_tokens, tool use.
 // Applied at REQUEST granularity to pick the starting (and, for streams, the only) tier.
+// The signal is INTRINSIC to the request (no oracle, §8 conformance firewall).
 import type { ChatCompletionRequest, Tier } from '../types/openai';
 
 export interface DifficultySignal {
@@ -9,7 +10,60 @@ export interface DifficultySignal {
   reason: string;
 }
 
-/** TODO(impl): compute intrinsic signal from the request alone (no oracle, §8 firewall). */
-export function computeDifficulty(_req: ChatCompletionRequest): DifficultySignal {
-  throw new Error('not implemented: computeDifficulty (ADR-203 §3.3)');
+const CODE_MARKERS = /```|diff --git|^[+-]{3}\s|\bfunction\b|\bclass\b|\bimport\b|\bSELECT\b|=>/m;
+const REASONING_MARKERS =
+  /\b(prove|derive|explain why|step[- ]by[- ]step|reason through|analy[sz]e|design|architect|algorithm|complexity|refactor|debug|optimi[sz]e|trade-?off)\b/i;
+
+function totalChars(req: ChatCompletionRequest): number {
+  return req.messages.reduce((n, m) => n + (m.content?.length ?? 0), 0);
+}
+
+/**
+ * Compute the intrinsic signal from the request alone. Additive scoring → tier:
+ *   score >= 4 → high · score >= 2 → mid · else low.
+ */
+export function computeDifficulty(req: ChatCompletionRequest): DifficultySignal {
+  const chars = totalChars(req);
+  const joined = req.messages.map((m) => m.content ?? '').join('\n');
+  const fired: string[] = [];
+  let score = 0;
+
+  if (chars > 4000) {
+    score += 2;
+    fired.push('long_prompt');
+  } else if (chars > 1200) {
+    score += 1;
+    fired.push('medium_prompt');
+  }
+
+  if (CODE_MARKERS.test(joined)) {
+    score += 2;
+    fired.push('code/diff');
+  }
+
+  if (REASONING_MARKERS.test(joined)) {
+    score += 1;
+    fired.push('reasoning_markers');
+  }
+
+  const maxTokens = req.max_tokens ?? 0;
+  if (maxTokens > 4000) {
+    score += 2;
+    fired.push('large_max_tokens');
+  } else if (maxTokens > 1500) {
+    score += 1;
+    fired.push('moderate_max_tokens');
+  }
+
+  if (Array.isArray(req.tools) && req.tools.length > 0) {
+    score += 1;
+    fired.push('tool_use');
+  }
+
+  const tier: Tier = score >= 4 ? 'high' : score >= 2 ? 'mid' : 'low';
+  const reason =
+    fired.length > 0
+      ? `difficulty=${tier} (score=${score}: ${fired.join(',')})`
+      : `difficulty=${tier} (score=0: everyday)`;
+  return { tier, score, reason };
 }

--- a/services/apicompletions/src/router/escalation.ts
+++ b/services/apicompletions/src/router/escalation.ts
@@ -1,0 +1,27 @@
+// Confidence-driven escalation (ADR-203 §3.3, §6.5) — NON-STREAMING (post_hoc) only.
+// τ is internal + adaptive, MetaHarness-owned, never a public input. Streams route once
+// up front (stream_oneshot) on the input signal; they do NOT run post-gen escalation.
+import type { Tier } from '../types/openai';
+
+export interface VerifierResult {
+  /** Internal self-confidence in [0,1]; compared against the internal adaptive τ. */
+  confidence: number;
+}
+
+export interface EscalationDecision {
+  escalate: boolean;
+  nextTier?: Tier;
+  reason: string;
+}
+
+/**
+ * Decide whether a buffered low/mid answer should be re-answered once at the next tier.
+ * Capped by the key's scopes and the request's max_tier. TODO(impl).
+ */
+export function shouldEscalate(
+  _result: VerifierResult,
+  _currentTier: Tier,
+  _maxTier: Tier,
+): EscalationDecision {
+  throw new Error('not implemented: shouldEscalate (ADR-203 §6.5)');
+}

--- a/services/apicompletions/src/router/escalation.ts
+++ b/services/apicompletions/src/router/escalation.ts
@@ -1,11 +1,13 @@
 // Confidence-driven escalation (ADR-203 §3.3, §6.5) — NON-STREAMING (post_hoc) only.
-// τ is internal + adaptive, MetaHarness-owned, never a public input. Streams route once
+// τ is INTERNAL + adaptive, MetaHarness-owned, NEVER a public input. Streams route once
 // up front (stream_oneshot) on the input signal; they do NOT run post-gen escalation.
 import type { Tier } from '../types/openai';
+import { nextTierUp, tierRank } from '../tier/resolveTier';
 
 export interface VerifierResult {
   /** Internal self-confidence in [0,1]; compared against the internal adaptive τ. */
   confidence: number;
+  reason?: string;
 }
 
 export interface EscalationDecision {
@@ -15,13 +17,55 @@ export interface EscalationDecision {
 }
 
 /**
+ * Internal, adaptive escalation threshold τ (§6.5). It is calibrated from
+ * usage_ledger / PLACEMENT data so the cheap tier absorbs everyday work and only the
+ * genuinely hard tail escalates. It is deliberately NOT exposed in the public contract
+ * (a raw float would leak an internal mechanism, be un-retunable as the pool swaps, and
+ * be gameable). The constant below is the heuristic seed of that learned threshold; the
+ * `max_tier` / `min_tier` semantic controls are what clients actually steer with.
+ */
+const TAU = 0.6;
+
+const HEDGE_RE =
+  /\b(i'?m not (entirely |really )?sure|i can'?t be certain|not confident|unclear|i don'?t know|cannot determine|might be wrong|hard to say)\b/i;
+
+/**
+ * Heuristic verifier self-confidence over a buffered (non-stream) answer.
+ * NOT a learned head — it flags hedging language and pathologically short answers.
+ * The provider's own confidence signal (when present) takes precedence.
+ */
+export function verify(text: string, providerConfidence?: number): VerifierResult {
+  if (typeof providerConfidence === 'number') {
+    return { confidence: providerConfidence, reason: 'provider_confidence' };
+  }
+  const trimmed = text.trim();
+  if (HEDGE_RE.test(trimmed)) return { confidence: 0.4, reason: 'hedging_language' };
+  if (trimmed.length < 8) return { confidence: 0.45, reason: 'answer_too_short' };
+  return { confidence: 0.9, reason: 'confident' };
+}
+
+/**
  * Decide whether a buffered low/mid answer should be re-answered once at the next tier.
- * Capped by the key's scopes and the request's max_tier. TODO(impl).
+ * Bounded by `ceiling` (= min(max_tier, highest held scope)); never escalates past it.
  */
 export function shouldEscalate(
-  _result: VerifierResult,
-  _currentTier: Tier,
-  _maxTier: Tier,
+  result: VerifierResult,
+  currentTier: Tier,
+  ceiling: Tier,
 ): EscalationDecision {
-  throw new Error('not implemented: shouldEscalate (ADR-203 §6.5)');
+  if (result.confidence >= TAU) {
+    return { escalate: false, reason: `confidence ${result.confidence.toFixed(2)} >= τ` };
+  }
+  if (tierRank(currentTier) >= tierRank(ceiling)) {
+    return { escalate: false, reason: `at ceiling ${ceiling} — cannot escalate further` };
+  }
+  const next = nextTierUp(currentTier);
+  if (!next) {
+    return { escalate: false, reason: 'no higher tier' };
+  }
+  return {
+    escalate: true,
+    nextTier: next,
+    reason: `confidence ${result.confidence.toFixed(2)} < τ → escalate ${currentTier}→${next}`,
+  };
 }

--- a/services/apicompletions/src/routes/chatCompletions.ts
+++ b/services/apicompletions/src/routes/chatCompletions.ts
@@ -14,6 +14,7 @@ import type {
 import { extractApiKey, verifyApiKey } from '../auth/apiKey';
 import { resolveTier } from '../tier/resolveTier';
 import { executeNonStream, effectiveEscalation } from '../core/pipeline';
+import { loadInflightScanner, streamInflight } from '../midstream/inflight';
 import { priceUsd } from '../metering/pricing';
 import { makeCounter } from '../metering/tokenizer';
 import { meter } from '../metering/record';
@@ -177,6 +178,20 @@ async function streamResponse(
   const id = `chatcmpl-${requestId}`;
   const writeChunk = (obj: unknown) => res.write(`data: ${JSON.stringify(obj)}\n\n`);
 
+  // `inflight` (§3.5, Option C′): midstream-only. The firewall returns a scanner ONLY when
+  // @midstream/wasm is present; today it is 404 on npm so loadInflightScanner → null and we
+  // FALL THROUGH to stream_oneshot (Option B). This hook is off-by-default + fully working
+  // without midstream; the SDK-safe truncation protocol lives in streamInflight for when the
+  // WASM is vendored/published.
+  if (body.escalation === 'inflight') {
+    const scanner = await loadInflightScanner(body);
+    if (scanner) {
+      await streamInflight({ deps, res, requestId, body, resolution, key, keyPrefix, startedAt, scanner });
+      return;
+    }
+    // midstream absent (operative state today) → degrade to Option B below.
+  }
+
   // `buffered`: run the full non-stream pipeline (with τ escalation), then flush as a
   // pseudo-stream — trades TTFT for verifier-gated escalation on a streaming-shaped reply.
   if (effectiveEscalation(body) === 'buffered') {
@@ -276,6 +291,7 @@ async function streamResponse(
   });
 
   for await (const delta of deps.provider.stream(model, body)) {
+    if (finalized) break; // client disconnected → stop streaming (close handler already billed)
     if (delta.content) completionCounter.pushDelta(delta.content);
     writeChunk({
       id,
@@ -285,6 +301,10 @@ async function streamResponse(
       choices: [{ index: 0, delta: delta.content ? { content: delta.content } : {}, finish_reason: delta.finishReason ?? null }],
     });
   }
+
+  // If the client disconnected, the close handler already wrote the truncated ledger row;
+  // do NOT run the normal-completion path (it would overwrite that row for the same requestId).
+  if (finalized) return;
 
   // Final usage estimate (§5.1 local floor) + x_cognitum on a trailing chunk.
   const completionTokens = completionCounter.completionTokens();

--- a/services/apicompletions/src/routes/chatCompletions.ts
+++ b/services/apicompletions/src/routes/chatCompletions.ts
@@ -1,9 +1,11 @@
 // POST /v1/chat/completions (ADR-203 §3.1). Orchestrates the full request flow:
-//   auth → tier → route → infer (JSON or SSE) → post-gen τ escalation → x_cognitum.
-// Metering (usage_ledger write + Pub/Sub publish) and the scatter-gather rate limiter are
-// wired in a later phase (§5.1/§5.3); this handler owns the CORE request path (§3.1 a–f).
+//   auth → idempotency → tier → rate-limit → route → infer (JSON or SSE) → post-gen τ
+//   escalation → meter (usage_ledger truth + Pub/Sub rollup) → x_cognitum.
+// Metering (§5.1), the scatter-gather rate limiter (§5.3), and the 24h idempotency cache
+// (§5.3) are now wired here; the core routing/inference path is owned by core/pipeline.
 import type { Request, Response } from 'express';
 import type { AppDeps } from '../deps';
+import type { ApiKeyDoc } from '../auth/apiKey';
 import type {
   ChatCompletionRequest,
   ChatCompletionResponse,
@@ -13,10 +15,14 @@ import { extractApiKey, verifyApiKey } from '../auth/apiKey';
 import { resolveTier } from '../tier/resolveTier';
 import { executeNonStream, effectiveEscalation } from '../core/pipeline';
 import { priceUsd } from '../metering/pricing';
+import { makeCounter } from '../metering/tokenizer';
+import { meter } from '../metering/record';
 import {
+  idempotencyKeyOf,
   mergeRoutingControls,
   requestIdOf,
   sendError,
+  sendRateLimited,
   setCognitumHeaders,
 } from '../core/http';
 
@@ -38,6 +44,7 @@ function validateChatBody(body: unknown): ChatCompletionRequest | { error: strin
 export function makeChatCompletions(deps: AppDeps) {
   return async function postChatCompletions(req: Request, res: Response): Promise<void> {
     const requestId = requestIdOf(req);
+    const startedAt = Date.now();
 
     // a. AUTH — real cog_ scheme (§6): X-API-Key / Bearer → SHA-256 → store lookup.
     const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
@@ -54,6 +61,19 @@ export function makeChatCompletions(deps: AppDeps) {
     const body = validated;
     mergeRoutingControls(body, req.headers);
 
+    // a'. IDEMPOTENCY (§5.3) — a replay returns the cached result and is NOT re-billed or
+    // rate-limited (short-circuits before tier/rate-limit/metering).
+    const idemKey = idempotencyKeyOf(req.headers);
+    if (idemKey) {
+      const cached = await deps.idempotency.lookup(idemKey);
+      if (cached) {
+        res.setHeader('X-Request-Id', requestId);
+        res.setHeader('Idempotent-Replay', 'true');
+        res.status(cached.status).json(cached.body);
+        return;
+      }
+    }
+
     // b. TIER — model dial + difficulty + scope enforcement (§3.3, §6 item 2).
     const resolution = resolveTier(body, auth.key);
     if (resolution.kind === 'error') {
@@ -61,10 +81,18 @@ export function makeChatCompletions(deps: AppDeps) {
       return;
     }
 
+    // c. RATE-LIMIT (§5.3) — scatter-gather per (keyHash, tier), per-tier limit.
+    const limit = deps.config.tierPools[resolution.tier].rateLimitPerMin;
+    const rl = await deps.rateLimiter.checkAndRecord(auth.key.key, resolution.tier, limit);
+    if (!rl.allowed) {
+      sendRateLimited(res, requestId, rl.retryAfterMs ?? 1000);
+      return;
+    }
+
     try {
       // e/f. INFER + ESCALATE.
       if (body.stream) {
-        await streamResponse(deps, req, res, requestId, body, resolution);
+        await streamResponse(deps, req, res, requestId, body, resolution, auth.key, auth.rawPrefix, startedAt);
         return;
       }
 
@@ -96,6 +124,23 @@ export function makeChatCompletions(deps: AppDeps) {
         usage: outcome.usage,
         x_cognitum,
       };
+
+      // g. METER — ledger (truth, awaited) + Pub/Sub rollup (fire-and-forget) (§5.1).
+      await meter(deps, {
+        requestId,
+        key: auth.key,
+        keyPrefix: auth.rawPrefix,
+        tier: outcome.resolvedTier,
+        resolvedModel: outcome.resolvedModel,
+        usage: outcome.usage,
+        priceUsd: outcome.priceUsd,
+        escalated: outcome.escalated,
+        latencyMs: Date.now() - startedAt,
+        tokensFromLocalFloor: outcome.tokensFromLocalFloor,
+        idempotencyKey: idemKey,
+      });
+
+      if (idemKey) await deps.idempotency.store(idemKey, { status: 200, body: response });
       res.status(200).json(response);
     } catch (err) {
       sendError(
@@ -113,6 +158,9 @@ export function makeChatCompletions(deps: AppDeps) {
  * SSE streaming (§3.3). Default `stream_oneshot`: route ONCE up front on the input signal
  * (resolution.tier already reflects it) — no post-gen escalation. `buffered` opts into
  * verifier-gated escalation at the cost of TTFT (buffer → verify → pseudo-stream).
+ * Streaming closes the truncation billing hole (§5.1): a FAMILY-CORRECT progressive counter
+ * is fed each delta, and the ledger is written from the local floor on normal completion OR
+ * on early client disconnect (flagged `truncated:true`) — a dropped stream is still billed.
  */
 async function streamResponse(
   deps: AppDeps,
@@ -121,6 +169,9 @@ async function streamResponse(
   requestId: string,
   body: ChatCompletionRequest,
   resolution: ReturnType<typeof resolveTier> & { kind: 'ok' },
+  key: ApiKeyDoc,
+  keyPrefix: string,
+  startedAt: number,
 ): Promise<void> {
   const created = Math.floor(Date.now() / 1000);
   const id = `chatcmpl-${requestId}`;
@@ -157,6 +208,18 @@ async function streamResponse(
     });
     res.write('data: [DONE]\n\n');
     res.end();
+    await meter(deps, {
+      requestId,
+      key,
+      keyPrefix,
+      tier: outcome.resolvedTier,
+      resolvedModel: outcome.resolvedModel,
+      usage: outcome.usage,
+      priceUsd: outcome.priceUsd,
+      escalated: outcome.escalated,
+      latencyMs: Date.now() - startedAt,
+      tokensFromLocalFloor: outcome.tokensFromLocalFloor,
+    });
     return;
   }
 
@@ -174,9 +237,46 @@ async function streamResponse(
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
 
-  let collected = '';
+  // §5.1 progressive billing: family-correct counter for the model that is actually serving,
+  // seeded with the prompt tokens; fed each outbound delta as bytes stream out.
+  const counter = makeCounter(model, tier);
+  const promptTokens = body.messages.reduce((n, m) => {
+    counter.pushDelta(m.content ?? '');
+    return n;
+  }, 0);
+  const promptFloor = counter.completionTokens();
+  // Reset the counter to count COMPLETION bytes only (prompt was just measured above).
+  const completionCounter = makeCounter(model, tier);
+
+  // Truncation guard (§5.1): if the client drops the TCP connection before [DONE], bill the
+  // partial answer from the local floor with truncated:true rather than losing the usage.
+  let finalized = false;
+  res.on('close', () => {
+    if (finalized) return;
+    finalized = true;
+    const completionTokens = completionCounter.completionTokens();
+    const usage = {
+      prompt_tokens: promptFloor,
+      completion_tokens: completionTokens,
+      total_tokens: promptFloor + completionTokens,
+    };
+    void meter(deps, {
+      requestId,
+      key,
+      keyPrefix,
+      tier,
+      resolvedModel: model,
+      usage,
+      priceUsd: priceUsd(deps.config, tier, usage),
+      escalated: false,
+      latencyMs: Date.now() - startedAt,
+      tokensFromLocalFloor: true,
+      truncated: true,
+    });
+  });
+
   for await (const delta of deps.provider.stream(model, body)) {
-    if (delta.content) collected += delta.content;
+    if (delta.content) completionCounter.pushDelta(delta.content);
     writeChunk({
       id,
       object: 'chat.completion.chunk',
@@ -185,11 +285,15 @@ async function streamResponse(
       choices: [{ index: 0, delta: delta.content ? { content: delta.content } : {}, finish_reason: delta.finishReason ?? null }],
     });
   }
+
   // Final usage estimate (§5.1 local floor) + x_cognitum on a trailing chunk.
-  const approx = (s: string) => Math.max(1, Math.ceil(s.length / 4));
-  const promptTokens = body.messages.reduce((n, m) => n + approx(m.content ?? ''), 0);
-  const completionTokens = approx(collected);
-  const usage = { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: promptTokens + completionTokens };
+  const completionTokens = completionCounter.completionTokens();
+  const usage = {
+    prompt_tokens: promptFloor,
+    completion_tokens: completionTokens,
+    total_tokens: promptFloor + completionTokens,
+  };
+  const price = priceUsd(deps.config, tier, usage);
   writeChunk({
     id,
     object: 'chat.completion.chunk',
@@ -204,9 +308,25 @@ async function streamResponse(
       escalated: false,
       cap_degraded: resolution.capDegraded,
       routing_reason: resolution.routingReason,
-      price_usd: priceUsd(deps.config, tier, usage),
+      price_usd: price,
     },
   });
   res.write('data: [DONE]\n\n');
   res.end();
+
+  // Normal completion — write the ledger from the family-correct floor (no provider usage on
+  // the live SSE path). Mark finalized FIRST so the close handler does not double-bill.
+  finalized = true;
+  await meter(deps, {
+    requestId,
+    key,
+    keyPrefix,
+    tier,
+    resolvedModel: model,
+    usage,
+    priceUsd: price,
+    escalated: false,
+    latencyMs: Date.now() - startedAt,
+    tokensFromLocalFloor: true,
+  });
 }

--- a/services/apicompletions/src/routes/chatCompletions.ts
+++ b/services/apicompletions/src/routes/chatCompletions.ts
@@ -1,0 +1,24 @@
+// POST /v1/chat/completions (ADR-203 §3.1). Orchestrates the full request flow:
+//   auth → tier → limit/idempotency → route → infer (SSE or JSON) → escalate → meter.
+// Skeleton handler returns 501; the pipeline modules (auth, tier, router, providers,
+// metering, ratelimit) are wired here during implementation.
+import type { Request, Response } from 'express';
+import type { ErrorEnvelope } from '../types/openai';
+
+export async function postChatCompletions(req: Request, res: Response): Promise<void> {
+  // TODO(impl): see §3.1 steps a–g.
+  // a. AUTH      verifyApiKey
+  // b. TIER      parseModelAlias + enforceScope
+  // c. LIMIT     checkAndRecord + idempotency.lookup
+  // d. ROUTE     computeDifficulty (auto) → tier pool model
+  // e. INFER     provider.complete / provider.stream (SSE)
+  // f. ESCALATE  shouldEscalate (non-stream / buffered only) — streams route once up front
+  // g. METER     makeCounter → writeLedger + publishUsage
+  const requestId = String(req.headers['x-request-id'] ?? '');
+  const body: ErrorEnvelope = {
+    error: 'apicompletions skeleton — chat/completions not yet implemented (ADR-203 §3.1)',
+    code: 'not_implemented',
+    requestId,
+  };
+  res.status(501).json(body);
+}

--- a/services/apicompletions/src/routes/chatCompletions.ts
+++ b/services/apicompletions/src/routes/chatCompletions.ts
@@ -1,24 +1,212 @@
 // POST /v1/chat/completions (ADR-203 §3.1). Orchestrates the full request flow:
-//   auth → tier → limit/idempotency → route → infer (SSE or JSON) → escalate → meter.
-// Skeleton handler returns 501; the pipeline modules (auth, tier, router, providers,
-// metering, ratelimit) are wired here during implementation.
+//   auth → tier → route → infer (JSON or SSE) → post-gen τ escalation → x_cognitum.
+// Metering (usage_ledger write + Pub/Sub publish) and the scatter-gather rate limiter are
+// wired in a later phase (§5.1/§5.3); this handler owns the CORE request path (§3.1 a–f).
 import type { Request, Response } from 'express';
-import type { ErrorEnvelope } from '../types/openai';
+import type { AppDeps } from '../deps';
+import type {
+  ChatCompletionRequest,
+  ChatCompletionResponse,
+  XCognitum,
+} from '../types/openai';
+import { extractApiKey, verifyApiKey } from '../auth/apiKey';
+import { resolveTier } from '../tier/resolveTier';
+import { executeNonStream, effectiveEscalation } from '../core/pipeline';
+import { priceUsd } from '../metering/pricing';
+import {
+  mergeRoutingControls,
+  requestIdOf,
+  sendError,
+  setCognitumHeaders,
+} from '../core/http';
 
-export async function postChatCompletions(req: Request, res: Response): Promise<void> {
-  // TODO(impl): see §3.1 steps a–g.
-  // a. AUTH      verifyApiKey
-  // b. TIER      parseModelAlias + enforceScope
-  // c. LIMIT     checkAndRecord + idempotency.lookup
-  // d. ROUTE     computeDifficulty (auto) → tier pool model
-  // e. INFER     provider.complete / provider.stream (SSE)
-  // f. ESCALATE  shouldEscalate (non-stream / buffered only) — streams route once up front
-  // g. METER     makeCounter → writeLedger + publishUsage
-  const requestId = String(req.headers['x-request-id'] ?? '');
-  const body: ErrorEnvelope = {
-    error: 'apicompletions skeleton — chat/completions not yet implemented (ADR-203 §3.1)',
-    code: 'not_implemented',
-    requestId,
+function validateChatBody(body: unknown): ChatCompletionRequest | { error: string; code: string } {
+  if (!body || typeof body !== 'object') return { error: 'Request body must be a JSON object.', code: 'invalid_request' };
+  const b = body as Partial<ChatCompletionRequest>;
+  if (typeof b.model !== 'string' || b.model.length === 0) {
+    return { error: 'Field "model" is required.', code: 'invalid_request' };
+  }
+  if (!Array.isArray(b.messages) || b.messages.length === 0) {
+    return { error: 'Field "messages" must be a non-empty array.', code: 'invalid_request' };
+  }
+  if (b.n !== undefined && b.n !== 1) {
+    return { error: 'Only n=1 is supported in v1.', code: 'invalid_request' };
+  }
+  return b as ChatCompletionRequest;
+}
+
+export function makeChatCompletions(deps: AppDeps) {
+  return async function postChatCompletions(req: Request, res: Response): Promise<void> {
+    const requestId = requestIdOf(req);
+
+    // a. AUTH — real cog_ scheme (§6): X-API-Key / Bearer → SHA-256 → store lookup.
+    const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
+    if (!auth.ok) {
+      sendError(res, requestId, auth.status, auth.code, auth.error);
+      return;
+    }
+
+    const validated = validateChatBody(req.body);
+    if ('error' in validated) {
+      sendError(res, requestId, 400, validated.code, validated.error);
+      return;
+    }
+    const body = validated;
+    mergeRoutingControls(body, req.headers);
+
+    // b. TIER — model dial + difficulty + scope enforcement (§3.3, §6 item 2).
+    const resolution = resolveTier(body, auth.key);
+    if (resolution.kind === 'error') {
+      sendError(res, requestId, resolution.status, resolution.code, resolution.error);
+      return;
+    }
+
+    try {
+      // e/f. INFER + ESCALATE.
+      if (body.stream) {
+        await streamResponse(deps, req, res, requestId, body, resolution);
+        return;
+      }
+
+      const outcome = await executeNonStream(deps, body, resolution);
+      const x_cognitum: XCognitum = {
+        request_id: requestId,
+        resolved_tier: outcome.resolvedTier,
+        resolved_model: outcome.resolvedModel,
+        escalated: outcome.escalated,
+        cap_degraded: outcome.capDegraded,
+        routing_reason: outcome.routingReason,
+        price_usd: outcome.priceUsd,
+      };
+      setCognitumHeaders(res, requestId, {
+        resolvedTier: outcome.resolvedTier,
+        resolvedModel: outcome.resolvedModel,
+        escalated: outcome.escalated,
+        capDegraded: outcome.capDegraded,
+        routingReason: outcome.routingReason,
+      });
+      const response: ChatCompletionResponse = {
+        id: `chatcmpl-${requestId}`,
+        object: 'chat.completion',
+        created: Math.floor(Date.now() / 1000),
+        model: body.model,
+        choices: [
+          { index: 0, message: { role: 'assistant', content: outcome.text }, finish_reason: 'stop' },
+        ],
+        usage: outcome.usage,
+        x_cognitum,
+      };
+      res.status(200).json(response);
+    } catch (err) {
+      sendError(
+        res,
+        requestId,
+        502,
+        'upstream_error',
+        err instanceof Error ? err.message : 'Upstream provider error.',
+      );
+    }
   };
-  res.status(501).json(body);
+}
+
+/**
+ * SSE streaming (§3.3). Default `stream_oneshot`: route ONCE up front on the input signal
+ * (resolution.tier already reflects it) — no post-gen escalation. `buffered` opts into
+ * verifier-gated escalation at the cost of TTFT (buffer → verify → pseudo-stream).
+ */
+async function streamResponse(
+  deps: AppDeps,
+  _req: Request,
+  res: Response,
+  requestId: string,
+  body: ChatCompletionRequest,
+  resolution: ReturnType<typeof resolveTier> & { kind: 'ok' },
+): Promise<void> {
+  const created = Math.floor(Date.now() / 1000);
+  const id = `chatcmpl-${requestId}`;
+  const writeChunk = (obj: unknown) => res.write(`data: ${JSON.stringify(obj)}\n\n`);
+
+  // `buffered`: run the full non-stream pipeline (with τ escalation), then flush as a
+  // pseudo-stream — trades TTFT for verifier-gated escalation on a streaming-shaped reply.
+  if (effectiveEscalation(body) === 'buffered') {
+    const outcome = await executeNonStream(deps, body, resolution);
+    setCognitumHeaders(res, requestId, outcome);
+    res.setHeader('Content-Type', 'text/event-stream');
+    writeChunk({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: body.model,
+      choices: [{ index: 0, delta: { role: 'assistant', content: outcome.text }, finish_reason: null }],
+    });
+    writeChunk({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: body.model,
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      x_cognitum: {
+        request_id: requestId,
+        resolved_tier: outcome.resolvedTier,
+        resolved_model: outcome.resolvedModel,
+        escalated: outcome.escalated,
+        cap_degraded: outcome.capDegraded,
+        routing_reason: outcome.routingReason,
+        price_usd: outcome.priceUsd,
+      },
+    });
+    res.write('data: [DONE]\n\n');
+    res.end();
+    return;
+  }
+
+  // stream_oneshot — stream live from the single resolved tier. Fallback-within-tier for
+  // live streams is deferred; use the first model in the chain.
+  const tier = resolution.tier;
+  const model = deps.config.tierPools[tier].models[0];
+  setCognitumHeaders(res, requestId, {
+    resolvedTier: tier,
+    resolvedModel: model,
+    escalated: false,
+    capDegraded: resolution.capDegraded,
+    routingReason: resolution.routingReason,
+  });
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+
+  let collected = '';
+  for await (const delta of deps.provider.stream(model, body)) {
+    if (delta.content) collected += delta.content;
+    writeChunk({
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: body.model,
+      choices: [{ index: 0, delta: delta.content ? { content: delta.content } : {}, finish_reason: delta.finishReason ?? null }],
+    });
+  }
+  // Final usage estimate (§5.1 local floor) + x_cognitum on a trailing chunk.
+  const approx = (s: string) => Math.max(1, Math.ceil(s.length / 4));
+  const promptTokens = body.messages.reduce((n, m) => n + approx(m.content ?? ''), 0);
+  const completionTokens = approx(collected);
+  const usage = { prompt_tokens: promptTokens, completion_tokens: completionTokens, total_tokens: promptTokens + completionTokens };
+  writeChunk({
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: body.model,
+    choices: [],
+    usage,
+    x_cognitum: {
+      request_id: requestId,
+      resolved_tier: tier,
+      resolved_model: model,
+      escalated: false,
+      cap_degraded: resolution.capDegraded,
+      routing_reason: resolution.routingReason,
+      price_usd: priceUsd(deps.config, tier, usage),
+    },
+  });
+  res.write('data: [DONE]\n\n');
+  res.end();
 }

--- a/services/apicompletions/src/routes/chatCompletions.ts
+++ b/services/apicompletions/src/routes/chatCompletions.ts
@@ -18,7 +18,10 @@ import { loadInflightScanner, streamInflight } from '../midstream/inflight';
 import { priceUsd } from '../metering/pricing';
 import { makeCounter } from '../metering/tokenizer';
 import { meter } from '../metering/record';
+import { maxOutputTokens, promptTokenFloor, worstCaseEstimateUsd } from '../budget/estimate';
 import {
+  accountIdOf,
+  agentIdOf,
   idempotencyCacheKey,
   idempotencyKeyOf,
   mergeRoutingControls,
@@ -112,10 +115,36 @@ export function makeChatCompletions(deps: AppDeps) {
       return;
     }
 
+    // d. RESERVE (ADR-204 §5.2) — atomic worst-case budget reservation at the CEILING tier,
+    // BEFORE any provider invoke. Denies 402 (account/agent budget) or 429 (loop) at the
+    // reservation write so an overspend is impossible (no reservation → no invoke). Unmetered
+    // accounts admit transparently with no reservation (resId undefined → COMMIT is a no-op).
+    const ceilingTier = resolution.ceiling;
+    const promptTokens = promptTokenFloor(deps.config, ceilingTier, body.messages);
+    const estimateUsd = worstCaseEstimateUsd(
+      deps.config,
+      ceilingTier,
+      promptTokens,
+      maxOutputTokens(deps.config, body.max_tokens),
+    );
+    const reservation = await deps.budget.reserve({
+      accountId: accountIdOf(auth.key),
+      agentId: agentIdOf(req.headers, auth.key),
+      ceilingTier,
+      estimateUsd,
+      reqType: body.stream ? 'streaming' : 'sync',
+      resId: requestId,
+    });
+    if (!reservation.admit) {
+      sendError(res, requestId, reservation.status, reservation.code, reservation.error);
+      return;
+    }
+    const resId = reservation.resId;
+
     try {
       // e/f. INFER + ESCALATE.
       if (body.stream) {
-        await streamResponse(deps, req, res, requestId, body, resolution, auth.key, auth.rawPrefix, startedAt);
+        await streamResponse(deps, req, res, requestId, body, resolution, auth.key, auth.rawPrefix, startedAt, resId);
         return;
       }
 
@@ -163,6 +192,10 @@ export function makeChatCompletions(deps: AppDeps) {
         idempotencyKey: idemKey,
       });
 
+      // d'. COMMIT (ADR-204 §5.2) — release the worst-case estimate, record the actual spend.
+      // Idempotent on resId; a no-op for unmetered accounts (resId undefined).
+      if (resId) await deps.budget.commit(resId, outcome.priceUsd);
+
       if (cacheKey) await deps.idempotency.store(cacheKey, { status: 200, body: response });
       res.status(200).json(response);
     } catch (err) {
@@ -193,6 +226,7 @@ async function streamResponse(
   key: ApiKeyDoc,
   keyPrefix: string,
   startedAt: number,
+  resId: string | undefined,
 ): Promise<void> {
   const created = Math.floor(Date.now() / 1000);
   const id = `chatcmpl-${requestId}`;
@@ -255,6 +289,7 @@ async function streamResponse(
       latencyMs: Date.now() - startedAt,
       tokensFromLocalFloor: outcome.tokensFromLocalFloor,
     });
+    if (resId) await deps.budget.commit(resId, outcome.priceUsd);
     return;
   }
 
@@ -295,6 +330,7 @@ async function streamResponse(
       completion_tokens: completionTokens,
       total_tokens: promptFloor + completionTokens,
     };
+    const truncatedPrice = priceUsd(deps.config, tier, usage);
     void meter(deps, {
       requestId,
       key,
@@ -302,12 +338,15 @@ async function streamResponse(
       tier,
       resolvedModel: model,
       usage,
-      priceUsd: priceUsd(deps.config, tier, usage),
+      priceUsd: truncatedPrice,
       escalated: false,
       latencyMs: Date.now() - startedAt,
       tokensFromLocalFloor: true,
       truncated: true,
     });
+    // §5.1 disconnect is BOTH un-locked AND billed (§5.5): commit the partial actual so the
+    // dropped stream releases its lease at the truncated floor, not the worst-case estimate.
+    if (resId) void deps.budget.commit(resId, truncatedPrice);
   });
 
   // A provider error AFTER the first chunk means headers are already flushed — we CANNOT fall
@@ -394,4 +433,6 @@ async function streamResponse(
     latencyMs: Date.now() - startedAt,
     tokensFromLocalFloor: true,
   });
+  // §5.2 COMMIT — release the worst-case estimate, book the streamed actual.
+  if (resId) await deps.budget.commit(resId, price);
 }

--- a/services/apicompletions/src/routes/chatCompletions.ts
+++ b/services/apicompletions/src/routes/chatCompletions.ts
@@ -19,6 +19,7 @@ import { priceUsd } from '../metering/pricing';
 import { makeCounter } from '../metering/tokenizer';
 import { meter } from '../metering/record';
 import {
+  idempotencyCacheKey,
   idempotencyKeyOf,
   mergeRoutingControls,
   requestIdOf,
@@ -26,6 +27,12 @@ import {
   sendRateLimited,
   setCognitumHeaders,
 } from '../core/http';
+
+// Explicit request-shape bounds (§3.4, sec-review). The global express.json limit only caps
+// raw bytes; these bound the structural fan-out fed to the difficulty regexes / tokenizer so
+// a single in-limit body can't carry a pathological messages array.
+const MAX_MESSAGES = 512;
+const MAX_MESSAGE_CHARS = 131_072; // 128 KiB of content per message
 
 function validateChatBody(body: unknown): ChatCompletionRequest | { error: string; code: string } {
   if (!body || typeof body !== 'object') return { error: 'Request body must be a JSON object.', code: 'invalid_request' };
@@ -35,6 +42,15 @@ function validateChatBody(body: unknown): ChatCompletionRequest | { error: strin
   }
   if (!Array.isArray(b.messages) || b.messages.length === 0) {
     return { error: 'Field "messages" must be a non-empty array.', code: 'invalid_request' };
+  }
+  if (b.messages.length > MAX_MESSAGES) {
+    return { error: `Too many messages (max ${MAX_MESSAGES}).`, code: 'invalid_request' };
+  }
+  for (const m of b.messages) {
+    const content = (m as { content?: unknown })?.content;
+    if (typeof content === 'string' && content.length > MAX_MESSAGE_CHARS) {
+      return { error: `A message exceeds the ${MAX_MESSAGE_CHARS}-character limit.`, code: 'invalid_request' };
+    }
   }
   if (b.n !== undefined && b.n !== 1) {
     return { error: 'Only n=1 is supported in v1.', code: 'invalid_request' };
@@ -50,6 +66,9 @@ export function makeChatCompletions(deps: AppDeps) {
     // a. AUTH — real cog_ scheme (§6): X-API-Key / Bearer → SHA-256 → store lookup.
     const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
     if (!auth.ok) {
+      if (auth.logCode) {
+        console.warn(`[auth] ${requestId} rejected (${auth.logCode})${auth.logReason ? `: ${auth.logReason}` : ''}`);
+      }
       sendError(res, requestId, auth.status, auth.code, auth.error);
       return;
     }
@@ -65,8 +84,11 @@ export function makeChatCompletions(deps: AppDeps) {
     // a'. IDEMPOTENCY (§5.3) — a replay returns the cached result and is NOT re-billed or
     // rate-limited (short-circuits before tier/rate-limit/metering).
     const idemKey = idempotencyKeyOf(req.headers);
-    if (idemKey) {
-      const cached = await deps.idempotency.lookup(idemKey);
+    // Namespace the attacker-chosen key by the authenticated principal so the cache cannot
+    // leak across tenants / scopes (sec-review §5.3).
+    const cacheKey = idemKey ? idempotencyCacheKey(auth.key, idemKey) : undefined;
+    if (cacheKey) {
+      const cached = await deps.idempotency.lookup(cacheKey);
       if (cached) {
         res.setHeader('X-Request-Id', requestId);
         res.setHeader('Idempotent-Replay', 'true');
@@ -141,16 +163,14 @@ export function makeChatCompletions(deps: AppDeps) {
         idempotencyKey: idemKey,
       });
 
-      if (idemKey) await deps.idempotency.store(idemKey, { status: 200, body: response });
+      if (cacheKey) await deps.idempotency.store(cacheKey, { status: 200, body: response });
       res.status(200).json(response);
     } catch (err) {
-      sendError(
-        res,
-        requestId,
-        502,
-        'upstream_error',
-        err instanceof Error ? err.message : 'Upstream provider error.',
-      );
+      // Never leak the concrete vendor model roster / provider name to the client (§3.4):
+      // the attempted-model chain (ProviderError) is logged server-side keyed by requestId;
+      // the wire body is a generic, stable message.
+      console.error(`[upstream] ${requestId} provider error: ${err instanceof Error ? err.message : String(err)}`);
+      sendError(res, requestId, 502, 'upstream_error', 'Upstream provider error.');
     }
   };
 }
@@ -290,16 +310,41 @@ async function streamResponse(
     });
   });
 
-  for await (const delta of deps.provider.stream(model, body)) {
-    if (finalized) break; // client disconnected → stop streaming (close handler already billed)
-    if (delta.content) completionCounter.pushDelta(delta.content);
-    writeChunk({
-      id,
-      object: 'chat.completion.chunk',
-      created,
-      model: body.model,
-      choices: [{ index: 0, delta: delta.content ? { content: delta.content } : {}, finish_reason: delta.finishReason ?? null }],
-    });
+  // A provider error AFTER the first chunk means headers are already flushed — we CANNOT fall
+  // through to the outer sendError (that calls res.json() → 'headers already sent', hanging the
+  // SSE socket). Instead emit a terminal SSE error chunk + [DONE] + end; the res.on('close')
+  // handler then bills the partial answer exactly once (truncated:true). If the error happens
+  // before any byte is written, rethrow so the outer catch can still send a clean 502 JSON.
+  try {
+    for await (const delta of deps.provider.stream(model, body)) {
+      if (finalized) break; // client disconnected → stop streaming (close handler already billed)
+      if (delta.content) completionCounter.pushDelta(delta.content);
+      writeChunk({
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model: body.model,
+        choices: [{ index: 0, delta: delta.content ? { content: delta.content } : {}, finish_reason: delta.finishReason ?? null }],
+      });
+    }
+  } catch (err) {
+    console.error(`[upstream] ${requestId} stream error: ${err instanceof Error ? err.message : String(err)}`);
+    if (!res.headersSent) {
+      throw err; // nothing streamed yet → let the outer catch emit a generic 502 JSON envelope
+    }
+    if (!res.writableEnded) {
+      writeChunk({
+        id,
+        object: 'chat.completion.chunk',
+        created,
+        model: body.model,
+        choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+        error: { code: 'upstream_error', message: 'Upstream provider error.' },
+      });
+      res.write('data: [DONE]\n\n');
+      res.end(); // → 'close' fires → close handler bills the partial (truncated:true) once
+    }
+    return;
   }
 
   // If the client disconnected, the close handler already wrote the truncated ledger row;

--- a/services/apicompletions/src/routes/completions.ts
+++ b/services/apicompletions/src/routes/completions.ts
@@ -1,0 +1,14 @@
+// POST /v1/completions (ADR-203 §2). Legacy OpenAI completions shape; shares the same
+// auth → tier → route → meter pipeline as chat/completions. Skeleton returns 501.
+import type { Request, Response } from 'express';
+import type { ErrorEnvelope } from '../types/openai';
+
+export async function postCompletions(req: Request, res: Response): Promise<void> {
+  const requestId = String(req.headers['x-request-id'] ?? '');
+  const body: ErrorEnvelope = {
+    error: 'apicompletions skeleton — completions not yet implemented (ADR-203 §2)',
+    code: 'not_implemented',
+    requestId,
+  };
+  res.status(501).json(body);
+}

--- a/services/apicompletions/src/routes/completions.ts
+++ b/services/apicompletions/src/routes/completions.ts
@@ -1,14 +1,104 @@
-// POST /v1/completions (ADR-203 §2). Legacy OpenAI completions shape; shares the same
-// auth → tier → route → meter pipeline as chat/completions. Skeleton returns 501.
+// POST /v1/completions (ADR-203 §2, §3.4). Legacy OpenAI completions shape; shares the
+// SAME auth → tier → route → escalate pipeline as chat/completions — the `prompt` is
+// adapted into a single user message, and the result is reshaped to the legacy
+// `choices[].text` / object:"text_completion" envelope. Non-streaming (this phase).
 import type { Request, Response } from 'express';
-import type { ErrorEnvelope } from '../types/openai';
+import type { AppDeps } from '../deps';
+import type { ChatCompletionRequest, XCognitum } from '../types/openai';
+import { extractApiKey, verifyApiKey } from '../auth/apiKey';
+import { resolveTier } from '../tier/resolveTier';
+import { executeNonStream } from '../core/pipeline';
+import { mergeRoutingControls, requestIdOf, sendError, setCognitumHeaders } from '../core/http';
 
-export async function postCompletions(req: Request, res: Response): Promise<void> {
-  const requestId = String(req.headers['x-request-id'] ?? '');
-  const body: ErrorEnvelope = {
-    error: 'apicompletions skeleton — completions not yet implemented (ADR-203 §2)',
-    code: 'not_implemented',
-    requestId,
+interface LegacyCompletionRequest extends Omit<ChatCompletionRequest, 'messages'> {
+  prompt?: string | string[];
+}
+
+function promptToMessages(prompt: string | string[] | undefined): ChatCompletionRequest['messages'] | null {
+  if (typeof prompt === 'string' && prompt.length > 0) {
+    return [{ role: 'user', content: prompt }];
+  }
+  if (Array.isArray(prompt) && prompt.length > 0) {
+    return [{ role: 'user', content: prompt.join('\n') }];
+  }
+  return null;
+}
+
+export function makeCompletions(deps: AppDeps) {
+  return async function postCompletions(req: Request, res: Response): Promise<void> {
+    const requestId = requestIdOf(req);
+
+    const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
+    if (!auth.ok) {
+      sendError(res, requestId, auth.status, auth.code, auth.error);
+      return;
+    }
+
+    const b = (req.body ?? {}) as LegacyCompletionRequest;
+    if (typeof b.model !== 'string' || b.model.length === 0) {
+      sendError(res, requestId, 400, 'invalid_request', 'Field "model" is required.');
+      return;
+    }
+    if (b.n !== undefined && b.n !== 1) {
+      sendError(res, requestId, 400, 'invalid_request', 'Only n=1 is supported in v1.');
+      return;
+    }
+    const messages = promptToMessages(b.prompt);
+    if (!messages) {
+      sendError(res, requestId, 400, 'invalid_request', 'Field "prompt" must be a non-empty string or array.');
+      return;
+    }
+
+    const chatReq: ChatCompletionRequest = {
+      model: b.model,
+      messages,
+      temperature: b.temperature,
+      top_p: b.top_p,
+      max_tokens: b.max_tokens,
+      stop: b.stop,
+      n: b.n,
+      fallback_policy: b.fallback_policy,
+      min_tier: b.min_tier,
+      max_tier: b.max_tier,
+      escalation: b.escalation,
+    };
+    mergeRoutingControls(chatReq, req.headers);
+
+    const resolution = resolveTier(chatReq, auth.key);
+    if (resolution.kind === 'error') {
+      sendError(res, requestId, resolution.status, resolution.code, resolution.error);
+      return;
+    }
+
+    try {
+      const outcome = await executeNonStream(deps, chatReq, resolution);
+      const x_cognitum: XCognitum = {
+        request_id: requestId,
+        resolved_tier: outcome.resolvedTier,
+        resolved_model: outcome.resolvedModel,
+        escalated: outcome.escalated,
+        cap_degraded: outcome.capDegraded,
+        routing_reason: outcome.routingReason,
+        price_usd: outcome.priceUsd,
+      };
+      setCognitumHeaders(res, requestId, outcome);
+      res.status(200).json({
+        id: `cmpl-${requestId}`,
+        object: 'text_completion',
+        created: Math.floor(Date.now() / 1000),
+        model: b.model,
+        choices: [{ index: 0, text: outcome.text, finish_reason: 'stop' }],
+        usage: outcome.usage,
+        x_cognitum,
+      });
+    } catch (err) {
+      sendError(
+        res,
+        requestId,
+        502,
+        'upstream_error',
+        err instanceof Error ? err.message : 'Upstream provider error.',
+      );
+    }
   };
-  res.status(501).json(body);
 }

--- a/services/apicompletions/src/routes/completions.ts
+++ b/services/apicompletions/src/routes/completions.ts
@@ -8,7 +8,8 @@ import type { ChatCompletionRequest, XCognitum } from '../types/openai';
 import { extractApiKey, verifyApiKey } from '../auth/apiKey';
 import { resolveTier } from '../tier/resolveTier';
 import { executeNonStream } from '../core/pipeline';
-import { mergeRoutingControls, requestIdOf, sendError, setCognitumHeaders } from '../core/http';
+import { meter } from '../metering/record';
+import { mergeRoutingControls, requestIdOf, sendError, sendRateLimited, setCognitumHeaders } from '../core/http';
 
 interface LegacyCompletionRequest extends Omit<ChatCompletionRequest, 'messages'> {
   prompt?: string | string[];
@@ -27,6 +28,7 @@ function promptToMessages(prompt: string | string[] | undefined): ChatCompletion
 export function makeCompletions(deps: AppDeps) {
   return async function postCompletions(req: Request, res: Response): Promise<void> {
     const requestId = requestIdOf(req);
+    const startedAt = Date.now();
 
     const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
     if (!auth.ok) {
@@ -70,6 +72,14 @@ export function makeCompletions(deps: AppDeps) {
       return;
     }
 
+    // RATE-LIMIT (§5.3) — scatter-gather per (keyHash, tier).
+    const limit = deps.config.tierPools[resolution.tier].rateLimitPerMin;
+    const rl = await deps.rateLimiter.checkAndRecord(auth.key.key, resolution.tier, limit);
+    if (!rl.allowed) {
+      sendRateLimited(res, requestId, rl.retryAfterMs ?? 1000);
+      return;
+    }
+
     try {
       const outcome = await executeNonStream(deps, chatReq, resolution);
       const x_cognitum: XCognitum = {
@@ -82,6 +92,21 @@ export function makeCompletions(deps: AppDeps) {
         price_usd: outcome.priceUsd,
       };
       setCognitumHeaders(res, requestId, outcome);
+
+      // METER — ledger (truth) + Pub/Sub rollup (fire-and-forget) (§5.1).
+      await meter(deps, {
+        requestId,
+        key: auth.key,
+        keyPrefix: auth.rawPrefix,
+        tier: outcome.resolvedTier,
+        resolvedModel: outcome.resolvedModel,
+        usage: outcome.usage,
+        priceUsd: outcome.priceUsd,
+        escalated: outcome.escalated,
+        latencyMs: Date.now() - startedAt,
+        tokensFromLocalFloor: outcome.tokensFromLocalFloor,
+      });
+
       res.status(200).json({
         id: `cmpl-${requestId}`,
         object: 'text_completion',

--- a/services/apicompletions/src/routes/completions.ts
+++ b/services/apicompletions/src/routes/completions.ts
@@ -15,14 +15,20 @@ interface LegacyCompletionRequest extends Omit<ChatCompletionRequest, 'messages'
   prompt?: string | string[];
 }
 
-function promptToMessages(prompt: string | string[] | undefined): ChatCompletionRequest['messages'] | null {
+// Bound the adapted prompt size (§3.4, sec-review) — mirrors the chat-route MAX_MESSAGE_CHARS
+// so a single in-byte-limit legacy body can't carry a pathological prompt into the tokenizer.
+const MAX_PROMPT_CHARS = 131_072;
+
+function promptToMessages(prompt: string | string[] | undefined): ChatCompletionRequest['messages'] | 'empty' | 'too_large' {
+  let content: string | null = null;
   if (typeof prompt === 'string' && prompt.length > 0) {
-    return [{ role: 'user', content: prompt }];
+    content = prompt;
+  } else if (Array.isArray(prompt) && prompt.length > 0) {
+    content = prompt.join('\n');
   }
-  if (Array.isArray(prompt) && prompt.length > 0) {
-    return [{ role: 'user', content: prompt.join('\n') }];
-  }
-  return null;
+  if (content === null) return 'empty';
+  if (content.length > MAX_PROMPT_CHARS) return 'too_large';
+  return [{ role: 'user', content }];
 }
 
 export function makeCompletions(deps: AppDeps) {
@@ -32,6 +38,9 @@ export function makeCompletions(deps: AppDeps) {
 
     const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
     if (!auth.ok) {
+      if (auth.logCode) {
+        console.warn(`[auth] ${requestId} rejected (${auth.logCode})${auth.logReason ? `: ${auth.logReason}` : ''}`);
+      }
       sendError(res, requestId, auth.status, auth.code, auth.error);
       return;
     }
@@ -46,8 +55,12 @@ export function makeCompletions(deps: AppDeps) {
       return;
     }
     const messages = promptToMessages(b.prompt);
-    if (!messages) {
+    if (messages === 'empty') {
       sendError(res, requestId, 400, 'invalid_request', 'Field "prompt" must be a non-empty string or array.');
+      return;
+    }
+    if (messages === 'too_large') {
+      sendError(res, requestId, 400, 'invalid_request', `Field "prompt" exceeds the ${MAX_PROMPT_CHARS}-character limit.`);
       return;
     }
 
@@ -117,13 +130,9 @@ export function makeCompletions(deps: AppDeps) {
         x_cognitum,
       });
     } catch (err) {
-      sendError(
-        res,
-        requestId,
-        502,
-        'upstream_error',
-        err instanceof Error ? err.message : 'Upstream provider error.',
-      );
+      // Generic wire body; the concrete attempted-model chain is logged server-side only (§3.4).
+      console.error(`[upstream] ${requestId} provider error: ${err instanceof Error ? err.message : String(err)}`);
+      sendError(res, requestId, 502, 'upstream_error', 'Upstream provider error.');
     }
   };
 }

--- a/services/apicompletions/src/routes/messages.ts
+++ b/services/apicompletions/src/routes/messages.ts
@@ -1,0 +1,326 @@
+// POST /v1/messages — the Anthropic Messages API surface over Cognitum Fugu.
+// Anthropic request → canonical → the SAME tier/route/meter/budget pipeline as
+// /v1/chat/completions → Anthropic response. Auth via the existing cog_ scheme on x-api-key
+// (case-insensitive; `anthropic-version` is accepted and ignored). The model→tier map lives in
+// the translation adapter (opus→high, sonnet→mid, haiku→low, cognitum-* pass-through).
+//
+// HONESTY GUARD: the response `model` field and x_cognitum.resolved_model/resolved_tier always
+// carry the REAL resolved model — when auto/low resolves to a non-Anthropic model (deepseek /
+// glm / gpt), the caller sees that model, never a misrepresented Claude alias.
+import type { Request, Response } from 'express';
+import type { AppDeps } from '../deps';
+import type { ApiKeyDoc } from '../auth/apiKey';
+import type { XCognitum } from '../types/openai';
+import type { AnthropicMessagesRequest } from '../anthropic/types';
+import { extractApiKey, verifyApiKey } from '../auth/apiKey';
+import { resolveTier } from '../tier/resolveTier';
+import { executeNonStream } from '../core/pipeline';
+import { priceUsd } from '../metering/pricing';
+import { makeCounter } from '../metering/tokenizer';
+import { meter } from '../metering/record';
+import { maxOutputTokens, promptTokenFloor, worstCaseEstimateUsd } from '../budget/estimate';
+import { anthropicToCanonical, buildAnthropicResponse, mapStopReason } from '../anthropic/translate';
+import {
+  contentBlockDeltaEvent,
+  contentBlockStartEvent,
+  contentBlockStopEvent,
+  messageDeltaEvent,
+  messageStartEvent,
+  messageStopEvent,
+  pingEvent,
+} from '../anthropic/sse';
+import {
+  accountIdOf,
+  agentIdOf,
+  idempotencyCacheKey,
+  idempotencyKeyOf,
+  mergeRoutingControls,
+  requestIdOf,
+  sendError,
+  sendRateLimited,
+  setCognitumHeaders,
+} from '../core/http';
+
+const MAX_MESSAGES = 512;
+const MAX_MESSAGE_CHARS = 131_072;
+
+type ValidatedBody = AnthropicMessagesRequest | { error: string; code: string };
+
+function validateMessagesBody(body: unknown): ValidatedBody {
+  if (!body || typeof body !== 'object') return { error: 'Request body must be a JSON object.', code: 'invalid_request' };
+  const b = body as Partial<AnthropicMessagesRequest>;
+  if (typeof b.model !== 'string' || b.model.length === 0) {
+    return { error: 'Field "model" is required.', code: 'invalid_request' };
+  }
+  if (typeof b.max_tokens !== 'number' || !Number.isFinite(b.max_tokens) || b.max_tokens <= 0) {
+    return { error: 'Field "max_tokens" is required and must be a positive integer.', code: 'invalid_request' };
+  }
+  if (!Array.isArray(b.messages) || b.messages.length === 0) {
+    return { error: 'Field "messages" must be a non-empty array.', code: 'invalid_request' };
+  }
+  if (b.messages.length > MAX_MESSAGES) {
+    return { error: `Too many messages (max ${MAX_MESSAGES}).`, code: 'invalid_request' };
+  }
+  for (const m of b.messages) {
+    const content = (m as { content?: unknown })?.content;
+    if (typeof content === 'string' && content.length > MAX_MESSAGE_CHARS) {
+      return { error: `A message exceeds the ${MAX_MESSAGE_CHARS}-character limit.`, code: 'invalid_request' };
+    }
+  }
+  return b as AnthropicMessagesRequest;
+}
+
+export function makeMessages(deps: AppDeps) {
+  return async function postMessages(req: Request, res: Response): Promise<void> {
+    const requestId = requestIdOf(req);
+    const startedAt = Date.now();
+
+    // a. AUTH — same cog_ scheme as /v1/chat/completions (x-api-key / Bearer). Express lowercases
+    // header names, so x-api-key matches case-insensitively; anthropic-version is ignored.
+    const auth = await verifyApiKey(extractApiKey(req.headers), deps.keyStore);
+    if (!auth.ok) {
+      if (auth.logCode) {
+        console.warn(`[auth] ${requestId} rejected (${auth.logCode})${auth.logReason ? `: ${auth.logReason}` : ''}`);
+      }
+      sendError(res, requestId, auth.status, auth.code, auth.error);
+      return;
+    }
+
+    const validated = validateMessagesBody(req.body);
+    if ('error' in validated) {
+      sendError(res, requestId, 400, validated.code, validated.error);
+      return;
+    }
+
+    // Translate Anthropic → canonical, then merge X-Cognitum-* routing-control headers
+    // (min/max_tier, fallback_policy) onto the canonical body so resolveTier honors them.
+    const canonical = anthropicToCanonical(validated);
+    mergeRoutingControls(canonical, req.headers);
+
+    // a'. IDEMPOTENCY (§5.3) — a replay returns the cached Anthropic body, un-billed.
+    const idemKey = idempotencyKeyOf(req.headers);
+    const cacheKey = idemKey ? idempotencyCacheKey(auth.key, idemKey) : undefined;
+    if (cacheKey) {
+      const cached = await deps.idempotency.lookup(cacheKey);
+      if (cached) {
+        res.setHeader('X-Request-Id', requestId);
+        res.setHeader('Idempotent-Replay', 'true');
+        res.status(cached.status).json(cached.body);
+        return;
+      }
+    }
+
+    // b. TIER — model dial + difficulty + scope enforcement (§3.3, §6 item 2).
+    const resolution = resolveTier(canonical, auth.key);
+    if (resolution.kind === 'error') {
+      sendError(res, requestId, resolution.status, resolution.code, resolution.error);
+      return;
+    }
+
+    // c. RATE-LIMIT (§5.3).
+    const limit = deps.config.tierPools[resolution.tier].rateLimitPerMin;
+    const rl = await deps.rateLimiter.checkAndRecord(auth.key.key, resolution.tier, limit);
+    if (!rl.allowed) {
+      sendRateLimited(res, requestId, rl.retryAfterMs ?? 1000);
+      return;
+    }
+
+    // d. RESERVE (ADR-204 §5.2) — worst-case at the ceiling tier, BEFORE the provider invoke.
+    const ceilingTier = resolution.ceiling;
+    const promptTokens = promptTokenFloor(deps.config, ceilingTier, canonical.messages);
+    const estimateUsd = worstCaseEstimateUsd(
+      deps.config,
+      ceilingTier,
+      promptTokens,
+      maxOutputTokens(deps.config, canonical.max_tokens),
+    );
+    const reservation = await deps.budget.reserve({
+      accountId: accountIdOf(auth.key),
+      agentId: agentIdOf(req.headers, auth.key),
+      ceilingTier,
+      estimateUsd,
+      reqType: canonical.stream ? 'streaming' : 'sync',
+      resId: requestId,
+    });
+    if (!reservation.admit) {
+      sendError(res, requestId, reservation.status, reservation.code, reservation.error);
+      return;
+    }
+    const resId = reservation.resId;
+
+    try {
+      if (canonical.stream) {
+        await streamAnthropic(deps, res, requestId, canonical, resolution, auth.key, auth.rawPrefix, startedAt, resId);
+        return;
+      }
+
+      const outcome = await executeNonStream(deps, canonical, resolution);
+      const xCognitum: XCognitum = {
+        request_id: requestId,
+        resolved_tier: outcome.resolvedTier,
+        resolved_model: outcome.resolvedModel,
+        escalated: outcome.escalated,
+        cap_degraded: outcome.capDegraded,
+        routing_reason: outcome.routingReason,
+        price_usd: outcome.priceUsd,
+      };
+      setCognitumHeaders(res, requestId, {
+        resolvedTier: outcome.resolvedTier,
+        resolvedModel: outcome.resolvedModel,
+        escalated: outcome.escalated,
+        capDegraded: outcome.capDegraded,
+        routingReason: outcome.routingReason,
+      });
+      const response = buildAnthropicResponse({
+        requestId,
+        resolvedModel: outcome.resolvedModel, // HONESTY GUARD
+        text: outcome.text,
+        usage: outcome.usage,
+        stopReason: mapStopReason('stop'),
+        xCognitum,
+      });
+
+      await meter(deps, {
+        requestId,
+        key: auth.key,
+        keyPrefix: auth.rawPrefix,
+        tier: outcome.resolvedTier,
+        resolvedModel: outcome.resolvedModel,
+        usage: outcome.usage,
+        priceUsd: outcome.priceUsd,
+        escalated: outcome.escalated,
+        latencyMs: Date.now() - startedAt,
+        tokensFromLocalFloor: outcome.tokensFromLocalFloor,
+        idempotencyKey: idemKey,
+      });
+      if (resId) await deps.budget.commit(resId, outcome.priceUsd);
+
+      if (cacheKey) await deps.idempotency.store(cacheKey, { status: 200, body: response });
+      res.status(200).json(response);
+    } catch (err) {
+      console.error(`[upstream] ${requestId} provider error: ${err instanceof Error ? err.message : String(err)}`);
+      sendError(res, requestId, 502, 'upstream_error', 'Upstream provider error.');
+    }
+  };
+}
+
+/**
+ * Anthropic SSE streaming (stream_oneshot — route ONCE up front, §3.3). Synthesizes the
+ * Anthropic event sequence from whatever backend serves (incl. the non-Anthropic MockProvider):
+ *   message_start → content_block_start → ping → content_block_delta×N
+ *     → content_block_stop → message_delta → message_stop
+ * The §5.1 family-correct progressive counter feeds the disconnect-billing floor: a client that
+ * drops the TCP connection before message_stop is still billed (truncated:true) and the budget
+ * lease is committed at the partial floor (§5.5).
+ */
+async function streamAnthropic(
+  deps: AppDeps,
+  res: Response,
+  requestId: string,
+  body: ReturnType<typeof anthropicToCanonical>,
+  resolution: ReturnType<typeof resolveTier> & { kind: 'ok' },
+  key: ApiKeyDoc,
+  keyPrefix: string,
+  startedAt: number,
+  resId: string | undefined,
+): Promise<void> {
+  const id = `msg_${requestId}`;
+  const tier = resolution.tier;
+  const model = deps.config.tierPools[tier].models[0];
+
+  setCognitumHeaders(res, requestId, {
+    resolvedTier: tier,
+    resolvedModel: model, // HONESTY GUARD — real resolved model in the headers too
+    escalated: false,
+    capDegraded: resolution.capDegraded,
+    routingReason: resolution.routingReason,
+  });
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+
+  // §5.1 family-correct prompt floor (input_tokens) + completion counter (output_tokens).
+  const promptCounter = makeCounter(model, tier);
+  for (const m of body.messages) promptCounter.pushDelta(m.content ?? '');
+  const promptFloor = promptCounter.completionTokens();
+  const completionCounter = makeCounter(model, tier);
+
+  const write = (frame: string): void => {
+    res.write(frame);
+  };
+  write(messageStartEvent({ id, model, inputTokens: promptFloor }));
+  write(contentBlockStartEvent());
+  write(pingEvent());
+
+  // Disconnect billing floor (§5.1) + budget lease commit at the partial (§5.5).
+  let finalized = false;
+  res.on('close', () => {
+    if (finalized) return;
+    finalized = true;
+    const completionTokens = completionCounter.completionTokens();
+    const usage = {
+      prompt_tokens: promptFloor,
+      completion_tokens: completionTokens,
+      total_tokens: promptFloor + completionTokens,
+    };
+    const truncatedPrice = priceUsd(deps.config, tier, usage);
+    void meter(deps, {
+      requestId,
+      key,
+      keyPrefix,
+      tier,
+      resolvedModel: model,
+      usage,
+      priceUsd: truncatedPrice,
+      escalated: false,
+      latencyMs: Date.now() - startedAt,
+      tokensFromLocalFloor: true,
+      truncated: true,
+    });
+    if (resId) void deps.budget.commit(resId, truncatedPrice);
+  });
+
+  for await (const delta of deps.provider.stream(model, body)) {
+    if (finalized) break; // client disconnected → close handler billed
+    if (delta.content) {
+      completionCounter.pushDelta(delta.content);
+      write(contentBlockDeltaEvent(delta.content));
+    }
+  }
+  if (finalized) return; // disconnect already billed; do not double-write the terminal frames
+
+  const completionTokens = completionCounter.completionTokens();
+  const usage = {
+    prompt_tokens: promptFloor,
+    completion_tokens: completionTokens,
+    total_tokens: promptFloor + completionTokens,
+  };
+  const price = priceUsd(deps.config, tier, usage);
+  const xCognitum: XCognitum = {
+    request_id: requestId,
+    resolved_tier: tier,
+    resolved_model: model, // HONESTY GUARD
+    escalated: false,
+    cap_degraded: resolution.capDegraded,
+    routing_reason: resolution.routingReason,
+    price_usd: price,
+  };
+  write(contentBlockStopEvent());
+  write(messageDeltaEvent({ stopReason: mapStopReason('stop'), outputTokens: completionTokens, xCognitum }));
+  write(messageStopEvent());
+  res.end();
+
+  finalized = true;
+  await meter(deps, {
+    requestId,
+    key,
+    keyPrefix,
+    tier,
+    resolvedModel: model,
+    usage,
+    priceUsd: price,
+    escalated: false,
+    latencyMs: Date.now() - startedAt,
+    tokensFromLocalFloor: true,
+  });
+  if (resId) await deps.budget.commit(resId, price);
+}

--- a/services/apicompletions/src/routes/models.ts
+++ b/services/apicompletions/src/routes/models.ts
@@ -1,0 +1,12 @@
+// GET /v1/models (ADR-203 §3.4). Lists the four cognitum-* aliases, NOT the underlying
+// pool (customers buy tiers, not models — keeps the pool swappable).
+import type { Request, Response } from 'express';
+
+const ALIASES = ['cognitum-auto', 'cognitum-low', 'cognitum-mid', 'cognitum-high'];
+
+export function getModels(_req: Request, res: Response): void {
+  res.json({
+    object: 'list',
+    data: ALIASES.map((id) => ({ id, object: 'model', owned_by: 'cognitum' })),
+  });
+}

--- a/services/apicompletions/src/server.ts
+++ b/services/apicompletions/src/server.ts
@@ -1,12 +1,14 @@
 // Express app factory (ADR-203 §2, §7.1). Mirrors @cognitum-one/api-gateway's Express
 // setup; this is the Cloud Run upstream the gateway forwards /v1/* to. SSE-capable
-// (no response buffering on the streaming path).
+// (no response buffering on the streaming path). Dependency-injected (deps) so tests run
+// the full auth → tier → route loop at $0 against a seeded key store + the MockProvider.
 import express, { type Express, type Request, type Response } from 'express';
-import { postChatCompletions } from './routes/chatCompletions';
-import { postCompletions } from './routes/completions';
+import { type AppDeps, type AppDepsOverrides, defaultDeps } from './deps';
+import { makeChatCompletions } from './routes/chatCompletions';
+import { makeCompletions } from './routes/completions';
 import { getModels } from './routes/models';
 
-export function createApp(): Express {
+export function createApp(deps: AppDeps = defaultDeps()): Express {
   const app = express();
   app.use(express.json({ limit: '4mb' }));
 
@@ -15,8 +17,13 @@ export function createApp(): Express {
   });
 
   app.get('/v1/models', getModels);
-  app.post('/v1/chat/completions', postChatCompletions);
-  app.post('/v1/completions', postCompletions);
+  app.post('/v1/chat/completions', makeChatCompletions(deps));
+  app.post('/v1/completions', makeCompletions(deps));
 
   return app;
+}
+
+/** Convenience for tests/local: build the app from default deps + targeted overrides. */
+export function createAppWith(overrides: AppDepsOverrides): Express {
+  return createApp(defaultDeps(overrides));
 }

--- a/services/apicompletions/src/server.ts
+++ b/services/apicompletions/src/server.ts
@@ -6,6 +6,7 @@ import express, { type Express, type Request, type Response } from 'express';
 import { type AppDeps, type AppDepsOverrides, defaultDeps } from './deps';
 import { makeChatCompletions } from './routes/chatCompletions';
 import { makeCompletions } from './routes/completions';
+import { makeMessages } from './routes/messages';
 import { getModels } from './routes/models';
 
 export function createApp(deps: AppDeps = defaultDeps()): Express {
@@ -19,6 +20,7 @@ export function createApp(deps: AppDeps = defaultDeps()): Express {
   app.get('/v1/models', getModels);
   app.post('/v1/chat/completions', makeChatCompletions(deps));
   app.post('/v1/completions', makeCompletions(deps));
+  app.post('/v1/messages', makeMessages(deps)); // Anthropic Messages API (ADR-203 §3.6)
 
   return app;
 }

--- a/services/apicompletions/src/server.ts
+++ b/services/apicompletions/src/server.ts
@@ -1,0 +1,22 @@
+// Express app factory (ADR-203 §2, §7.1). Mirrors @cognitum-one/api-gateway's Express
+// setup; this is the Cloud Run upstream the gateway forwards /v1/* to. SSE-capable
+// (no response buffering on the streaming path).
+import express, { type Express, type Request, type Response } from 'express';
+import { postChatCompletions } from './routes/chatCompletions';
+import { postCompletions } from './routes/completions';
+import { getModels } from './routes/models';
+
+export function createApp(): Express {
+  const app = express();
+  app.use(express.json({ limit: '4mb' }));
+
+  app.get('/healthz', (_req: Request, res: Response) => {
+    res.json({ status: 'ok', service: 'apicompletions' });
+  });
+
+  app.get('/v1/models', getModels);
+  app.post('/v1/chat/completions', postChatCompletions);
+  app.post('/v1/completions', postCompletions);
+
+  return app;
+}

--- a/services/apicompletions/src/tier/resolveTier.ts
+++ b/services/apicompletions/src/tier/resolveTier.ts
@@ -1,34 +1,163 @@
-// Tier resolution + scope enforcement (ADR-203 §3.3, §6 item 2).
-import type { CognitumModel, FallbackPolicy, Tier } from '../types/openai';
-import type { ApiKeyDoc } from '../auth/apiKey';
+// Tier resolution + scope enforcement (ADR-203 §3.3, §3.4, §6 item 2).
+// The `model` field is the routing dial; raw vendor ids are rejected (404). Auto mode
+// maps the intrinsic difficulty signal → starting tier, bounded by min_tier/max_tier and
+// capped by the key's held scopes; scope mismatch is governed by fallback_policy.
+import type { ChatCompletionRequest, CognitumModel, FallbackPolicy, Tier } from '../types/openai';
+import { type ApiKeyDoc, highestHeldTier, holdsTier } from '../auth/apiKey';
+import { computeDifficulty, type DifficultySignal } from '../router/difficulty';
+
+const TIER_ORDER: Tier[] = ['low', 'mid', 'high'];
+export function tierRank(t: Tier): number {
+  return TIER_ORDER.indexOf(t);
+}
+function maxTier(a: Tier, b: Tier): Tier {
+  return tierRank(a) >= tierRank(b) ? a : b;
+}
+function minTier(a: Tier, b: Tier): Tier {
+  return tierRank(a) <= tierRank(b) ? a : b;
+}
+/** Next tier up, or null at the ceiling. */
+export function nextTierUp(t: Tier): Tier | null {
+  const i = tierRank(t);
+  return i >= 0 && i < TIER_ORDER.length - 1 ? TIER_ORDER[i + 1] : null;
+}
 
 export interface TierResolution {
-  /** Tier that will execute (the billed tier). */
+  kind: 'ok';
+  /** Tier that will execute (the billed/starting tier). */
   tier: Tier;
   /** Auto mode resolves via the difficulty signal; explicit modes pin the tier. */
   mode: 'auto' | 'explicit';
   agentic: boolean;
   capDegraded: boolean;
-  routingReason?: string;
+  routingReason: string;
+  /** Quality floor (min_tier) honoured during routing. */
+  floor: Tier;
+  /** Escalation cost cap — min(max_tier ?? high, highest held tier). Bounds τ (§6.5). */
+  ceiling: Tier;
+  difficulty?: DifficultySignal;
 }
 
-/** Map the cognitum-* model alias to {mode, baseTier, agentic}. Raw vendor ids -> null (404). */
+export interface TierError {
+  kind: 'error';
+  status: number;
+  code: string;
+  error: string;
+}
+
+const ALIAS_RE = /^cognitum-(auto|low|mid|high|mock)(-agent)?$/;
+
+/** Map a cognitum-* alias to {mode, tier?, agentic}. Raw vendor ids → null (→ 404). */
 export function parseModelAlias(
-  _model: string,
+  model: string,
 ): { mode: 'auto' | 'explicit'; tier?: Tier; agentic: boolean } | null {
-  throw new Error('not implemented: parseModelAlias (ADR-203 §3.4)');
+  const m = ALIAS_RE.exec(model);
+  if (!m) return null;
+  const which = m[1];
+  const agentic = m[2] === '-agent';
+  if (which === 'auto') return { mode: 'auto', agentic };
+  // cognitum-mock is the non-prod $0 alias (§7.3); it pins the low tier against the mock provider.
+  if (which === 'mock') return { mode: 'explicit', tier: 'low', agentic };
+  return { mode: 'explicit', tier: which as Tier, agentic };
 }
 
 /**
- * Enforce scope ↔ tier (§6 item 2). On scope mismatch in auto mode, behaviour is
- * governed by fallback_policy: fail_fast (403) | best_effort (cap + cap_degraded).
- * TODO(impl).
+ * Resolve the request's model dial + difficulty + key scopes into the tier that will run.
+ * Returns a {kind:'ok'} resolution or a {kind:'error'} wire error (404 model / 403 scope).
  */
-export function enforceScope(
-  _key: ApiKeyDoc,
-  _wanted: Tier,
-  _model: CognitumModel,
-  _policy: FallbackPolicy,
-): TierResolution {
-  throw new Error('not implemented: enforceScope (ADR-203 §6 item 2)');
+export function resolveTier(req: ChatCompletionRequest, key: ApiKeyDoc): TierResolution | TierError {
+  const parsed = parseModelAlias(req.model);
+  if (!parsed) {
+    return {
+      kind: 'error',
+      status: 404,
+      code: 'model_not_found',
+      error: `Unknown model '${req.model}'. Use a cognitum-* tier alias (cognitum-auto|low|mid|high); raw vendor ids are not accepted.`,
+    };
+  }
+
+  // Explicit mode pins the tier — no routing, no escalation. Key must hold the scope.
+  if (parsed.mode === 'explicit') {
+    const tier = parsed.tier!;
+    if (!holdsTier(key, tier)) {
+      return {
+        kind: 'error',
+        status: 403,
+        code: 'tier_scope_insufficient',
+        error: `Model '${req.model}' requires the completions:${tier} scope, which this API key does not hold.`,
+      };
+    }
+    return {
+      kind: 'ok',
+      tier,
+      mode: 'explicit',
+      agentic: parsed.agentic,
+      capDegraded: false,
+      routingReason: `explicit:${tier}`,
+      floor: tier,
+      ceiling: tier,
+    };
+  }
+
+  // Auto mode — needs at least one completions scope.
+  const held = highestHeldTier(key);
+  if (!held) {
+    return {
+      kind: 'error',
+      status: 403,
+      code: 'no_completions_scope',
+      error: 'API key holds no completions:{low,mid,high} scope.',
+    };
+  }
+
+  const diff = computeDifficulty(req);
+  // Clamp the difficulty-implied tier by the request's quality floor / cost cap.
+  let wanted = diff.tier;
+  const floor = req.min_tier ?? 'low';
+  const reqCap = req.max_tier ?? 'high';
+  wanted = maxTier(wanted, floor); // never below the quality floor
+  wanted = minTier(wanted, reqCap); // never above the cost cap
+
+  // Escalation ceiling: bounded by both the cost cap and the highest held scope (§6.5).
+  const ceiling = minTier(reqCap, held);
+
+  if (tierRank(wanted) > tierRank(held)) {
+    // Scope mismatch — difficulty needs a tier the key lacks (§6 item 2).
+    const policy: FallbackPolicy = req.fallback_policy ?? 'fail_fast';
+    if (policy === 'fail_fast') {
+      return {
+        kind: 'error',
+        status: 403,
+        code: 'tier_scope_insufficient',
+        error: `Task difficulty requires cognitum-${wanted} tier, but this API key is limited to completions:${held}.`,
+      };
+    }
+    // best_effort — run at the highest held tier and flag cap_degraded.
+    return {
+      kind: 'ok',
+      tier: held,
+      mode: 'auto',
+      agentic: parsed.agentic,
+      capDegraded: true,
+      routingReason: `best_effort: ${diff.reason} capped to held ${held}`,
+      floor,
+      ceiling,
+      difficulty: diff,
+    };
+  }
+
+  return {
+    kind: 'ok',
+    tier: wanted,
+    mode: 'auto',
+    agentic: parsed.agentic,
+    capDegraded: false,
+    routingReason: wanted === diff.tier ? diff.reason : `${diff.reason} clamped to ${wanted} (min=${floor},max=${reqCap})`,
+    floor,
+    ceiling,
+    difficulty: diff,
+  };
 }
+
+/** Re-export for callers that only need to know about the model alias / cognitum dial. */
+export type { CognitumModel };

--- a/services/apicompletions/src/tier/resolveTier.ts
+++ b/services/apicompletions/src/tier/resolveTier.ts
@@ -1,0 +1,34 @@
+// Tier resolution + scope enforcement (ADR-203 §3.3, §6 item 2).
+import type { CognitumModel, FallbackPolicy, Tier } from '../types/openai';
+import type { ApiKeyDoc } from '../auth/apiKey';
+
+export interface TierResolution {
+  /** Tier that will execute (the billed tier). */
+  tier: Tier;
+  /** Auto mode resolves via the difficulty signal; explicit modes pin the tier. */
+  mode: 'auto' | 'explicit';
+  agentic: boolean;
+  capDegraded: boolean;
+  routingReason?: string;
+}
+
+/** Map the cognitum-* model alias to {mode, baseTier, agentic}. Raw vendor ids -> null (404). */
+export function parseModelAlias(
+  _model: string,
+): { mode: 'auto' | 'explicit'; tier?: Tier; agentic: boolean } | null {
+  throw new Error('not implemented: parseModelAlias (ADR-203 §3.4)');
+}
+
+/**
+ * Enforce scope ↔ tier (§6 item 2). On scope mismatch in auto mode, behaviour is
+ * governed by fallback_policy: fail_fast (403) | best_effort (cap + cap_degraded).
+ * TODO(impl).
+ */
+export function enforceScope(
+  _key: ApiKeyDoc,
+  _wanted: Tier,
+  _model: CognitumModel,
+  _policy: FallbackPolicy,
+): TierResolution {
+  throw new Error('not implemented: enforceScope (ADR-203 §6 item 2)');
+}

--- a/services/apicompletions/src/types/openai.ts
+++ b/services/apicompletions/src/types/openai.ts
@@ -1,0 +1,86 @@
+// OpenAI-compatible wire types (ADR-203 §3.4). Skeleton stubs — fields will be
+// filled out during implementation. The shapes here are intentionally minimal
+// but byte-compatible with the OpenAI chat/completions contract.
+
+export type Tier = 'low' | 'mid' | 'high';
+
+/** The four routing dials exposed via the `model` field (raw vendor ids rejected). */
+export type CognitumModel =
+  | 'cognitum-auto'
+  | 'cognitum-low'
+  | 'cognitum-mid'
+  | 'cognitum-high'
+  | 'cognitum-low-agent'
+  | 'cognitum-mid-agent'
+  | 'cognitum-high-agent'
+  | 'cognitum-mock';
+
+export type FallbackPolicy = 'fail_fast' | 'best_effort';
+
+/** §3.4 / §3.5 escalation strategy. `inflight` is midstream-only and degrades to stream_oneshot. */
+export type EscalationStrategy = 'stream_oneshot' | 'post_hoc' | 'buffered' | 'inflight';
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string;
+  name?: string;
+}
+
+export interface ChatCompletionRequest {
+  model: string;
+  messages: ChatMessage[];
+  temperature?: number;
+  top_p?: number;
+  max_tokens?: number;
+  stream?: boolean;
+  stop?: string | string[];
+  n?: number;
+  tools?: unknown[];
+  tool_choice?: unknown;
+  // Cognitum namespaced routing controls (also accepted as X-Cognitum-* headers).
+  fallback_policy?: FallbackPolicy;
+  min_tier?: Tier;
+  max_tier?: Tier;
+  escalation?: EscalationStrategy;
+}
+
+export interface Usage {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+}
+
+/** Namespaced response extension block (§3.4). */
+export interface XCognitum {
+  request_id: string;
+  resolved_tier: Tier;
+  resolved_model: string;
+  escalated: boolean;
+  cap_degraded: boolean;
+  routing_reason?: string;
+  price_usd: number;
+}
+
+export interface ChatCompletionChoice {
+  index: number;
+  message?: ChatMessage;
+  delta?: Partial<ChatMessage>;
+  finish_reason: string | null;
+}
+
+export interface ChatCompletionResponse {
+  id: string;
+  object: 'chat.completion' | 'chat.completion.chunk';
+  created: number;
+  model: string;
+  choices: ChatCompletionChoice[];
+  usage?: Usage;
+  x_cognitum?: XCognitum;
+}
+
+/** Uniform error envelope, matching the production gateway contract. */
+export interface ErrorEnvelope {
+  error: string;
+  code: string;
+  requestId: string;
+}

--- a/services/apicompletions/terraform/main.tf
+++ b/services/apicompletions/terraform/main.tf
@@ -1,0 +1,51 @@
+# Cognitum Fugu apicompletions — reviewable Terraform (ADR-203 §7.2).
+# Extends the agentbbs-gcp/terraform/main.tf shape. REVIEWABLE CONFIG, DO NOT BLIND-APPLY:
+# always `terraform plan` first (same rule as agentbbs-gcp and ADR-180).
+#
+# SKELETON — resource bodies are stubbed/commented. Fill in during rollout step 8.
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+# Enable the APIs the service needs (run / firestore / pubsub / cloudfunctions / cloudbuild / eventarc).
+resource "google_project_service" "services" {
+  for_each = toset([
+    "run.googleapis.com",
+    "firestore.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "eventarc.googleapis.com",
+  ])
+  service            = each.value
+  disable_on_destroy = false
+}
+
+# The default Firestore DB ALREADY EXISTS in cognitum-20260110 — `terraform import`, do NOT create.
+# import { id = "projects/${var.project_id}/databases/(default)", to = google_firestore_database.default }
+# resource "google_firestore_database" "default" { ... }
+
+# Pub/Sub topic + subscription feeding aggregateUsage (§5.1).
+# resource "google_pubsub_topic" "completions_usage" { name = "completions-usage" ... }
+# resource "google_pubsub_subscription" "completions_usage" { topic = ... }
+
+# gen2 rollup function (§7.1).
+# resource "google_cloudfunctions2_function" "aggregate_usage" { ... ALLOW_INTERNAL_ONLY ... }
+
+# The Cloud Run completions service (§7.1): timeout=300s, concurrency=8, max-instances=20.
+# resource "google_cloud_run_v2_service" "apicompletions" { ... }
+
+# Least-privilege service account `apicompletions-sa` (§7.1):
+# roles/datastore.user, roles/pubsub.publisher, roles/secretmanager.secretAccessor.
+# resource "google_service_account" "apicompletions_sa" { ... }

--- a/services/apicompletions/terraform/outputs.tf
+++ b/services/apicompletions/terraform/outputs.tf
@@ -1,0 +1,3 @@
+# Outputs wired during rollout step 8 (§7.2). Stubbed for the skeleton.
+# output "service_url"   { value = google_cloud_run_v2_service.apicompletions.uri }
+# output "usage_topic"   { value = google_pubsub_topic.completions_usage.id }

--- a/services/apicompletions/terraform/variables.tf
+++ b/services/apicompletions/terraform/variables.tf
@@ -1,0 +1,17 @@
+variable "project_id" {
+  type        = string
+  description = "GCP project — Cognitum production (ADR-203 §7.1)."
+  default     = "cognitum-20260110"
+}
+
+variable "region" {
+  type        = string
+  description = "Deploy region."
+  default     = "us-central1"
+}
+
+variable "image" {
+  type        = string
+  description = "Container image for the apicompletions Cloud Run service."
+  default     = ""
+}

--- a/services/apicompletions/tests/auth.test.ts
+++ b/services/apicompletions/tests/auth.test.ts
@@ -58,12 +58,25 @@ describe('auth — cog_ key scheme (ADR-203 §6)', () => {
     expect((await verifyApiKey(VALID2, s))).toMatchObject({ ok: false, status: 401, code: 'invalid_api_key' });
   });
 
-  it('rejects inactive and expired keys with 401', async () => {
+  it('rejects inactive and expired keys with an OPAQUE 401 (granular reason in logs only)', async () => {
     const s = new InMemoryKeyStore();
     s.add(VALID, { permissions: [COMPLETION_SCOPES.low], rateLimit: 1, active: false, expiresAt: null });
     s.add(VALID2, { permissions: [COMPLETION_SCOPES.low], rateLimit: 1, active: true, expiresAt: new Date(Date.now() - 1000) });
-    expect((await verifyApiKey(VALID, s))).toMatchObject({ ok: false, code: 'key_inactive' });
-    expect((await verifyApiKey(VALID2, s))).toMatchObject({ ok: false, code: 'key_expired' });
+    // External wire code/error must NOT reveal key state (anti-enumeration, §6) — collapsed to
+    // the same invalid_api_key / 'Invalid API key.' as an unknown key; reason kept in logCode.
+    expect((await verifyApiKey(VALID, s))).toMatchObject({ ok: false, code: 'invalid_api_key', error: 'Invalid API key.', logCode: 'key_inactive' });
+    expect((await verifyApiKey(VALID2, s))).toMatchObject({ ok: false, code: 'invalid_api_key', error: 'Invalid API key.', logCode: 'key_expired' });
+  });
+
+  it('returns an indistinguishable response for unknown vs inactive vs expired keys', async () => {
+    const s = new InMemoryKeyStore();
+    s.add(VALID, { permissions: [COMPLETION_SCOPES.low], rateLimit: 1, active: false, expiresAt: null });
+    const unknown = await verifyApiKey(VALID2, s); // valid format, not in store
+    const inactive = await verifyApiKey(VALID, s);
+    if (unknown.ok || inactive.ok) throw new Error('expected both to fail');
+    expect(unknown.status).toBe(inactive.status);
+    expect(unknown.code).toBe(inactive.code);
+    expect(unknown.error).toBe(inactive.error);
   });
 
   it('accepts a valid, active, scoped key', async () => {

--- a/services/apicompletions/tests/auth.test.ts
+++ b/services/apicompletions/tests/auth.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  COMPLETION_SCOPES,
+  InMemoryKeyStore,
+  extractApiKey,
+  hashKey,
+  highestHeldTier,
+  holdsTier,
+  isValidKeyFormat,
+  keyPrefix,
+  verifyApiKey,
+} from '../src/auth/apiKey';
+
+// Valid cog_ keys = cog_ + 64 hex chars (ADR-203 §6).
+const VALID = 'cog_' + 'a'.repeat(64);
+const VALID2 = 'cog_' + 'b'.repeat(64);
+
+function store(): InMemoryKeyStore {
+  const s = new InMemoryKeyStore();
+  s.add(VALID, {
+    permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.high],
+    rateLimit: 120,
+    active: true,
+    expiresAt: null,
+    accountId: 'acct_1',
+  });
+  return s;
+}
+
+describe('auth — cog_ key scheme (ADR-203 §6)', () => {
+  it('validates the cog_ + 64-hex format', () => {
+    expect(isValidKeyFormat(VALID)).toBe(true);
+    expect(isValidKeyFormat('cog_short')).toBe(false);
+    expect(isValidKeyFormat('sk-openai-style')).toBe(false);
+    expect(isValidKeyFormat('cog_' + 'z'.repeat(64))).toBe(false); // z not hex
+  });
+
+  it('SHA-256 hashes the key and exposes only a 12-char prefix', () => {
+    expect(hashKey(VALID)).toHaveLength(64);
+    expect(hashKey(VALID)).not.toContain(VALID); // never the plaintext
+    expect(keyPrefix(VALID)).toBe('cog_aaaaaaaa');
+    expect(keyPrefix(VALID)).toHaveLength(12);
+  });
+
+  it('extracts the key from X-API-Key (preferred) or Bearer', () => {
+    expect(extractApiKey({ 'x-api-key': VALID })).toBe(VALID);
+    expect(extractApiKey({ authorization: `Bearer ${VALID}` })).toBe(VALID);
+    expect(extractApiKey({ authorization: `bearer ${VALID}` })).toBe(VALID); // case-insensitive
+    // X-API-Key wins when both present
+    expect(extractApiKey({ 'x-api-key': VALID, authorization: `Bearer ${VALID2}` })).toBe(VALID);
+    expect(extractApiKey({})).toBeUndefined();
+  });
+
+  it('rejects missing / malformed / unknown keys with 401', async () => {
+    const s = store();
+    expect((await verifyApiKey(undefined, s))).toMatchObject({ ok: false, status: 401, code: 'missing_api_key' });
+    expect((await verifyApiKey('nope', s))).toMatchObject({ ok: false, status: 401, code: 'invalid_api_key' });
+    expect((await verifyApiKey(VALID2, s))).toMatchObject({ ok: false, status: 401, code: 'invalid_api_key' });
+  });
+
+  it('rejects inactive and expired keys with 401', async () => {
+    const s = new InMemoryKeyStore();
+    s.add(VALID, { permissions: [COMPLETION_SCOPES.low], rateLimit: 1, active: false, expiresAt: null });
+    s.add(VALID2, { permissions: [COMPLETION_SCOPES.low], rateLimit: 1, active: true, expiresAt: new Date(Date.now() - 1000) });
+    expect((await verifyApiKey(VALID, s))).toMatchObject({ ok: false, code: 'key_inactive' });
+    expect((await verifyApiKey(VALID2, s))).toMatchObject({ ok: false, code: 'key_expired' });
+  });
+
+  it('accepts a valid, active, scoped key', async () => {
+    const out = await verifyApiKey(VALID, store());
+    expect(out.ok).toBe(true);
+    if (out.ok) {
+      expect(out.key.accountId).toBe('acct_1');
+      expect(out.rawPrefix).toBe('cog_aaaaaaaa');
+    }
+  });
+
+  it('computes held scopes (caps auto escalation, §6 item 2)', async () => {
+    const out = await verifyApiKey(VALID, store());
+    if (!out.ok) throw new Error('expected ok');
+    expect(highestHeldTier(out.key)).toBe('high');
+    expect(holdsTier(out.key, 'low')).toBe(true);
+    expect(holdsTier(out.key, 'mid')).toBe(false); // low+high only
+    expect(holdsTier(out.key, 'high')).toBe(true);
+  });
+});

--- a/services/apicompletions/tests/budget.test.ts
+++ b/services/apicompletions/tests/budget.test.ts
@@ -1,0 +1,212 @@
+// Reserve-and-Commit budget tracker — emulator-first ($0, in-memory) tests (ADR-204 rev-2
+// §5.2/§5.5). Exercises the deny boundary (over-cap → 402), the reserve→commit happy path,
+// crash (no commit) → lease expiry → headroom recovery, shard isolation, and idempotent late
+// COMMIT — plus the request-path wiring (reserve→invoke→commit) end-to-end via the mock provider.
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createAppWith } from '../src/server';
+import { COMPLETION_SCOPES, InMemoryKeyStore } from '../src/auth/apiKey';
+import { InMemoryBudgetTracker } from '../src/budget/tracker';
+import { worstCaseEstimateUsd, promptTokenFloor } from '../src/budget/estimate';
+import { loadConfig } from '../src/config';
+
+const KEY = 'cog_' + '7'.repeat(64);
+
+function keyStore(accountId = 'acct-1'): InMemoryKeyStore {
+  const s = new InMemoryKeyStore();
+  s.add(KEY, {
+    permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.mid, COMPLETION_SCOPES.high],
+    rateLimit: 1000,
+    active: true,
+    expiresAt: null,
+    accountId,
+  });
+  return s;
+}
+
+// A controllable clock so lease-expiry / recovery is deterministic.
+function clock(start = 1_000_000): { now: () => number; advance: (ms: number) => void } {
+  let t = start;
+  return { now: () => t, advance: (ms: number) => { t += ms; } };
+}
+
+// ───────────────────── Unit: the tracker mechanism (§5.2/§5.5) ─────────────────────
+describe('budget tracker — Reserve-and-Commit unit semantics (ADR-204 §5.2/§5.5)', () => {
+  const cfg = loadConfig();
+
+  it('unmetered account (no subscription doc) admits transparently with no reservation', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    const out = await t.reserve({ accountId: 'nobody', agentId: 'a', ceilingTier: 'high', estimateUsd: 9999, reqType: 'sync', resId: 'r1' });
+    expect(out.admit).toBe(true);
+    if (out.admit) expect(out.resId).toBeUndefined();
+    await t.commit('r1', 1); // no-op, must not throw
+  });
+
+  it('reserve → commit happy path: estimate held then released, actual booked', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 20, perAgentCapUsd: 8, shardCount: 4 });
+    const out = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'low', estimateUsd: 0.5, reqType: 'sync', resId: 'r1', shard: 0 });
+    expect(out.admit).toBe(true);
+    const shardAfterReserve = t.getShard('acct', 'ag', 0)!;
+    expect(shardAfterReserve.reservedUsd).toBeCloseTo(0.5, 9);
+    expect(shardAfterReserve.committedUsd).toBe(0);
+
+    await t.commit('r1', 0.2); // actual < estimate → gap returns to headroom
+    const shardAfterCommit = t.getShard('acct', 'ag', 0)!;
+    expect(shardAfterCommit.reservedUsd).toBeCloseTo(0, 9);
+    expect(shardAfterCommit.committedUsd).toBeCloseTo(0.2, 9);
+    expect(t.getReservation('r1')!.state).toBe('committed');
+  });
+
+  it('over-cap → 402: a worst-case estimate beyond the per-shard cap is denied at RESERVE', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    // perAgentCap 4 over K=4 → perShardCap 1.0; estimate 1.5 exceeds it.
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 20, perAgentCapUsd: 4, shardCount: 4 });
+    const out = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 1.5, reqType: 'sync', resId: 'r1', shard: 0 });
+    expect(out.admit).toBe(false);
+    if (!out.admit) {
+      expect(out.status).toBe(402);
+      expect(out.code).toBe('agent_budget_exhausted');
+    }
+  });
+
+  it('over-cap → 402: a headroom-exhausted account denies before touching any shard', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 5, perAgentCapUsd: 100, shardCount: 4, headroomExhausted: true });
+    const out = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'low', estimateUsd: 0.01, reqType: 'sync', resId: 'r1', shard: 0 });
+    expect(out.admit).toBe(false);
+    if (!out.admit) {
+      expect(out.status).toBe(402);
+      expect(out.code).toBe('account_budget_exhausted');
+    }
+  });
+
+  it('suspended account denies at RESERVE (status guard)', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 20, perAgentCapUsd: 8, shardCount: 4, status: 'suspended' });
+    const out = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'low', estimateUsd: 0.1, reqType: 'sync', resId: 'r1', shard: 0 });
+    expect(out.admit).toBe(false);
+    if (!out.admit) expect(out.code).toBe('account_budget_exhausted');
+  });
+
+  it('crash (no commit) → lease expires → reconcile reclaims headroom → next reserve admits', async () => {
+    const c = clock();
+    const t = new InMemoryBudgetTracker(cfg, { now: c.now });
+    // perShardCap 1.0; a single reservation of 0.9 nearly fills it.
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 20, perAgentCapUsd: 4, shardCount: 4 });
+    const first = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 0.9, reqType: 'sync', resId: 'r1', shard: 0 });
+    expect(first.admit).toBe(true);
+    // Agent crashes — r1 never commits. A second reserve of 0.9 would breach 1.0 → denied now.
+    const blocked = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 0.9, reqType: 'sync', resId: 'r2', shard: 0 });
+    expect(blocked.admit).toBe(false);
+
+    // Advance past the sync lease (~60s) and run the reconciler — the lapsed lease stops
+    // consuming headroom (§5.5 expiresAt>now predicate), so the shard reservedUsd resets.
+    c.advance(cfg.budget.leaseSyncMs + 1);
+    t.reconcile('acct');
+    expect(t.getShard('acct', 'ag', 0)!.reservedUsd).toBeCloseTo(0, 9);
+    expect(t.getReservation('r1')!.state).toBe('expired');
+
+    const recovered = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 0.9, reqType: 'sync', resId: 'r3', shard: 0 });
+    expect(recovered.admit).toBe(true);
+  });
+
+  it('shard isolation: filling shard 0 to its cap does not deny shard 1 of the same agent', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 20, perAgentCapUsd: 4, shardCount: 4 }); // perShardCap 1.0
+    const fill0 = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 1.0, reqType: 'sync', resId: 'r0', shard: 0 });
+    expect(fill0.admit).toBe(true);
+    const deny0 = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 0.1, reqType: 'sync', resId: 'r0b', shard: 0 });
+    expect(deny0.admit).toBe(false); // shard 0 is full
+    const ok1 = await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 1.0, reqType: 'sync', resId: 'r1', shard: 1 });
+    expect(ok1.admit).toBe(true); // shard 1 untouched
+  });
+
+  it('idempotent late COMMIT: a finish past the lease books once; a replayed COMMIT is a no-op', async () => {
+    const c = clock();
+    const t = new InMemoryBudgetTracker(cfg, { now: c.now });
+    t.seedAccount('acct', { servingBudgetUsd: 10, hardCapUsd: 20, perAgentCapUsd: 8, shardCount: 4 });
+    await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'low', estimateUsd: 0.5, reqType: 'sync', resId: 'r1', shard: 0 });
+    // The request runs PAST its lease, then commits late.
+    c.advance(cfg.budget.leaseSyncMs + 1);
+    await t.commit('r1', 0.3);
+    const shard1 = t.getShard('acct', 'ag', 0)!;
+    expect(shard1.committedUsd).toBeCloseTo(0.3, 9);
+    expect(shard1.reservedUsd).toBeCloseTo(0, 9);
+    // Replayed COMMIT must not double-charge.
+    await t.commit('r1', 0.3);
+    expect(t.getShard('acct', 'ag', 0)!.committedUsd).toBeCloseTo(0.3, 9);
+  });
+
+  it('reconcile flips headroomExhausted once committed+reserved ≥ hardCap', async () => {
+    const t = new InMemoryBudgetTracker(cfg);
+    t.seedAccount('acct', { servingBudgetUsd: 1, hardCapUsd: 1.5, perAgentCapUsd: 100, shardCount: 2 });
+    await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 1.0, reqType: 'streaming', resId: 'r1', shard: 0 });
+    await t.commit('r1', 1.0);
+    await t.reserve({ accountId: 'acct', agentId: 'ag', ceilingTier: 'high', estimateUsd: 0.8, reqType: 'streaming', resId: 'r2', shard: 1 });
+    t.reconcile('acct');
+    expect(t.getAccount('acct')!.headroomExhausted).toBe(true);
+  });
+});
+
+// ───────────────────── Estimate function (§5.2 worst-case) ─────────────────────
+describe('budget estimate — worst-case at the ceiling tier (ADR-204 §5.2)', () => {
+  const cfg = loadConfig();
+  it('prices prompt at Rate_In and maxTokens at Rate_Out of the CEILING tier', () => {
+    const high = cfg.tierPools.high;
+    const est = worstCaseEstimateUsd(cfg, 'high', 1_000_000, 1_000_000);
+    expect(est).toBeCloseTo(high.rateInPer1M + high.rateOutPer1M, 6);
+  });
+  it('ceiling-tier estimate ≥ low-tier estimate for the same tokens (gates the §4.3 margin attack)', () => {
+    expect(worstCaseEstimateUsd(cfg, 'high', 1000, 1000)).toBeGreaterThan(worstCaseEstimateUsd(cfg, 'low', 1000, 1000));
+  });
+  it('prompt floor is family-correct for the ceiling tier model', () => {
+    const n = promptTokenFloor(cfg, 'high', [{ role: 'user', content: 'hello world' }]);
+    expect(n).toBeGreaterThan(0);
+  });
+});
+
+// ───────────────────── Request-path wiring (reserve→invoke→commit) ─────────────────────
+describe('budget wiring — /v1/chat/completions reserve→invoke→commit (ADR-204 §5.2)', () => {
+  it('unmetered key: request succeeds unchanged (budget layer transparent)', async () => {
+    const app = createAppWith({ keyStore: keyStore() }); // default tracker, no seeded account
+    const r = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', KEY)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(200);
+    expect(r.body.x_cognitum.resolved_tier).toBe('low');
+  });
+
+  it('metered account at/over cap: request is denied 402 BEFORE the provider invoke', async () => {
+    const budget = new InMemoryBudgetTracker(loadConfig());
+    budget.seedAccount('acct-1', { servingBudgetUsd: 0, hardCapUsd: 0, perAgentCapUsd: 0, shardCount: 4, headroomExhausted: true });
+    const app = createAppWith({ keyStore: keyStore('acct-1'), budget });
+    const r = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', KEY)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(402);
+    expect(r.body.code).toBe('account_budget_exhausted');
+  });
+
+  it('metered happy path: a reservation is committed with the actual after the invoke', async () => {
+    const budget = new InMemoryBudgetTracker(loadConfig());
+    budget.seedAccount('acct-1', { servingBudgetUsd: 100, hardCapUsd: 100, perAgentCapUsd: 100, shardCount: 1 });
+    const app = createAppWith({ keyStore: keyStore('acct-1'), budget });
+    const r = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', KEY)
+      .set('X-Cognitum-Agent-Id', 'agent-x')
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi there' }] });
+    expect(r.status).toBe(200);
+    const reservation = budget.getReservation(r.headers['x-request-id']);
+    expect(reservation).toBeDefined();
+    expect(reservation!.state).toBe('committed');
+    expect(reservation!.actualUsd).toBeCloseTo(r.body.x_cognitum.price_usd, 9);
+    // The shard for agent-x holds the committed actual, no outstanding reservation.
+    const shard = budget.getShard('acct-1', 'agent-x', reservation!.shard)!;
+    expect(shard.reservedUsd).toBeCloseTo(0, 9);
+    expect(shard.committedUsd).toBeCloseTo(r.body.x_cognitum.price_usd, 9);
+  });
+});

--- a/services/apicompletions/tests/endpoints.test.ts
+++ b/services/apicompletions/tests/endpoints.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createApp, createAppWith } from '../src/server';
+import { COMPLETION_SCOPES, InMemoryKeyStore } from '../src/auth/apiKey';
+import type { ModelProvider, ProviderDelta, ProviderResult } from '../src/providers/types';
+import { ProviderError } from '../src/providers/types';
+import type { ChatCompletionRequest } from '../src/types/openai';
+
+const LOW = 'cog_' + '1'.repeat(64); // completions:low only
+const ALL = 'cog_' + '2'.repeat(64); // low+mid+high
+
+function seededStore(): InMemoryKeyStore {
+  const s = new InMemoryKeyStore();
+  s.add(LOW, { permissions: [COMPLETION_SCOPES.low], rateLimit: 120, active: true, expiresAt: null, accountId: 'a1' });
+  s.add(ALL, {
+    permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.mid, COMPLETION_SCOPES.high],
+    rateLimit: 120,
+    active: true,
+    expiresAt: null,
+    accountId: 'a2',
+  });
+  return s;
+}
+
+const app = createAppWith({ keyStore: seededStore() });
+const HARD = '```\n' + 'design '.repeat(800) + '\n```'; // long + code + reasoning → high
+
+describe('endpoints — /v1/chat/completions (ADR-203 §3.1, §3.4)', () => {
+  it('rejects raw vendor model ids with 404', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      .send({ model: 'gpt-5.5', messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe('model_not_found');
+  });
+
+  it('explicit cognitum-low returns an OpenAI-shaped completion with x_cognitum', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe('chat.completion');
+    expect(res.body.choices[0].message.role).toBe('assistant');
+    expect(res.body.choices[0].finish_reason).toBe('stop');
+    expect(res.body.usage).toHaveProperty('total_tokens');
+    expect(res.body.x_cognitum.resolved_tier).toBe('low');
+    expect(['deepseek-v4-pro', 'glm-5.2']).toContain(res.body.x_cognitum.resolved_model);
+    expect(typeof res.body.x_cognitum.price_usd).toBe('number');
+    expect(res.headers['x-cognitum-resolved-tier']).toBe('low');
+    expect(res.headers['x-request-id']).toBeTruthy();
+  });
+
+  it('explicit high without the scope is 403', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-high', messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('tier_scope_insufficient');
+  });
+
+  it('cognitum-auto routes an easy prompt to low', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'what is 2+2?' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.x_cognitum.resolved_tier).toBe('low');
+    expect(res.body.x_cognitum.escalated).toBe(false);
+  });
+
+  it('cognitum-auto routes a hard prompt to high up front', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: HARD }], max_tokens: 5000 });
+    expect(res.status).toBe(200);
+    expect(res.body.x_cognitum.resolved_tier).toBe('high');
+  });
+
+  it('best_effort scope mismatch degrades (cap_degraded) instead of 403', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .set('X-Cognitum-Fallback-Policy', 'best_effort')
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: HARD }], max_tokens: 5000 });
+    expect(res.status).toBe(200);
+    expect(res.body.x_cognitum.resolved_tier).toBe('low');
+    expect(res.body.x_cognitum.cap_degraded).toBe(true);
+    expect(res.headers['x-cognitum-cap-degraded']).toBe('true');
+  });
+
+  it('post-gen τ escalation: a hedged low answer escalates low→mid (§6.5)', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      // "tricky" looks easy (→ low) but the low-pool mock hedges → τ fires → escalate to mid
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'this is tricky' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.x_cognitum.escalated).toBe(true);
+    expect(res.body.x_cognitum.resolved_tier).toBe('mid');
+  });
+
+  it('enforces n=1 in v1', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }], n: 2 });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('invalid_request');
+  });
+
+  it('stream:true emits an OpenAI-compatible SSE (stream_oneshot, no escalation)', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello' }], stream: true });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.headers['x-cognitum-resolved-tier']).toBe('low');
+    expect(res.text).toContain('data:');
+    expect(res.text).toContain('chat.completion.chunk');
+    expect(res.text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+  });
+});
+
+describe('endpoints — provider fallback chain (ADR-203 §3.2)', () => {
+  // A provider that fails the first low-pool model and succeeds on the second.
+  const flaky: ModelProvider = {
+    name: 'flaky',
+    async complete(model: string, _req: ChatCompletionRequest): Promise<ProviderResult> {
+      if (model === 'deepseek-v4-pro') throw new ProviderError('simulated 503', [model]);
+      return { text: `served by ${model}`, usage: { prompt_tokens: 5, completion_tokens: 5, total_tokens: 10 } };
+    },
+    async *stream(): AsyncIterable<ProviderDelta> {
+      yield { content: '', finishReason: 'stop' };
+    },
+  };
+
+  it('fails over WITHIN the tier without changing the billed tier', async () => {
+    const fbApp = createAppWith({ keyStore: seededStore(), provider: flaky });
+    const res = await request(fbApp)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(200);
+    expect(res.body.x_cognitum.resolved_tier).toBe('low'); // tier unchanged
+    expect(res.body.x_cognitum.resolved_model).toBe('glm-5.2'); // failed over to #2
+  });
+
+  it('returns 502 when the whole tier chain fails', async () => {
+    const dead: ModelProvider = {
+      name: 'dead',
+      async complete(model: string): Promise<ProviderResult> {
+        throw new ProviderError('down', [model]);
+      },
+      async *stream(): AsyncIterable<ProviderDelta> {
+        yield { content: '', finishReason: 'stop' };
+      },
+    };
+    const deadApp = createAppWith({ keyStore: seededStore(), provider: dead });
+    const res = await request(deadApp)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(502);
+    expect(res.body.code).toBe('upstream_error');
+  });
+});
+
+describe('endpoints — /v1/completions (legacy) + /v1/models', () => {
+  it('legacy completions adapts prompt → messages and returns text_completion', async () => {
+    const res = await request(app)
+      .post('/v1/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', prompt: 'translate hello to French' });
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe('text_completion');
+    expect(typeof res.body.choices[0].text).toBe('string');
+    expect(res.body.x_cognitum.resolved_tier).toBe('low');
+  });
+
+  it('GET /v1/models still lists only the cognitum-* aliases', async () => {
+    const res = await request(createApp()).get('/v1/models');
+    expect(res.status).toBe(200);
+    const ids = (res.body.data as Array<{ id: string }>).map((m) => m.id);
+    expect(ids).toEqual(['cognitum-auto', 'cognitum-low', 'cognitum-mid', 'cognitum-high']);
+  });
+});

--- a/services/apicompletions/tests/endpoints.test.ts
+++ b/services/apicompletions/tests/endpoints.test.ts
@@ -167,6 +167,12 @@ describe('endpoints — provider fallback chain (ADR-203 §3.2)', () => {
       .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }] });
     expect(res.status).toBe(502);
     expect(res.body.code).toBe('upstream_error');
+    // The wire body must NOT leak the concrete vendor model roster / provider name (§3.4).
+    expect(res.body.error).toBe('Upstream provider error.');
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain('deepseek');
+    expect(serialized).not.toContain('glm-');
+    expect(serialized).not.toContain('tier chain');
   });
 });
 

--- a/services/apicompletions/tests/firewall.test.ts
+++ b/services/apicompletions/tests/firewall.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { loadMidstream, inflightAvailable } from '../src/midstream/firewall';
+
+describe('midstream optional-dependency firewall (ADR-203 §3.5)', () => {
+  it('degrades to Option B today (@midstream/wasm 404 on npm)', async () => {
+    // The dynamic import must fail gracefully, not throw — Option B is the operative state.
+    await expect(loadMidstream()).resolves.toBeNull();
+    await expect(inflightAvailable()).resolves.toBe(false);
+  });
+});

--- a/services/apicompletions/tests/health.test.ts
+++ b/services/apicompletions/tests/health.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../src/server';
+
+describe('apicompletions skeleton — health + surface', () => {
+  const app = createApp();
+
+  it('GET /healthz returns ok', async () => {
+    const res = await request(app).get('/healthz');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.service).toBe('apicompletions');
+  });
+
+  it('GET /v1/models lists the four cognitum-* aliases (not raw vendor ids)', async () => {
+    const res = await request(app).get('/v1/models');
+    expect(res.status).toBe(200);
+    const ids = (res.body.data as Array<{ id: string }>).map((m) => m.id);
+    expect(ids).toEqual(['cognitum-auto', 'cognitum-low', 'cognitum-mid', 'cognitum-high']);
+  });
+
+  it('POST /v1/chat/completions is a 501 skeleton (not yet implemented)', async () => {
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'hi' }] });
+    expect(res.status).toBe(501);
+    expect(res.body.code).toBe('not_implemented');
+  });
+});

--- a/services/apicompletions/tests/health.test.ts
+++ b/services/apicompletions/tests/health.test.ts
@@ -19,11 +19,12 @@ describe('apicompletions skeleton — health + surface', () => {
     expect(ids).toEqual(['cognitum-auto', 'cognitum-low', 'cognitum-mid', 'cognitum-high']);
   });
 
-  it('POST /v1/chat/completions is a 501 skeleton (not yet implemented)', async () => {
+  it('POST /v1/chat/completions without an API key is 401 (auth enforced, §6)', async () => {
     const res = await request(app)
       .post('/v1/chat/completions')
       .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'hi' }] });
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('not_implemented');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('missing_api_key');
+    expect(res.body).toHaveProperty('requestId');
   });
 });

--- a/services/apicompletions/tests/messages.test.ts
+++ b/services/apicompletions/tests/messages.test.ts
@@ -1,0 +1,204 @@
+// Anthropic Messages API (/v1/messages) — emulator-first ($0, mock provider) tests.
+// Covers: the model→tier map, the non-streaming Anthropic response shape, the streaming event
+// sequence, the honesty guard (real resolved model surfaced, never misrepresented as Claude),
+// auth via x-api-key, and the pure translation/SSE adapters.
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createAppWith } from '../src/server';
+import { COMPLETION_SCOPES, InMemoryKeyStore } from '../src/auth/apiKey';
+import {
+  mapModelToDial,
+  anthropicToCanonical,
+  buildAnthropicResponse,
+  mapStopReason,
+  extractText,
+} from '../src/anthropic/translate';
+import {
+  messageStartEvent,
+  contentBlockStartEvent,
+  pingEvent,
+  contentBlockDeltaEvent,
+  contentBlockStopEvent,
+  messageDeltaEvent,
+  messageStopEvent,
+} from '../src/anthropic/sse';
+import type { XCognitum } from '../src/types/openai';
+
+const KEY = 'cog_' + '5'.repeat(64); // low+mid+high
+
+function keyStore(): InMemoryKeyStore {
+  const s = new InMemoryKeyStore();
+  s.add(KEY, {
+    permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.mid, COMPLETION_SCOPES.high],
+    rateLimit: 1000,
+    active: true,
+    expiresAt: null,
+    accountId: 'acct-anthropic',
+  });
+  return s;
+}
+
+// ───────────────────── Translation adapter (pure) ─────────────────────
+describe('anthropic translate — model→tier map + canonical translation (§3.6)', () => {
+  it('maps Claude family names to tiers (opus→high, sonnet→mid, haiku→low)', () => {
+    expect(mapModelToDial('claude-opus-4-8')).toBe('cognitum-high');
+    expect(mapModelToDial('claude-3-5-sonnet-20241022')).toBe('cognitum-mid');
+    expect(mapModelToDial('claude-haiku-4')).toBe('cognitum-low');
+  });
+  it('passes cognitum-* dials through verbatim', () => {
+    expect(mapModelToDial('cognitum-auto')).toBe('cognitum-auto');
+    expect(mapModelToDial('cognitum-high')).toBe('cognitum-high');
+  });
+  it('falls back to cognitum-auto for an unrecognized model', () => {
+    expect(mapModelToDial('some-other-model')).toBe('cognitum-auto');
+  });
+  it('extracts text from both string and block-array content', () => {
+    expect(extractText('hi')).toBe('hi');
+    expect(extractText([{ type: 'text', text: 'a' }, { type: 'text', text: 'b' }])).toBe('ab');
+    expect(extractText([{ type: 'image', source: {} } as never, { type: 'text', text: 'c' }])).toBe('c');
+  });
+  it('lifts the top-level system field into a leading system message', () => {
+    const canon = anthropicToCanonical({
+      model: 'claude-haiku-4',
+      max_tokens: 100,
+      system: 'be terse',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+    expect(canon.model).toBe('cognitum-low');
+    expect(canon.messages[0]).toEqual({ role: 'system', content: 'be terse' });
+    expect(canon.messages[1]).toEqual({ role: 'user', content: 'hello' });
+    expect(canon.max_tokens).toBe(100);
+  });
+  it('maps OpenAI finish_reason → Anthropic stop_reason (length→max_tokens, else end_turn)', () => {
+    expect(mapStopReason('length')).toBe('max_tokens');
+    expect(mapStopReason('stop')).toBe('end_turn');
+    expect(mapStopReason(undefined)).toBe('end_turn');
+  });
+  it('buildAnthropicResponse surfaces the REAL resolved model (honesty guard)', () => {
+    const xc: XCognitum = { request_id: 'r', resolved_tier: 'low', resolved_model: 'deepseek-v4-pro', escalated: false, cap_degraded: false, price_usd: 0 };
+    const resp = buildAnthropicResponse({
+      requestId: 'r', resolvedModel: 'deepseek-v4-pro', text: 'hi',
+      usage: { prompt_tokens: 3, completion_tokens: 2, total_tokens: 5 }, stopReason: 'end_turn', xCognitum: xc,
+    });
+    expect(resp.type).toBe('message');
+    expect(resp.model).toBe('deepseek-v4-pro'); // NOT claude-*
+    expect(resp.content).toEqual([{ type: 'text', text: 'hi' }]);
+    expect(resp.usage).toEqual({ input_tokens: 3, output_tokens: 2 });
+  });
+});
+
+// ───────────────────── SSE adapter (pure) ─────────────────────
+describe('anthropic SSE — event frame builders (§3.6 streaming)', () => {
+  it('frames carry the Anthropic event:/data: shape', () => {
+    const f = contentBlockDeltaEvent('hello');
+    expect(f).toContain('event: content_block_delta');
+    expect(f).toContain('"type":"text_delta"');
+    expect(f).toContain('"text":"hello"');
+    expect(f.endsWith('\n\n')).toBe(true);
+  });
+  it('message_start carries the real model + zeroed output_tokens', () => {
+    const f = messageStartEvent({ id: 'msg_1', model: 'glm-5.2', inputTokens: 7 });
+    expect(f).toContain('event: message_start');
+    expect(f).toContain('"model":"glm-5.2"');
+    expect(f).toContain('"input_tokens":7');
+    expect(f).toContain('"output_tokens":0');
+  });
+});
+
+// ───────────────────── Auth ─────────────────────
+describe('/v1/messages — auth via x-api-key (§6)', () => {
+  it('401 without an API key', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app).post('/v1/messages').send({ model: 'claude-haiku-4', max_tokens: 50, messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(401);
+  });
+  it('authenticates via x-api-key (case-insensitive header) and ignores anthropic-version', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app)
+      .post('/v1/messages')
+      .set('X-API-Key', KEY)
+      .set('anthropic-version', '2023-06-01')
+      .send({ model: 'claude-haiku-4', max_tokens: 50, messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(200);
+  });
+});
+
+// ───────────────────── Non-streaming response shape + honesty guard ─────────────────────
+describe('/v1/messages — non-streaming Anthropic response (§3.6)', () => {
+  it('returns the Anthropic message shape', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app)
+      .post('/v1/messages')
+      .set('X-API-Key', KEY)
+      .send({ model: 'cognitum-high', max_tokens: 64, system: 'be brief', messages: [{ role: 'user', content: 'what is 2+2?' }] });
+    expect(r.status).toBe(200);
+    expect(r.body.type).toBe('message');
+    expect(r.body.role).toBe('assistant');
+    expect(Array.isArray(r.body.content)).toBe(true);
+    expect(r.body.content[0].type).toBe('text');
+    expect(typeof r.body.content[0].text).toBe('string');
+    expect(r.body.id).toMatch(/^msg_/);
+    expect(r.body.stop_reason).toBe('end_turn');
+    expect(r.body.usage).toHaveProperty('input_tokens');
+    expect(r.body.usage).toHaveProperty('output_tokens');
+  });
+
+  it('honesty guard: haiku (→low) resolves to a NON-Anthropic model surfaced in model + x_cognitum', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app)
+      .post('/v1/messages')
+      .set('X-API-Key', KEY)
+      .send({ model: 'claude-haiku-4', max_tokens: 64, messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(200);
+    // The low pool serves deepseek/glm — the response must NOT misrepresent it as Claude.
+    expect(r.body.x_cognitum.resolved_tier).toBe('low');
+    expect(['deepseek-v4-pro', 'glm-5.2']).toContain(r.body.x_cognitum.resolved_model);
+    expect(r.body.model).toBe(r.body.x_cognitum.resolved_model);
+    expect(r.body.model).not.toMatch(/claude/i);
+    expect(r.headers['x-cognitum-resolved-model']).toBe(r.body.model);
+  });
+
+  it('tier map: opus→high resolves at the high tier', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app)
+      .post('/v1/messages')
+      .set('X-API-Key', KEY)
+      .send({ model: 'claude-opus-4-8', max_tokens: 64, messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(200);
+    expect(r.body.x_cognitum.resolved_tier).toBe('high');
+  });
+
+  it('400 when max_tokens is missing (Anthropic requires it)', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app)
+      .post('/v1/messages')
+      .set('X-API-Key', KEY)
+      .send({ model: 'claude-haiku-4', messages: [{ role: 'user', content: 'hi' }] });
+    expect(r.status).toBe(400);
+  });
+});
+
+// ───────────────────── Streaming event sequence ─────────────────────
+describe('/v1/messages — streaming event sequence (§3.6)', () => {
+  it('synthesizes the Anthropic event sequence from the (non-Anthropic) mock provider', async () => {
+    const app = createAppWith({ keyStore: keyStore() });
+    const r = await request(app)
+      .post('/v1/messages')
+      .set('X-API-Key', KEY)
+      .send({ model: 'claude-haiku-4', max_tokens: 64, stream: true, messages: [{ role: 'user', content: 'stream please' }] });
+    expect(r.status).toBe(200);
+    const text = r.text;
+    // The required events appear in order.
+    const order = ['message_start', 'content_block_start', 'ping', 'content_block_delta', 'content_block_stop', 'message_delta', 'message_stop'];
+    let cursor = -1;
+    for (const ev of order) {
+      const idx = text.indexOf(`event: ${ev}`, cursor + 1);
+      expect(idx, `event ${ev} present and ordered`).toBeGreaterThan(cursor);
+      cursor = idx;
+    }
+    // The streamed terminal frame carries the honest resolution + the text_delta payload.
+    expect(text).toContain('"type":"text_delta"');
+    expect(text).toContain('"stop_reason":"end_turn"');
+    expect(text).toMatch(/"resolved_tier":"low"/);
+  });
+});

--- a/services/apicompletions/tests/metering.test.ts
+++ b/services/apicompletions/tests/metering.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import { createAppWith } from '../src/server';
+import { COMPLETION_SCOPES, InMemoryKeyStore } from '../src/auth/apiKey';
+import {
+  InMemoryLedgerStore,
+  InMemoryUsagePublisher,
+  type UsageRecord,
+} from '../src/metering/ledger';
+import { priceUsd } from '../src/metering/pricing';
+import {
+  familyOf,
+  estimateTokens,
+  estimateTokensForFamily,
+  makeCounter,
+} from '../src/metering/tokenizer';
+import {
+  RateLimiter,
+  InMemoryRateLimitStore,
+} from '../src/ratelimit/limiter';
+import { InMemoryIdempotencyStore } from '../src/ratelimit/idempotency';
+import { loadConfig } from '../src/config';
+import { fold, aggregate, periodOf, InMemoryRollupStore } from '../functions/aggregateUsage/src/index';
+import type { Tier, Usage } from '../src/types/openai';
+
+const LOW = 'cog_' + '1'.repeat(64); // completions:low only
+const ALL = 'cog_' + '2'.repeat(64); // low+mid+high
+
+function seededStore(): InMemoryKeyStore {
+  const s = new InMemoryKeyStore();
+  s.add(LOW, { permissions: [COMPLETION_SCOPES.low], rateLimit: 120, active: true, expiresAt: null, accountId: 'a1' });
+  s.add(ALL, {
+    permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.mid, COMPLETION_SCOPES.high],
+    rateLimit: 120,
+    active: true,
+    expiresAt: null,
+    accountId: 'a2',
+  });
+  return s;
+}
+
+// ───────────────────────── Pricing (§5.2) ─────────────────────────
+describe('pricing — strictly linear pass on the RESOLVED tier (ADR-203 §5.2)', () => {
+  const cfg = loadConfig();
+  const usage: Usage = { prompt_tokens: 1_000_000, completion_tokens: 1_000_000, total_tokens: 2_000_000 };
+
+  it('charges Input×Rate_In + Output×Rate_Out at the resolved tier', () => {
+    const low = cfg.tierPools.low;
+    expect(priceUsd(cfg, 'low', usage)).toBeCloseTo(low.rateInPer1M + low.rateOutPer1M, 6);
+  });
+
+  it('rates are ASYMMETRIC (output > input) per tier', () => {
+    const inOnly: Usage = { prompt_tokens: 1_000_000, completion_tokens: 0, total_tokens: 1_000_000 };
+    const outOnly: Usage = { prompt_tokens: 0, completion_tokens: 1_000_000, total_tokens: 1_000_000 };
+    expect(priceUsd(cfg, 'mid', outOnly)).toBeGreaterThan(priceUsd(cfg, 'mid', inOnly));
+  });
+
+  it('escalation bills at the HIGHER resolved tier, not the requested one', () => {
+    expect(priceUsd(cfg, 'high', usage)).toBeGreaterThan(priceUsd(cfg, 'low', usage));
+  });
+});
+
+// ───────────────────── Family-correct tokenizer (§5.1) ─────────────────────
+describe('tokenizer — family-correct byte→token floor (ADR-203 §5.1)', () => {
+  it('resolves the BPE family from the resolved model id', () => {
+    expect(familyOf('deepseek-v4-pro')).toBe('deepseek');
+    expect(familyOf('glm-5.2')).toBe('glm');
+    expect(familyOf('gpt-5.5')).toBe('openai');
+    expect(familyOf('gemini-3.1-pro')).toBe('gemini');
+    expect(familyOf('claude-opus-4.8')).toBe('anthropic');
+    expect(familyOf('some-unknown-model')).toBe('unknown');
+  });
+
+  it('does NOT count non-OpenAI output with the OpenAI ratio (the §5.1 mis-bill bug)', () => {
+    const text = 'def f(x):\n    return x * 2  # a representative chunk of generated output';
+    const openai = estimateTokensForFamily('openai', text);
+    const deepseek = estimateTokensForFamily('deepseek', text);
+    const glm = estimateTokensForFamily('glm', text);
+    // Distinct per family — deepseek/glm pack more bytes/token, so fewer tokens than OpenAI.
+    expect(deepseek).not.toBe(openai);
+    expect(glm).not.toBe(openai);
+    expect(estimateTokens('deepseek-v4-pro', text)).toBe(deepseek);
+    expect(estimateTokens('gpt-5.5', text)).toBe(openai);
+  });
+
+  it('progressive counter sums deltas as the FLOOR (provider count preferred when it arrives)', () => {
+    const c = makeCounter('deepseek-v4-pro', 'low');
+    expect(c.family).toBe('deepseek');
+    expect(c.completionTokens()).toBe(0); // empty stream → 0
+    c.pushDelta('hello ');
+    c.pushDelta('world, this is a streamed answer.');
+    const whole = estimateTokens('deepseek-v4-pro', 'hello world, this is a streamed answer.');
+    expect(c.completionTokens()).toBe(whole); // byte-accumulate then divide once
+  });
+});
+
+// ───────────────────── Rate limiter (§5.3) ─────────────────────
+describe('rate limiter — scatter-gather COUNT() + debounce (ADR-203 §5.3)', () => {
+  const KEY = 'hash-key-1';
+  const TIER: Tier = 'low';
+
+  it('admits up to the per-tier limit then denies with a retry hint', async () => {
+    // debounce 0 → every check re-counts the append-only window (no soft over-admit).
+    const limiter = new RateLimiter(new InMemoryRateLimitStore(), { debounceMs: 0 });
+    expect((await limiter.checkAndRecord(KEY, TIER, 2)).allowed).toBe(true);
+    expect((await limiter.checkAndRecord(KEY, TIER, 2)).allowed).toBe(true);
+    const denied = await limiter.checkAndRecord(KEY, TIER, 2);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterMs).toBeGreaterThan(0);
+  });
+
+  it('counts per (key, tier) — a different tier has an independent window', async () => {
+    const limiter = new RateLimiter(new InMemoryRateLimitStore(), { debounceMs: 0 });
+    await limiter.checkAndRecord(KEY, 'low', 1);
+    expect((await limiter.checkAndRecord(KEY, 'low', 1)).allowed).toBe(false); // low exhausted
+    expect((await limiter.checkAndRecord(KEY, 'mid', 1)).allowed).toBe(true); // mid independent
+  });
+
+  it('TTL window: ticks outside the window are not counted', async () => {
+    const limiter = new RateLimiter(new InMemoryRateLimitStore(), { debounceMs: 0, windowMs: 30 });
+    expect((await limiter.checkAndRecord(KEY, TIER, 1)).allowed).toBe(true);
+    expect((await limiter.checkAndRecord(KEY, TIER, 1)).allowed).toBe(false);
+    await new Promise((r) => setTimeout(r, 45)); // let the window + TTL roll
+    expect((await limiter.checkAndRecord(KEY, TIER, 1)).allowed).toBe(true);
+  });
+
+  it('debounce makes the limiter intentionally SOFT — bounded over-admit within the cache TTL', async () => {
+    // A long debounce caches a stale count; optimistic increments still apply, but the
+    // documented §5.3 trade is that a burst inside the TTL can briefly over-admit.
+    const limiter = new RateLimiter(new InMemoryRateLimitStore(), { debounceMs: 5_000 });
+    const a = await limiter.checkAndRecord(KEY, TIER, 1); // count 0 → admit, optimistic → 1
+    const b = await limiter.checkAndRecord(KEY, TIER, 1); // cached 1 ≥ 1 → denied
+    expect(a.allowed).toBe(true);
+    expect(b.allowed).toBe(false);
+  });
+
+  it('returns 429 over HTTP with a Retry-After header when the tier limit is hit', async () => {
+    const cfg = loadConfig();
+    cfg.tierPools = { ...cfg.tierPools, low: { ...cfg.tierPools.low, rateLimitPerMin: 2 } };
+    const app = createAppWith({
+      config: cfg,
+      keyStore: seededStore(),
+      rateLimiter: new RateLimiter(new InMemoryRateLimitStore(), { debounceMs: 0 }),
+    });
+    const fire = () =>
+      request(app)
+        .post('/v1/chat/completions')
+        .set('X-API-Key', LOW)
+        .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }] });
+    expect((await fire()).status).toBe(200);
+    expect((await fire()).status).toBe(200);
+    const limited = await fire();
+    expect(limited.status).toBe(429);
+    expect(limited.body.code).toBe('rate_limit_exceeded');
+    expect(limited.headers['retry-after']).toBeTruthy();
+  });
+});
+
+// ───────────────────── Idempotency (§5.3) ─────────────────────
+describe('idempotency — 24h replay cache, NOT re-billed (ADR-203 §5.3)', () => {
+  it('a replay returns the cached body and writes only ONE ledger row', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const app = createAppWith({ keyStore: seededStore(), ledger, idempotency: new InMemoryIdempotencyStore() });
+    const send = () =>
+      request(app)
+        .post('/v1/chat/completions')
+        .set('X-API-Key', LOW)
+        .set('Idempotency-Key', 'idem-123')
+        .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello' }] });
+
+    const first = await send();
+    expect(first.status).toBe(200);
+    expect(first.headers['idempotent-replay']).toBeUndefined();
+
+    const replay = await send();
+    expect(replay.status).toBe(200);
+    expect(replay.headers['idempotent-replay']).toBe('true');
+    expect(replay.body.id).toBe(first.body.id); // identical cached body
+
+    expect(ledger.size).toBe(1); // billed once, not twice
+  });
+});
+
+// ───────────────────── Ledger + publish on the request path (§5.1) ─────────────────────
+describe('metering — usage_ledger truth + Pub/Sub rollup feed (ADR-203 §5.1)', () => {
+  it('writes one ledger row + publishes one usage event per completion', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const publisher = new InMemoryUsagePublisher();
+    const app = createAppWith({ keyStore: seededStore(), ledger, usagePublisher: publisher });
+
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello world' }] });
+    expect(res.status).toBe(200);
+
+    await vi_flush();
+    const rows = ledger.all();
+    expect(rows).toHaveLength(1);
+    const row: UsageRecord = rows[0];
+    expect(row.tier).toBe('low');
+    expect(row.accountId).toBe('a1');
+    expect(row.keyPrefix).toBe('cog_11111111'); // only the 12-char prefix, never the key
+    expect(row.priceUsd).toBeCloseTo(res.body.x_cognitum.price_usd, 9);
+    expect(row.totalTokens).toBe(res.body.usage.total_tokens);
+    expect(publisher.published).toHaveLength(1);
+    expect(publisher.published[0].requestId).toBe(row.requestId);
+  });
+
+  it('escalation records the RESOLVED (higher) tier + escalated flag in the ledger (§5.2)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const app = createAppWith({ keyStore: seededStore(), ledger });
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'this is tricky' }] });
+    expect(res.status).toBe(200);
+    await vi_flush();
+    const row = ledger.all()[0];
+    expect(row.escalated).toBe(true);
+    expect(row.tier).toBe('mid'); // billed at the tier that ran
+  });
+
+  it('streaming writes a family-correct local-floor ledger row on completion (§5.1)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const app = createAppWith({ keyStore: seededStore(), ledger });
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello' }], stream: true });
+    expect(res.status).toBe(200);
+    await vi_flush();
+    const row = ledger.all()[0];
+    expect(row).toBeTruthy();
+    expect(row.tokensFromLocalFloor).toBe(true);
+    expect(row.completionTokens).toBeGreaterThan(0);
+  });
+
+  it('legacy /v1/completions also meters (§5.1)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const app = createAppWith({ keyStore: seededStore(), ledger });
+    const res = await request(app)
+      .post('/v1/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', prompt: 'translate hello' });
+    expect(res.status).toBe(200);
+    await vi_flush();
+    expect(ledger.size).toBe(1);
+  });
+});
+
+// ───────────────────── aggregateUsage fold (§5.1) ─────────────────────
+describe('aggregateUsage — Pub/Sub → usage_rollups fold (ADR-203 §5.1)', () => {
+  const evt = (over: Partial<Parameters<typeof fold>[1]> = {}) => ({
+    accountId: 'acct-1',
+    tier: 'low',
+    resolvedModel: 'deepseek-v4-pro',
+    promptTokens: 10,
+    completionTokens: 20,
+    totalTokens: 30,
+    priceUsd: 0.001,
+    ts: Date.UTC(2026, 5, 27),
+    ...over,
+  });
+
+  it('periodOf derives the UTC YYYY-MM billing period', () => {
+    expect(periodOf(Date.UTC(2026, 0, 5))).toBe('2026-01');
+    expect(periodOf(Date.UTC(2026, 11, 31))).toBe('2026-12');
+  });
+
+  it('folds events into per-tier / per-model buckets + running totals', () => {
+    let doc = fold(null, evt());
+    doc = fold(doc, evt({ tier: 'high', resolvedModel: 'claude-opus-4.8', priceUsd: 0.05, totalTokens: 100 }));
+    expect(doc.totals.requests).toBe(2);
+    expect(doc.totals.totalTokens).toBe(130);
+    expect(doc.byTier.low.requests).toBe(1);
+    expect(doc.byTier.high.priceUsd).toBeCloseTo(0.05, 9);
+    expect(doc.byModel['deepseek-v4-pro'].requests).toBe(1);
+  });
+
+  it('aggregate read-fold-writes into usage_rollups/{accountId}/{period}', async () => {
+    const store = new InMemoryRollupStore();
+    await aggregate(store, evt());
+    await aggregate(store, evt());
+    const doc = await store.get('acct-1', '2026-06');
+    expect(doc?.totals.requests).toBe(2);
+    expect(doc?.totals.priceUsd).toBeCloseTo(0.002, 9);
+  });
+});
+
+/** Let detached fire-and-forget publishes + close-handler microtasks settle before asserting. */
+async function vi_flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 5));
+}

--- a/services/apicompletions/tests/metering.test.ts
+++ b/services/apicompletions/tests/metering.test.ts
@@ -179,6 +179,32 @@ describe('idempotency — 24h replay cache, NOT re-billed (ADR-203 §5.3)', () =
 
     expect(ledger.size).toBe(1); // billed once, not twice
   });
+
+  it('does NOT replay across API keys — the cache is namespaced per principal (sec-review §5.3)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const idempotency = new InMemoryIdempotencyStore();
+    const app = createAppWith({ keyStore: seededStore(), ledger, idempotency });
+    const send = (apiKey: string) =>
+      request(app)
+        .post('/v1/chat/completions')
+        .set('X-API-Key', apiKey)
+        .set('Idempotency-Key', 'shared-idem-key')
+        .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'secret for key A' }] });
+
+    // Key A (LOW) stores a completion under Idempotency-Key 'shared-idem-key'.
+    const a = await send(LOW);
+    expect(a.status).toBe(200);
+    expect(a.headers['idempotent-replay']).toBeUndefined();
+
+    // Key B (ALL) sends the SAME attacker-chosen Idempotency-Key → MUST MISS (no replay), and
+    // is processed/billed on its own — never served A's cached body (cross-tenant leak).
+    const b = await send(ALL);
+    expect(b.status).toBe(200);
+    expect(b.headers['idempotent-replay']).toBeUndefined(); // not a replay of A
+    expect(b.body.id).not.toBe(a.body.id); // distinct completion, not A's leaked row
+
+    expect(ledger.size).toBe(2); // both keys billed — no cross-tenant billing bypass
+  });
 });
 
 // ───────────────────── Ledger + publish on the request path (§5.1) ─────────────────────

--- a/services/apicompletions/tests/routing.test.ts
+++ b/services/apicompletions/tests/routing.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import type { ApiKeyDoc } from '../src/auth/apiKey';
+import { COMPLETION_SCOPES } from '../src/auth/apiKey';
+import { parseModelAlias, resolveTier, tierRank, nextTierUp } from '../src/tier/resolveTier';
+import { computeDifficulty } from '../src/router/difficulty';
+import { shouldEscalate, verify } from '../src/router/escalation';
+import type { ChatCompletionRequest, Tier } from '../src/types/openai';
+
+function key(...tiers: Tier[]): ApiKeyDoc {
+  return {
+    key: 'hash',
+    prefix: 'cog_xxxxxxxx',
+    permissions: tiers.map((t) => COMPLETION_SCOPES[t]),
+    rateLimit: 100,
+    active: true,
+    expiresAt: null,
+    accountId: 'acct',
+  };
+}
+
+function chat(model: string, content: string, extra: Partial<ChatCompletionRequest> = {}): ChatCompletionRequest {
+  return { model, messages: [{ role: 'user', content }], ...extra };
+}
+
+describe('parseModelAlias (ADR-203 §3.4) — model field is the dial', () => {
+  it('maps the cognitum-* aliases', () => {
+    expect(parseModelAlias('cognitum-auto')).toEqual({ mode: 'auto', agentic: false });
+    expect(parseModelAlias('cognitum-low')).toEqual({ mode: 'explicit', tier: 'low', agentic: false });
+    expect(parseModelAlias('cognitum-mid')).toEqual({ mode: 'explicit', tier: 'mid', agentic: false });
+    expect(parseModelAlias('cognitum-high')).toEqual({ mode: 'explicit', tier: 'high', agentic: false });
+    expect(parseModelAlias('cognitum-high-agent')).toEqual({ mode: 'explicit', tier: 'high', agentic: true });
+    expect(parseModelAlias('cognitum-auto-agent')).toEqual({ mode: 'auto', agentic: true });
+  });
+
+  it('rejects raw vendor ids (→ 404 model_not_found)', () => {
+    expect(parseModelAlias('gpt-5.5')).toBeNull();
+    expect(parseModelAlias('claude-opus-4.8')).toBeNull();
+    expect(parseModelAlias('deepseek-v4-pro')).toBeNull();
+    expect(parseModelAlias('')).toBeNull();
+  });
+});
+
+describe('computeDifficulty (ADR-203 §3.3, PLACEMENT §7) — intrinsic input signal', () => {
+  it('routes everyday short prompts to low', () => {
+    expect(computeDifficulty(chat('cognitum-auto', 'what time is it in Tokyo?')).tier).toBe('low');
+  });
+  it('lifts on code/diff presence', () => {
+    const d = computeDifficulty(chat('cognitum-auto', '```py\nimport os\ndef f():\n  return 1\n```'));
+    expect(tierRank(d.tier)).toBeGreaterThanOrEqual(tierRank('mid'));
+  });
+  it('escalates to high on long reasoning + code + tools', () => {
+    const big = 'design '.repeat(800); // long + reasoning marker
+    const d = computeDifficulty(chat('cognitum-auto', '```\n' + big + '\n```', { tools: [{}], max_tokens: 5000 }));
+    expect(d.tier).toBe('high');
+  });
+});
+
+describe('resolveTier (ADR-203 §3.3, §6 item 2)', () => {
+  it('explicit mode pins the tier and requires the matching scope', () => {
+    const ok = resolveTier(chat('cognitum-low', 'hi'), key('low'));
+    expect(ok).toMatchObject({ kind: 'ok', tier: 'low', mode: 'explicit' });
+    const denied = resolveTier(chat('cognitum-high', 'hi'), key('low'));
+    expect(denied).toMatchObject({ kind: 'error', status: 403, code: 'tier_scope_insufficient' });
+  });
+
+  it('returns 404 for raw vendor model ids', () => {
+    expect(resolveTier(chat('gpt-5.5', 'hi'), key('high'))).toMatchObject({ kind: 'error', status: 404, code: 'model_not_found' });
+  });
+
+  it('auto mode routes by difficulty within held scope', () => {
+    const r = resolveTier(chat('cognitum-auto', 'what is 2+2?'), key('low', 'mid', 'high'));
+    expect(r).toMatchObject({ kind: 'ok', tier: 'low', mode: 'auto' });
+  });
+
+  it('auto: min_tier is a quality floor, max_tier a cost cap', () => {
+    const floored = resolveTier(chat('cognitum-auto', 'hi', { min_tier: 'mid' }), key('low', 'mid', 'high'));
+    expect(floored).toMatchObject({ kind: 'ok', tier: 'mid' });
+    const big = 'design '.repeat(800);
+    const capped = resolveTier(chat('cognitum-auto', '```\n' + big + '\n```', { max_tokens: 5000, max_tier: 'mid' }), key('low', 'mid', 'high'));
+    expect(capped).toMatchObject({ kind: 'ok', tier: 'mid' }); // high difficulty capped to mid
+  });
+
+  it('auto scope-mismatch: fail_fast → 403, best_effort → cap_degraded', () => {
+    const big = 'design '.repeat(800);
+    const hard = '```\n' + big + '\n```';
+    const failFast = resolveTier(chat('cognitum-auto', hard, { max_tokens: 5000 }), key('low'));
+    expect(failFast).toMatchObject({ kind: 'error', status: 403, code: 'tier_scope_insufficient' });
+
+    const bestEffort = resolveTier(chat('cognitum-auto', hard, { max_tokens: 5000, fallback_policy: 'best_effort' }), key('low'));
+    expect(bestEffort).toMatchObject({ kind: 'ok', tier: 'low', capDegraded: true });
+  });
+
+  it('auto with no completions scope → 403', () => {
+    const k: ApiKeyDoc = { ...key(), permissions: ['payments:create'] };
+    expect(resolveTier(chat('cognitum-auto', 'hi'), k)).toMatchObject({ kind: 'error', status: 403, code: 'no_completions_scope' });
+  });
+});
+
+describe('escalation — internal adaptive τ (ADR-203 §6.5), non-stream only', () => {
+  it('verify flags hedging as low confidence', () => {
+    expect(verify("I'm not entirely sure about this").confidence).toBeLessThan(0.6);
+    expect(verify('The capital of France is Paris.').confidence).toBeGreaterThanOrEqual(0.6);
+    expect(verify('anything', 0.2).confidence).toBe(0.2); // provider signal pre-empts
+  });
+
+  it('escalates a low-confidence low answer to mid, bounded by ceiling', () => {
+    const lowConf = { confidence: 0.4 };
+    expect(shouldEscalate(lowConf, 'low', 'high')).toMatchObject({ escalate: true, nextTier: 'mid' });
+    // ceiling caps it
+    expect(shouldEscalate(lowConf, 'low', 'low')).toMatchObject({ escalate: false });
+    // high confidence never escalates
+    expect(shouldEscalate({ confidence: 0.95 }, 'low', 'high')).toMatchObject({ escalate: false });
+    // already at the ceiling
+    expect(shouldEscalate(lowConf, 'high', 'high')).toMatchObject({ escalate: false });
+  });
+
+  it('tier helpers', () => {
+    expect(nextTierUp('low')).toBe('mid');
+    expect(nextTierUp('mid')).toBe('high');
+    expect(nextTierUp('high')).toBeNull();
+  });
+});

--- a/services/apicompletions/tests/streaming.test.ts
+++ b/services/apicompletions/tests/streaming.test.ts
@@ -76,6 +76,21 @@ function slowProvider(deltas = ['alpha ', 'bravo ', 'charlie ', 'delta ', 'echo 
   };
 }
 
+/** A provider that streams one good delta, then throws (provider 5xx mid-stream). */
+function throwAfterFirst(): ModelProvider {
+  return {
+    name: 'throw-after-first',
+    async complete(): Promise<ProviderResult> {
+      return { text: 'partial answer ', usage: undefined };
+    },
+    async *stream(): AsyncIterable<ProviderDelta> {
+      yield { content: 'partial answer ', finishReason: null };
+      // Carries vendor detail that must NEVER reach the client (§3.4).
+      throw new Error('openrouter deepseek-v4-pro → HTTP 503');
+    },
+  };
+}
+
 // ───────────────────── integration — the route streaming paths ─────────────────────
 describe('streaming — /v1/chat/completions SSE paths (ADR-203 §3.3)', () => {
   it('stream_oneshot (default for stream:true): OpenAI-shaped SSE + final usage/x_cognitum chunk', async () => {
@@ -141,6 +156,33 @@ describe('streaming — /v1/chat/completions SSE paths (ADR-203 §3.3)', () => {
     expect(rows[0].truncated).toBe(true);
     expect(rows[0].tier).toBe('low');
     expect(rows[0].tokensFromLocalFloor).toBe(true);
+  });
+
+  it('provider error AFTER the first chunk → terminal SSE error (no headers-already-sent crash), bills once, no vendor leak (sec-review §3.3/§3.4)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const app = createAppWith({ keyStore: seededStore(), provider: throwAfterFirst(), ledger });
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hi' }], stream: true });
+    // Headers were already flushed by the first chunk → status is 200 SSE, NOT a 502 JSON.
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    expect(res.text).toContain('partial answer'); // the delta delivered before the error
+    // A terminal error chunk is emitted with a GENERIC message — no vendor id / provider name.
+    const errChunk = parseChunks(res.text).find((c) => (c as { error?: unknown }).error) as
+      | { error?: { code?: string; message?: string } }
+      | undefined;
+    expect(errChunk?.error?.code).toBe('upstream_error');
+    expect(errChunk?.error?.message).toBe('Upstream provider error.');
+    expect(res.text).not.toContain('deepseek');
+    expect(res.text).not.toContain('openrouter');
+    expect(res.text).not.toContain('HTTP 503');
+    expect(res.text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+    await tick(60); // let res 'close' + the truncation meter settle
+    const rows = ledger.all();
+    expect(rows).toHaveLength(1); // billed exactly once (partial, truncated) — not double-billed
+    expect(rows[0].truncated).toBe(true);
   });
 });
 

--- a/services/apicompletions/tests/streaming.test.ts
+++ b/services/apicompletions/tests/streaming.test.ts
@@ -1,0 +1,308 @@
+// Streaming paths + disconnect billing + inflight Option C′ (ADR-203 §3.3, §3.5, §5.1).
+// All $0: MockProvider + in-memory ledger; no paid model calls, no emulator network.
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import type { Response } from 'express';
+import { createAppWith } from '../src/server';
+import { COMPLETION_SCOPES, InMemoryKeyStore } from '../src/auth/apiKey';
+import type { ApiKeyDoc } from '../src/auth/apiKey';
+import { InMemoryLedgerStore } from '../src/metering/ledger';
+import { MockProvider } from '../src/providers/mockProvider';
+import { defaultDeps } from '../src/deps';
+import type { ModelProvider, ProviderDelta, ProviderResult } from '../src/providers/types';
+import type { ChatCompletionRequest } from '../src/types/openai';
+import type { TierResolution } from '../src/tier/resolveTier';
+import {
+  buildTruncationChunk,
+  loadInflightScanner,
+  streamInflight,
+  type EscalationSignal,
+  type InflightScanner,
+} from '../src/midstream/inflight';
+
+const LOW = 'cog_' + '1'.repeat(64);
+const ALL = 'cog_' + '2'.repeat(64);
+
+function seededStore(): InMemoryKeyStore {
+  const s = new InMemoryKeyStore();
+  s.add(LOW, { permissions: [COMPLETION_SCOPES.low], rateLimit: 120, active: true, expiresAt: null, accountId: 'a1' });
+  s.add(ALL, {
+    permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.mid, COMPLETION_SCOPES.high],
+    rateLimit: 120,
+    active: true,
+    expiresAt: null,
+    accountId: 'a2',
+  });
+  return s;
+}
+
+const tick = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Parse an SSE body into the decoded chunk objects (drops the [DONE] sentinel). */
+function parseChunks(text: string): Array<Record<string, unknown>> {
+  return text
+    .split('\n\n')
+    .map((s) => s.replace(/^data: /, '').trim())
+    .filter((s) => s.length > 0 && s !== '[DONE]')
+    .map((s) => JSON.parse(s) as Record<string, unknown>);
+}
+
+interface Chunk {
+  choices?: Array<{ delta?: { content?: string }; finish_reason?: string | null }>;
+  usage?: { completion_tokens: number };
+  x_cognitum?: {
+    escalated: boolean;
+    resolved_tier: string;
+    next_context?: string;
+    discarded_prefix_tokens?: number;
+  };
+}
+const as = (c: Record<string, unknown>): Chunk => c as Chunk;
+
+/** A provider that streams several deltas with a delay between each (for disconnect tests). */
+function slowProvider(deltas = ['alpha ', 'bravo ', 'charlie ', 'delta ', 'echo '], delayMs = 15): ModelProvider {
+  return {
+    name: 'slow',
+    async complete(model: string): Promise<ProviderResult> {
+      return { text: deltas.join(''), usage: { prompt_tokens: 1, completion_tokens: deltas.length, total_tokens: deltas.length + 1 } };
+    },
+    async *stream(): AsyncIterable<ProviderDelta> {
+      for (const d of deltas) {
+        await tick(delayMs);
+        yield { content: d, finishReason: null };
+      }
+      yield { content: '', finishReason: 'stop' };
+    },
+  };
+}
+
+// ───────────────────── integration — the route streaming paths ─────────────────────
+describe('streaming — /v1/chat/completions SSE paths (ADR-203 §3.3)', () => {
+  it('stream_oneshot (default for stream:true): OpenAI-shaped SSE + final usage/x_cognitum chunk', async () => {
+    const app = createAppWith({ keyStore: seededStore(), provider: new MockProvider() });
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello world' }], stream: true });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    const chunks = parseChunks(res.text).map(as);
+    // Content deltas exist, the trailing chunk carries usage + x_cognitum, no escalation.
+    expect(chunks.some((c) => c.choices?.[0]?.delta?.content)).toBe(true);
+    const last = chunks[chunks.length - 1];
+    expect(last.usage?.completion_tokens).toBeGreaterThan(0);
+    expect(last.x_cognitum?.escalated).toBe(false);
+    expect(last.x_cognitum?.resolved_tier).toBe('low');
+    expect(res.text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+  });
+
+  it('escalation:"buffered" buffers → verifies → pseudo-streams the escalated answer (§3.3)', async () => {
+    const app = createAppWith({ keyStore: seededStore(), provider: new MockProvider() });
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', ALL)
+      // "tricky" routes low, the low-pool mock hedges → τ fires → buffered escalates low→mid
+      .send({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'this is tricky' }], stream: true, escalation: 'buffered' });
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toContain('text/event-stream');
+    const chunks = parseChunks(res.text).map(as);
+    const stop = chunks.find((c) => c.choices?.[0]?.finish_reason === 'stop');
+    expect(stop?.x_cognitum?.escalated).toBe(true);
+    expect(stop?.x_cognitum?.resolved_tier).toBe('mid');
+    expect(res.text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+  });
+
+  it('escalation:"inflight" degrades to Option B today (midstream 404) — oneshot, no truncation chunk', async () => {
+    const app = createAppWith({ keyStore: seededStore(), provider: new MockProvider() });
+    const res = await request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'hello' }], stream: true, escalation: 'inflight' });
+    expect(res.status).toBe(200);
+    const chunks = parseChunks(res.text).map(as);
+    expect(chunks.some((c) => c.choices?.[0]?.finish_reason === 'content_filter')).toBe(false);
+    const last = chunks[chunks.length - 1];
+    expect(last.x_cognitum?.escalated).toBe(false);
+    expect(last.x_cognitum?.resolved_tier).toBe('low');
+  });
+
+  it('client disconnect mid-stream bills the partial answer with truncated:true (§5.1)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const app = createAppWith({ keyStore: seededStore(), provider: slowProvider(), ledger });
+    const pending = request(app)
+      .post('/v1/chat/completions')
+      .set('X-API-Key', LOW)
+      .send({ model: 'cognitum-low', messages: [{ role: 'user', content: 'stream please' }], stream: true });
+    setTimeout(() => pending.abort(), 30); // drop the socket after the first chunk(s)
+    await pending.then(() => undefined, () => undefined); // aborted request rejects — swallow
+    await tick(120); // let res 'close' + the truncation meter settle
+    const rows = ledger.all();
+    expect(rows).toHaveLength(1); // exactly one row — NOT overwritten by a normal-completion meter
+    expect(rows[0].truncated).toBe(true);
+    expect(rows[0].tier).toBe('low');
+    expect(rows[0].tokensFromLocalFloor).toBe(true);
+  });
+});
+
+// ───────────────────── unit — midstream firewall + inflight protocol (§3.5) ─────────────────────
+const lowResolution = (): TierResolution => ({
+  kind: 'ok',
+  tier: 'low',
+  mode: 'auto',
+  agentic: false,
+  capDegraded: false,
+  routingReason: 'difficulty: low',
+  floor: 'low',
+  ceiling: 'high',
+});
+
+const allKey = (): ApiKeyDoc => ({
+  key: 'hash',
+  prefix: 'cog_22222222',
+  permissions: [COMPLETION_SCOPES.low, COMPLETION_SCOPES.mid, COMPLETION_SCOPES.high],
+  rateLimit: 120,
+  active: true,
+  expiresAt: null,
+  accountId: 'a2',
+});
+
+/** A scanner that fires the given signal on the Nth content delta (else null). */
+function scannerAfter(n: number, signal: EscalationSignal): InflightScanner {
+  let i = 0;
+  return {
+    push(): EscalationSignal | null {
+      i += 1;
+      return i >= n ? signal : null;
+    },
+  };
+}
+
+/** Minimal Response capturing SSE writes + a fireable 'close' (client-disconnect) event. */
+class FakeRes {
+  readonly chunks: string[] = [];
+  ended = false;
+  private closeCbs: Array<() => void> = [];
+  setHeader(): void {}
+  write(s: string): boolean {
+    this.chunks.push(s);
+    return true;
+  }
+  end(): void {
+    this.ended = true;
+  }
+  on(event: string, cb: () => void): this {
+    if (event === 'close') this.closeCbs.push(cb);
+    return this;
+  }
+  fireClose(): void {
+    for (const cb of this.closeCbs) cb();
+  }
+  get text(): string {
+    return this.chunks.join('');
+  }
+}
+
+describe('midstream inflight — firewall + SDK-safe truncation (ADR-203 §3.5)', () => {
+  it('loadInflightScanner returns null today (@midstream/wasm 404 → Option B)', async () => {
+    const scanner = await loadInflightScanner({ model: 'cognitum-auto', messages: [{ role: 'user', content: 'hi' }] });
+    expect(scanner).toBeNull();
+  });
+
+  it('buildTruncationChunk emits an SDK-safe terminal chunk (finish_reason + escalation block)', () => {
+    const c = as(
+      buildTruncationChunk({
+        id: 'x',
+        created: 1,
+        model: 'cognitum-auto',
+        signal: { reason: 'explicit_refusal', finishReason: 'content_filter' },
+        resolvedTier: 'high',
+        nextContext: 'x:high',
+      }),
+    );
+    expect(c.choices?.[0]?.finish_reason).toBe('content_filter');
+    expect(c.x_cognitum?.escalated).toBe(true);
+    expect(c.x_cognitum?.resolved_tier).toBe('high');
+    expect(c.x_cognitum?.next_context).toBe('x:high');
+  });
+
+  it('streamInflight: a present scanner fires → SDK-safe truncation + higher-tier bridge + honest billing', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const deps = defaultDeps({ ledger, provider: new MockProvider() });
+    const res = new FakeRes();
+    const signal: EscalationSignal = { reason: 'loop_detected', finishReason: 'content_filter' };
+    await streamInflight({
+      deps,
+      res: res as unknown as Response,
+      requestId: 'req-esc',
+      body: { model: 'cognitum-auto', messages: [{ role: 'user', content: 'hello world this is a test prompt' }], stream: true, escalation: 'inflight' },
+      resolution: lowResolution(),
+      key: allKey(),
+      keyPrefix: 'cog_22222222',
+      startedAt: Date.now(),
+      scanner: scannerAfter(2, signal),
+    });
+    const chunks = parseChunks(res.text).map(as);
+    const trunc = chunks.find((c) => c.choices?.[0]?.finish_reason === 'content_filter');
+    expect(trunc).toBeTruthy();
+    expect(trunc?.x_cognitum?.escalated).toBe(true);
+    expect(trunc?.x_cognitum?.resolved_tier).toBe('mid'); // low → next tier up
+    expect(trunc?.x_cognitum?.next_context).toBe('req-esc:mid');
+    expect(res.ended).toBe(true);
+    expect(res.text.trimEnd().endsWith('data: [DONE]')).toBe(true);
+    await tick(10);
+    const row = ledger.get('req-esc');
+    expect(row?.tier).toBe('mid'); // delivered answer billed at the escalated tier (§3.5)
+    expect(row?.escalated).toBe(true);
+    expect(row?.discardedPrefixTokens).toBeGreaterThan(0); // wasted low prefix recorded honestly
+  });
+
+  it('streamInflight: no early signal → finishes at the starting tier (Option B-equivalent)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const deps = defaultDeps({ ledger, provider: new MockProvider() });
+    const res = new FakeRes();
+    await streamInflight({
+      deps,
+      res: res as unknown as Response,
+      requestId: 'req-clean',
+      body: { model: 'cognitum-auto', messages: [{ role: 'user', content: 'hello world' }], stream: true, escalation: 'inflight' },
+      resolution: lowResolution(),
+      key: allKey(),
+      keyPrefix: 'cog_22222222',
+      startedAt: Date.now(),
+      scanner: { push: () => null },
+    });
+    const chunks = parseChunks(res.text).map(as);
+    expect(chunks.some((c) => c.choices?.[0]?.finish_reason === 'content_filter')).toBe(false);
+    expect(chunks[chunks.length - 1].x_cognitum?.escalated).toBe(false);
+    await tick(10);
+    const row = ledger.get('req-clean');
+    expect(row?.tier).toBe('low');
+    expect(row?.escalated).toBe(false);
+    expect(row?.discardedPrefixTokens).toBeUndefined();
+  });
+
+  it('streamInflight: client disconnect mid-stream bills truncated:true (§5.1)', async () => {
+    const ledger = new InMemoryLedgerStore();
+    const deps = defaultDeps({ ledger, provider: slowProvider() });
+    const res = new FakeRes();
+    const p = streamInflight({
+      deps,
+      res: res as unknown as Response,
+      requestId: 'req-drop',
+      body: { model: 'cognitum-auto', messages: [{ role: 'user', content: 'stream please' }], stream: true, escalation: 'inflight' },
+      resolution: lowResolution(),
+      key: allKey(),
+      keyPrefix: 'cog_22222222',
+      startedAt: Date.now(),
+      scanner: { push: () => null },
+    });
+    await tick(20); // let a delta or two flow
+    res.fireClose(); // client drops the connection
+    await p;
+    await tick(10);
+    const row = ledger.get('req-drop');
+    expect(row?.truncated).toBe(true);
+    expect(row?.tier).toBe('low');
+    expect(row?.escalated).toBe(false);
+  });
+});

--- a/services/apicompletions/tsconfig.json
+++ b/services/apicompletions/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests", "functions", "terraform"]
+}

--- a/services/apicompletions/vitest.config.ts
+++ b/services/apicompletions/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['tests/**/*.test.ts'],
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
Implements **ADR-203** (Cognitum Fugu metered tiered Completions API) via a 6-phase workflow. **For review — not a merge yet.**

**Done (build + 100 unit/mock tests green across 9 files, emulator-first, $0 mock provider):** scaffold (TS/Node Express, matches cognitum-one/api stack) · real `cog_` SHA-256 auth + completions:{low,mid,high} scopes · tier router (model-as-dial, intrinsic input difficulty, min/max_tier, fail_fast/best_effort) · OpenAI `/v1/chat/completions`·`/completions`·`/models` · metering (family-correct tokenizer floor, usage_ledger+PubSub, resolved-tier pricing) · scatter-gather rate limiter (usage_ticks+COUNT+debounce) · SSE streaming (stream_oneshot default, buffered opt-in) · midstream firewall (degrades to Option B — @midstream/wasm is 404) · terraform (validate+plan, 19 resources, no apply).

**Adversarial review:** 20 findings; HIGH idempotency cross-tenant cache leak fixed (per-principal namespacing) + 19 others.

---

**Follow-on features LANDED (this push):**

1. **Reserve-and-Commit budget tracker + runaway guards (ADR-204 rev-2 §5.2/§5.5)** — `src/budget/`. Account doc `subscriptions/{accountId}` (status + decoupled `headroomExhausted` flag), SHARDED per-agent docs `agents/{agentId}_{shard}` (perShardCap = perAgentCap/K), reservation-lease docs `reservations/{resId}`. RESERVE (pre-invoke, atomic) prices the worst case at the ceiling tier and reads ONLY the account doc + one shard doc — no subcollection scan — denying **402** (account/agent budget) or **429** (loop) at the reservation write. COMMIT (post-invoke) releases the estimate, books the actual, **idempotent on resId**. Reconciler reclaims a crashed agent's headroom at logical lease `expiresAt` (not native-TTL GC). InMemory ($0 test) + Firestore (`runTransaction`) bindings. **Wired into the request path** (reserve→invoke→commit) for non-stream + streaming/truncated; unmetered accounts admit transparently. *15 new tests: over-cap→402, reserve→commit, crash→expire→recover, shard isolation, idempotent late-COMMIT, headroom flip, estimate, end-to-end wiring.*

2. **Anthropic Messages API `/v1/messages` + translation adapter (ADR-203 §3.6)** — `src/anthropic/` + `src/routes/messages.ts`. Anthropic request → canonical → the SAME pipeline → Anthropic response. Model→tier map (opus→high, sonnet→mid, haiku→low, cognitum-* pass-through); auth via the existing cog_ scheme on `x-api-key` (case-insensitive) + ignored `anthropic-version`. SSE adapter synthesizes the full Anthropic event sequence (message_start→content_block_start→ping→content_block_delta→content_block_stop→message_delta→message_stop) from ANY backend incl. the non-Anthropic MockProvider; stream_oneshot routing + disconnect-billing floor. **Honesty guard:** the `model` field + `x_cognitum.resolved_model`/`resolved_tier` always carry the REAL resolved model — never misrepresented as Claude when auto/low resolves to deepseek/glm/gpt. *16 new tests: model→tier map, translation, SSE frames, non-stream shape, streaming sequence, honesty guard, x-api-key auth.*

**Honesty note:** the vitest suite is 100 tests across 9 files (no separate emulator-gated E2E suite exists on this branch — the budget/messages tests run $0 against in-memory Firestore-shaped fakes + the MockProvider, the same DI posture as the rest of the service). ADR-203 currently documents through §3.5; the §3.6 Messages-API section is implemented per this PR's spec and should be back-filled into the ADR.

**Deferred / next (honest):** heavy GCP SDKs (firebase-admin, @google-cloud/pubsub, js-tiktoken) are stubbed behind local interfaces for $0 testing → production wiring is the next step. The midstream inflight path (off-by-default, unreachable today) does not yet commit its budget lease — it relies on the §5.5 lease-expiry reconciler, which is the correct safety net for it. Open dependency: `accountId` on cognitum-one/api `api_keys`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)
