### PR TITLE
fix(cli): propagate main() exit code in bin.js — failed commands now exit non-zero (#73)

### DIFF
--- a/packages/create-agent-harness/__tests__/bin-exit-code.test.ts
+++ b/packages/create-agent-harness/__tests__/bin-exit-code.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+//
+// #73 regression guard — `metaharness`'s bin.js must propagate main()'s exit
+// code. Before this fix, bin.js discarded main()'s return value, so EVERY
+// subcommand exited 0 — a failed command looked green in CI/scripts.
+//
+// These tests spawn the built dist/bin.js as a real process and assert the
+// process exit code. Cases 1, 3 and 4 would FAIL against the pre-fix bin.js
+// (which always exited 0); they pass once the code is propagated. Case 2 pins
+// that a genuinely-successful flow, and the bare help/usage banner, stay 0 —
+// so the fix does not turn a passing invocation into a spurious non-zero.
+
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const BIN = join(__dirname, '..', 'dist', 'bin.js');
+
+function run(args: string[], cwd?: string): number {
+  const r = spawnSync(process.execPath, [BIN, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    // Never inherit — keep the test output clean and deterministic.
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  // spawnSync returns status === null if the child was killed by a signal;
+  // treat that as a hard failure so the assertion is meaningful.
+  return r.status ?? -1;
+}
+
+describe('#73 — bin.js propagates main() exit code', () => {
+  it('exits NON-ZERO when a delegated sub-dispatch fails (from-repo missing args)', () => {
+    // `from-repo` with no url/name prints its usage and main() returns 2.
+    // Pre-fix this exited 0 (the bug this test pins).
+    expect(run(['from-repo'])).not.toBe(0);
+  });
+
+  it('exits NON-ZERO on an unknown --host (validation failure)', () => {
+    // Fails validation and returns before any scaffold write — no side effects.
+    expect(run(['some-name', '--host', 'definitely-not-a-host'])).not.toBe(0);
+  });
+
+  it('exits NON-ZERO when `analyze` is given a non-existent path', () => {
+    expect(run(['analyze', '/nonexistent-path-for-73-test-xyz'])).not.toBe(0);
+  });
+
+  it('exits 0 on a successful passing flow (--list)', () => {
+    expect(run(['--list'])).toBe(0);
+  });
+
+  it('exits 0 for bare `metaharness` (help/usage banner)', () => {
+    expect(run([])).toBe(0);
+  });
+});

--- a/packages/create-agent-harness/src/bin.ts
+++ b/packages/create-agent-harness/src/bin.ts
@@ -2,7 +2,19 @@
 // SPDX-License-Identifier: MIT
 import { main } from './index.js';
 
-main(process.argv.slice(2)).catch((err: unknown) => {
-  console.error(err instanceof Error ? err.message : String(err));
-  process.exit(1);
-});
+// #73: propagate main()'s exit code. `main()` returns a numeric code from every
+// command path (0 on success, non-zero on failure); historically this value was
+// discarded, so EVERY subcommand exited 0 and a failed command looked green in
+// CI/scripts. Set process.exitCode (not process.exit) so buffered stdout/stderr
+// still flushes before the process ends. `learn` sets process.exitCode itself and
+// also returns the same code (PR #72), so this assignment is idempotent for it.
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code ?? 0;
+  })
+  .catch((err: unknown) => {
+    // Expected failures throw an Error with a clean message — print that, no
+    // raw stack. Unknown throwables get stringified.
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exitCode = 1;
+  });

--- a/packages/create-agent-harness/src/index.ts
+++ b/packages/create-agent-harness/src/index.ts
@@ -705,7 +705,11 @@ export async function main(argv: string[]): Promise<number> {
     console.log('');
     console.log(`Templates: ${TEMPLATES.join(', ')}`);
     console.log(`Hosts: ${HOSTS.join(', ')}`);
-    return 2;
+    // #73: bare `metaharness` prints help/usage — that is a successful
+    // invocation, not a failure, so it exits 0. (An invoked *subcommand*
+    // missing required args, e.g. `from-repo`/`analyze`, still returns a
+    // non-zero usage code from its own branch — those are genuine errors.)
+    return 0;
   }
 
   // GH #10: support a multi-host harness. The first --host is primary (drives


### PR DESCRIPTION
Fixes #73.

## Problem
`metaharness`'s `bin.js` awaited `main()` but **discarded its resolved value** — the `.catch()` only handled rejections. Since `main()` returns a numeric code from every path (0 success, non-zero failure), that code was thrown away and the process always exited `0`. A failed command looked green in CI/scripts. PR #72 scope-fixed only the new `learn` command (it self-sets `process.exitCode`); this is the repo-wide fix.

## Per-command return audit (`main()`, pre-fix)
`main()` was already typed `Promise<number>` and **already returned a number on every path** — the bug was purely that `bin.js` ignored it:

| Path | Returned (pre-fix) | Notes |
|---|---|---|
| `from-repo` / `analyze` / `genome` / `score` (delegated) | `r.code` (0 or non-zero) | already correct |
| `weight-eft` / `redblue` (delegated) | `dispatch().code` | already correct |
| `learn` (delegated) | `learnCmd()` code (also self-sets `process.exitCode`, PR #72) | already correct |
| `from-repo` missing args | `2` | usage error |
| `--list` | `0` | |
| `--from-existing` found / not-found | `0` / `1` | negative detection = 1 (intended signal) |
| unknown `--host` | `2` | validation failure |
| scaffold success / error | `0` / `1` | |
| bare `metaharness` (no name → help/usage) | `2` | **changed → `0`** (see below) |

No path returned `void`/`undefined`; the delegated subcommands already returned `.code`. So the fix is small: propagate in `bin.js`, plus one exit-code reconciliation.

## Fix
- **`src/bin.ts`** — `process.exitCode = (await main(...)) ?? 0`; thrown errors → `process.exitCode = 1` with a clean message (no raw stack). Uses `process.exitCode` (not `process.exit`) so buffered output flushes. Idempotent with `learn`'s self-set (same value).
- **`src/index.ts`** — the bare-`metaharness` help/usage branch now returns `0` instead of `2`. Printing help is a successful invocation, not a failure, and its **observed** exit code is unchanged (it exited `0` before too, via the bug). An invoked *subcommand* with bad/missing args still returns its own non-zero usage code.
- **`__tests__/bin-exit-code.test.ts`** — spawns the built `dist/bin.js` and pins the exit codes.

## Before / after exit codes (measured, real process)
| Invocation | Before | After |
|---|---|---|
| `metaharness from-repo` (missing args — **failing**) | `0` ❌ | `2` ✅ |
| `metaharness some-name --host bogus` (**failing**) | `0` ❌ | `2` ✅ |
| `metaharness analyze /nonexistent` (**failing**) | `0` ❌ | `1` ✅ |
| `metaharness learn ...` no repo checkout (**failing**) | `2` (via #72 self-set) | `2` ✅ |
| `metaharness --list` (**passing**) | `0` | `0` ✅ |
| `metaharness my-bot ...` scaffold (**passing**) | `0` | `0` ✅ |
| bare `metaharness` (help/usage) | `0` | `0` ✅ |

## Meaningfully-changed exit behavior
Every **genuine failure** now surfaces non-zero (previously all `0`). The only *code-value* change to a non-failure path is bare-`metaharness` help (`2` → `0` in `main()`), whose observed exit code stays `0`. No command's actual behavior (output, side effects) changes.

## Verification
- New regression test fails against pre-fix `dist/bin.js` (the 3 failing-command cases exited `0`) and passes after.
- Full package suite: **331 passed (31 files)**. Lint (`tsc --noEmit`) clean.
- `node scripts/path-guard.mjs` ✅ · `node scripts/healthcheck.mjs` ✅ (8/8).
- Package version **not** bumped.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)