### PR TITLE
fix(ci): unbreak the Node matrix — path-guard false positives + cost-breaker e2e timeout

### DIFF
--- a/packages/darwin-mode/__tests__/e2e/cost-breaker.e2e.test.ts
+++ b/packages/darwin-mode/__tests__/e2e/cost-breaker.e2e.test.ts
@@ -72,7 +72,7 @@ describe('evolve — cost circuit-breaker (ADR-072)', () => {
     for (const record of result.records) {
       expect(await inspectVariant(record.variant.dir)).toEqual([]);
     }
-  });
+  }, 30_000); // one full evolve run — 5s default flakes on slow CI runners (macos matrix)
 
   it('a generous budget produces at least as many scored records as a tiny one', async () => {
     const tiny = await evolve({

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -66,6 +66,15 @@ const CHECKS = {
       // @metaharness/projects (Darwin Shield / defensive zero-day harness, ADR-155+)
       // is a standalone published library on its own semver, like @metaharness/darwin.
       '@metaharness/projects',
+      // @metaharness/redblue (defensive red/blue adversarial testing, ADR-197) ships
+      // on its own semver (0.1.2 → 0.1.4 across the HackerOne-integration arc).
+      '@metaharness/redblue',
+      // @metaharness/weight-eft (evolutionary fine-tuning, ADR-198) likewise —
+      // published 0.1.1 with the umbrella-CLI wiring.
+      '@metaharness/weight-eft',
+      // @metaharness/jujutsu (version-control-for-agents + agenticow bridge, ADR-202)
+      // likewise — npm 0.2.0 was published on its own cadence.
+      '@metaharness/jujutsu',
       '@metaharness/kernel',
       '@metaharness/host-claude-code',
       '@metaharness/host-codex',

--- a/scripts/path-guard.mjs
+++ b/scripts/path-guard.mjs
@@ -55,6 +55,17 @@ const SKIP_FILES = new Set([
   'packages/create-agent-harness/src/validate.ts',
   // Rust hook-matcher test uses `/tmp` as a deliberate hooks-input fixture.
   'crates/kernel/src/hooks.rs',
+  // Linux-only GCP ops scripts (same rationale as the bench/ dir skip above):
+  // they drive/run on Linux VMs where `/tmp/.orkey` + `/tmp/startup-*.sh` are
+  // the repo's documented conventions, are never run on Windows, and ship in
+  // no npm tarball. Mechanically "fixing" them with os.tmpdir() would change
+  // real nightly-loop behavior on the machines they target.
+  'scripts/gcp-cluster.mjs',
+  'scripts/tbench-gcp.mjs',
+  'scripts/nightly-sota-review.mjs',
+  // weight-eft's reward-hacking detector defines /tmp-shaped DETECTION
+  // regexes as data (same class as the scanner itself, first entry above).
+  'packages/weight-eft/src/reward-hack.ts',
 ]);
 
 const BAD_PATTERNS = [


### PR DESCRIPTION
Main's Node-matrix CI has been red on TWO independent causes, both fixed here:

1. **Path-guard false positives (the primary failure, all 6 jobs):** `scripts/path-guard.mjs` reports 17 'regressions' — all in Linux-only GCP ops scripts (`gcp-cluster.mjs`, `tbench-gcp.mjs`, `nightly-sota-review.mjs`; landed 06-25→27, after the guard's last sweep) plus `reward-hack.ts`'s /tmp-shaped *detection regexes*. Added them to `SKIP_FILES` with rationale, matching the guard's existing bench/ + scanner-self-skip idiom. Mechanically converting the ops scripts to `os.tmpdir()` would change real nightly-loop behavior on the Linux targets. Verified: guard exits 0.

2. **cost-breaker e2e timing flake (macos jobs):** 'completes and writes a winner under a tiny per-generation budget' hits vitest's 5000ms default on slow runners (same main run: ubuntu 3420ms pass, macos 5063ms fail; local 481ms). Raised to `30_000`, matching its sibling in the same file.

Unblocks #71 / #72 / #74.