### PR TITLE
feat(swebench): D1-S1 — SWE-bench code-repair Evaluator adapter for @metaharness/flywheel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4367,6 +4367,7 @@
         "metaharness-darwin": "dist/cli.js"
       },
       "devDependencies": {
+        "@metaharness/flywheel": "^0.1.1",
         "typescript": "^5.4.0",
         "vitest": "^2.0.0"
       },

--- a/packages/darwin-mode/bench/swebench/flywheel-swebench-evaluator.mjs
+++ b/packages/darwin-mode/bench/swebench/flywheel-swebench-evaluator.mjs
@@ -1,0 +1,77 @@
+// D1-S1 (self-learning scale loop) — the SWE-bench code-repair Evaluator for @metaharness/flywheel.
+//
+// Bridges a flywheel POLICY (operating-policy levers) + a holdout of SWE-bench instances → a flywheel
+// `Score`, so `runFlywheelGenerations` can compound operating-policy improvements on the REAL code-repair
+// domain (not the arithmetic reasoning proxy). The whole point of @metaharness/flywheel's injected
+// Evaluator seam: everything SWE-bench-specific lives HERE, never in the flywheel core.
+//
+// The two expensive halves are INJECTED so this stays testable at $0 and the real (network + Docker)
+// pieces wire in only for the budgeted live run (D1-S4):
+//   • runSolver(policy, instances) -> [{ instance_id, model_patch, costUsd? }]
+//       REAL = wrap bench/swebench/solve.mjs (the cheap-model search-replace solver, `--base-url`),
+//       shaping its prompts from the policy levers. The solver NEVER runs tests.
+//   • gradePredictions(predictions) -> { resolvedIds: string[] }
+//       REAL = the OFFICIAL `swebench` Docker harness (test execution + resolved scoring). This adapter
+//       NEVER re-implements resolved-scoring — a gold score comes only from the official harness.
+//
+// The Score projection (the honest mapping onto the flywheel's four abstract axes):
+//   primary    = # resolved (tests pass)                      — higher better
+//   noopRate   = fraction of EMPTY/no-op patches (model gave up) — lower better (the cand-6 signal)
+//   costPerWin = $ per resolved instance                       — lower better
+//   regressed  = false (no safety-regression signal in SWE-bench; reserved for a red/blue gate)
+
+/** An empty/no-op patch = the solver committed nothing (gave up). Default predicate. */
+export function isEmptyPatch(p) {
+  return !p || typeof p.model_patch !== 'string' || p.model_patch.trim().length === 0;
+}
+
+/**
+ * Build a @metaharness/flywheel `Evaluator` over SWE-bench. `runSolver` + `gradePredictions` are the
+ * only domain seams. Returns `(policy, suite) => Promise<Score>`.
+ */
+export function makeSwebenchEvaluator({ runSolver, gradePredictions, emptyPatch = isEmptyPatch }) {
+  if (typeof runSolver !== 'function') throw new Error('makeSwebenchEvaluator: runSolver is required');
+  if (typeof gradePredictions !== 'function') throw new Error('makeSwebenchEvaluator: gradePredictions is required');
+
+  return async function swebenchEvaluate(policy, suite) {
+    const instances = suite.items;
+    const predictions = await runSolver(policy, instances);
+    const { resolvedIds } = await gradePredictions(predictions);
+    const resolved = new Set(resolvedIds);
+
+    const n = Math.max(1, predictions.length);
+    const empties = predictions.filter((p) => emptyPatch(p)).length;
+    const totalCost = predictions.reduce((s, p) => s + (Number(p.costUsd) || 0), 0);
+    const wins = predictions.filter((p) => resolved.has(p.instance_id)).length;
+
+    return {
+      primary: wins,
+      // cost PER WIN: with zero resolved, cost-per-win is the WORST possible (you spent and won
+      // nothing) — a large sentinel, NOT the raw spend. Otherwise a policy that resolves nothing looks
+      // artificially "cheap" and blocks every real gain on the cost axis.
+      noopRate: empties / n,
+      costPerWin: wins > 0 ? totalCost / wins : 999,
+      regressed: false,
+    };
+  };
+}
+
+/**
+ * Build a @metaharness/flywheel `Proposer` for SWE-bench operating-policy levers. Frontier call that
+ * improves ONE lever's text. INJECTED `complete(model, prompt) -> text`. (Real = an OpenRouter/cognitum
+ * chat call; mock in tests.) The proposer is domain-flavored only in its PROMPT — the flywheel core
+ * never sees it.
+ */
+export function makeSwebenchProposer({ complete, proposerModel }) {
+  return async function swebenchPropose(base, target) {
+    const current = base.policy?.[target] ?? '(none)';
+    const prompt =
+      `You optimize a cheap code-repair agent's OPERATING POLICY so it resolves more SWE-bench ` +
+      `instances (tests pass) and gives up less often (fewer empty patches). Improve ONLY its "${target}" ` +
+      `— one concrete, generalizable instruction (e.g. "always emit a minimal search/replace edit to the ` +
+      `most-relevant file before the step budget ends; never return an empty patch"). Current "${target}":\n` +
+      `${current}\n\nReturn ONLY the improved policy text, no preamble.`;
+    const text = await complete(proposerModel, prompt);
+    return (text || '').trim() || current;
+  };
+}

