### PR TITLE
ci: wire solver-trajectory.test.mjs into ADR-231 gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,7 @@ jobs:
         run: |
           node scripts/sota-attest.test.mjs
           node scripts/nightly-sota-gate.test.mjs
+          node packages/darwin-mode/bench/swebench/solver-trajectory.test.mjs
       - name: Native-router interop guard (ADR-043 — CJS default-unwrap regression)
         # tiny-dancer is CJS; vitest's interop masks the ESM `.default` unwrap, so
         # this runs under plain `node` (the real install condition) and fails if a


### PR DESCRIPTION
Completes #79 — adds the forward-contract's test suite to the CI ADR-231 step (the authoring agent couldn't touch ci.yml). Verified exits 0.