--- a/packages/darwin-mode/bench/swebench/flywheel-swebench-evaluator.test.mjs
+++ b/packages/darwin-mode/bench/swebench/flywheel-swebench-evaluator.test.mjs
@@ -1,0 +1,74 @@
+// D1-S1 validation ($0, mock solver + scorer): proves the SWE-bench Evaluator adapter plugs into
+// @metaharness/flywheel and drives runFlywheelGenerations end-to-end — the same compounding loop we
+// proved on the reasoning proxy, now shaped like code-repair. The REAL solver (solve.mjs) + REAL scorer
+// (official swebench Docker harness) inject in D1-S4; this test never claims a real SWE-bench result
+// (dataSource:'SYNTHETIC').
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { runFlywheelGenerations, makeSigner, verifyReplayBundle, meetsPromotionRule, gateFingerprint } from '@metaharness/flywheel';
+import { makeSwebenchEvaluator, makeSwebenchProposer, isEmptyPatch } from './flywheel-swebench-evaluator.mjs';
+
+// SWE-bench-shaped instances: a graduated "difficulty" (how much policy quality it takes to resolve).
+const suite = (id, diffs) => ({ id, items: diffs.map((d, i) => ({ instance_id: `${id}-${i}`, difficulty: d })) });
+const quality = (policy) => Object.values(policy).join('').split('#').length - 1;
+
+// MOCK solver: under policy quality Q, an instance with difficulty ≤ Q gets a committed search/replace
+// patch; a harder one gets an EMPTY patch (the model gives up — the cand-6 no-op signal). Better policy
+// ⇒ more commits (fewer no-ops) AND more resolvable.
+const runSolver = async (policy, instances) => {
+  const Q = quality(policy);
+  return instances.map((it) =>
+    Q >= it.difficulty
+      ? { instance_id: it.instance_id, model_patch: `--- a\n+++ b\n@@ fix ${it.instance_id}`, costUsd: 0.01 }
+      : { instance_id: it.instance_id, model_patch: '', costUsd: 0.004 },
+  );
+};
+// MOCK grader (stands in for the official swebench Docker harness): a committed (non-empty) patch on a
+// solvable instance resolves. Real harness runs the tests; this mock just marks committed patches resolved.
+const gradePredictions = async (preds) => ({ resolvedIds: preds.filter((p) => !isEmptyPatch(p)).map((p) => p.instance_id) });
+// MOCK proposer completion: append one quality token to the current lever text.
+const complete = async (_model, prompt) => {
+  const m = String(prompt).match(/Current "[^"]*":\n([\s\S]*?)\n\nReturn/);
+  return `${m?.[1] ?? ''}#`.trim();
+};
+
+test('SWE-bench Evaluator adapter drives @metaharness/flywheel to a compounding lift curve', async () => {
+  const evaluator = makeSwebenchEvaluator({ runSolver, gradePredictions });
+  const proposer = makeSwebenchProposer({ complete, proposerModel: 'mock-frontier' });
+
+  const result = await runFlywheelGenerations({
+    rootPolicy: { editPolicy: '', escalationPolicy: '', verifierPolicy: '' },
+    proposer,
+    evaluator,
+    promotionRule: meetsPromotionRule,
+    holdout: suite('holdout', [1, 2, 3, 4, 5, 6]),
+    anchor: suite('anchor', [1, 2, 3]),
+    maxGenerations: 8,
+    signer: makeSigner(),
+    dataSource: 'SYNTHETIC', // mock solver/scorer — NOT a real SWE-bench result
+  });
+
+  // The wheel compounded: ≥2 anchor-surviving improvements → a real lift curve, on code-repair-shaped data.
+  assert.strictEqual(result.milestoneReached, true, 'expected ≥2 anchor-surviving compounding promotions');
+  const primaries = result.liftCurve.map((p) => p.primary);
+  assert.ok(primaries[primaries.length - 1] > primaries[0], 'resolved count must climb along the chain');
+  for (let i = 1; i < primaries.length; i++) assert.ok(primaries[i] >= primaries[i - 1], 'monotone non-decreasing');
+
+  // The bundle replays externally, gate provably unchanged.
+  const v = verifyReplayBundle(result.replayBundle, { pinnedGateFingerprint: gateFingerprint(meetsPromotionRule) });
+  assert.strictEqual(v.pass, true, `replay must pass: ${v.failures.join(',')}`);
+  assert.deepStrictEqual(result.replayBundle.chain.at(-1).parents, [], 'chain reaches the gen-0 root');
+});
+
+test('Score projection: resolved→primary, empty-patch→noopRate, cost→costPerWin', async () => {
+  const evaluator = makeSwebenchEvaluator({ runSolver, gradePredictions });
+  // quality 0 (root policy): only difficulty-≤0 resolve ⇒ nothing; all 4 give up (empty).
+  const s0 = await evaluator({ editPolicy: '' }, suite('h', [1, 2, 3, 4]));
+  assert.strictEqual(s0.primary, 0);
+  assert.strictEqual(s0.noopRate, 1); // all empty
+  // quality 3: difficulties 1,2,3 resolve; 4 gives up.
+  const s3 = await evaluator({ editPolicy: '###' }, suite('h', [1, 2, 3, 4]));
+  assert.strictEqual(s3.primary, 3);
+  assert.strictEqual(s3.noopRate, 0.25); // 1 of 4 empty
+  assert.ok(s3.costPerWin < s0.costPerWin, 'cost per resolved improves as more resolve');
+});

--- a/packages/darwin-mode/package.json
+++ b/packages/darwin-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaharness/darwin",
   "version": "0.8.0",
-  "description": "Freeze the model, evolve the harness. Two measured applications: (1) SWE-bench code-repair — conformant GLM->Opus empty-patch cascade resolves 51.3% Lite (n=300) and 55.6% Verified (278/500, Wilson 95% CI [51.2, 59.9], official swebench gold eval, no gold tests in-loop, ~$0.15/instance est.); the same cheap->frontier cascade generalizes across both splits at ~56x cheaper than frontier-only; (2) Darwin Shield (v0.3.0) — a defensive zero-day discovery harness (Semgrep + fuzz oracles, safety-gated, deterministic replay). The harness, not the model, is the lever. Dependency-free (Node built-ins).",
+  "description": "Freeze the model, evolve the harness. Two measured applications: (1) SWE-bench code-repair \u2014 conformant GLM->Opus empty-patch cascade resolves 51.3% Lite (n=300) and 55.6% Verified (278/500, Wilson 95% CI [51.2, 59.9], official swebench gold eval, no gold tests in-loop, ~$0.15/instance est.); the same cheap->frontier cascade generalizes across both splits at ~56x cheaper than frontier-only; (2) Darwin Shield (v0.3.0) \u2014 a defensive zero-day discovery harness (Semgrep + fuzz oracles, safety-gated, deterministic replay). The harness, not the model, is the lever. Dependency-free (Node built-ins).",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -60,7 +60,8 @@
   },
   "devDependencies": {
     "typescript": "^5.4.0",
-    "vitest": "^2.0.0"
+    "vitest": "^2.0.0",
+    "@metaharness/flywheel": "^0.1.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What — self-learning scale-loop, iteration 1 (D1-S1)

The first phase of **D1: prove the flywheel on the REAL code-repair domain** (the "reasoning proxy" caveat killer). This is the adapter that lets `runFlywheelGenerations` (`@metaharness/flywheel`) compound *operating-policy* improvements on **SWE-bench**, reusing the existing solver + the official Docker scorer.

- **`flywheel-swebench-evaluator.mjs`** — `makeSwebenchEvaluator({runSolver, gradePredictions})` → a flywheel `Evaluator`; `makeSwebenchProposer({complete, proposerModel})` → a `Proposer`. Both expensive halves are **injected**: real `runSolver` = `solve.mjs` (cheap-model search/replace, `--base-url`); real `gradePredictions` = the **official swebench Docker harness** — the adapter **never re-implements resolved-scoring**. Score projection: `primary`=#resolved, `noopRate`=empty-patch fraction (the cand-6 give-up signal), `costPerWin`=$/resolved, `regressed`=false.
- **`flywheel-swebench-evaluator.test.mjs`** ($0, `node:test`) — mock solver+scorer drive `runFlywheelGenerations` end-to-end → a **compounding lift curve** + an externally-replayable, gate-frozen bundle, plus a Score-projection unit. `dataSource:'SYNTHETIC'` (mock — **not** a real SWE-bench result).

## A real bug the test caught
`costPerWin` with **0 wins** must be the worst sentinel (999), not the raw spend — otherwise a resolve-nothing policy looks artificially "cheap" and blocks every genuine gain on the cost axis. Fixed.

## Scope / honesty
This is the **adapter + $0 validation**. The real (network + Docker, budgeted) SWE-bench run is D1-S4; a gold score comes **only** from the official harness. `meetsPromotionRule` untouched.

**Next (D1-S2):** freeze a SWE-bench-Lite holdout + a separate anchor slice.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)