### PR TITLE
feat(swebench): D1-S3 — real CLI runSolver (wraps solve.mjs) + policy seam + $0 dry-run

### DIFF
--- a/packages/darwin-mode/bench/swebench/_stub-solve.mjs
+++ b/packages/darwin-mode/bench/swebench/_stub-solve.mjs
@@ -1,0 +1,16 @@
+// $0 STUB solver for the D1-S3 CLI-plumbing test — a stand-in for solve.mjs. Reads the same args
+// (--manifest/--out/--report) and the SWE_POLICY_SYSTEM env seam, then writes canned predictions with
+// NO network / no repo clone / no model. A synthetic instance carries a `difficulty`; it "resolves"
+// (non-empty patch) iff the policy quality (count of '#' in SWE_POLICY_SYSTEM) ≥ difficulty — so a
+// better policy commits more, mirroring the real solver's behavior for the plumbing test.
+import { readFileSync, writeFileSync } from 'node:fs';
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i >= 0 ? process.argv[i + 1] : d; };
+const instances = JSON.parse(readFileSync(arg('--manifest'), 'utf-8')).instances;
+const quality = (process.env.SWE_POLICY_SYSTEM || '').split('#').length - 1;
+const out = arg('--out'), report = arg('--report');
+const lines = instances.map((it) => {
+  const patch = quality >= (it.difficulty ?? 1) ? `--- a\n+++ b\n@@ ${it.instance_id}` : '';
+  return JSON.stringify({ instance_id: it.instance_id, model_name_or_path: 'stub', model_patch: patch });
+});
+writeFileSync(out, lines.join('\n') + '\n');
+writeFileSync(report, JSON.stringify({ totalCost: instances.length * 0.01, n: instances.length }));

--- a/packages/darwin-mode/bench/swebench/solve.mjs
+++ b/packages/darwin-mode/bench/swebench/solve.mjs
@@ -131,7 +131,12 @@ for (const inst of manifest) {
     // ADR-192: the FILE: path extension and worked example are templated to the instance's language
     // so a weak model is shown an in-language pattern (js example for a js instance, etc.).
     const ext = prof.exampleExt;
-    const sys = `You are a non-conversational code-patching tool. Output ONLY search/replace edit blocks. NEVER write prose, explanations, summaries, or markdown fences. Each edit is EXACTLY:\nFILE: path/to/file.${ext}\n<<<SEARCH\n<lines copied verbatim from the file, incl. indentation>\n=======\n<replacement lines>\n>>>REPLACE\nExample of a valid response:\nFILE: pkg/util.${ext}\n<<<SEARCH\n${prof.exampleSnippet}\n>>>REPLACE`;
+    const sysBase = `You are a non-conversational code-patching tool. Output ONLY search/replace edit blocks. NEVER write prose, explanations, summaries, or markdown fences. Each edit is EXACTLY:\nFILE: path/to/file.${ext}\n<<<SEARCH\n<lines copied verbatim from the file, incl. indentation>\n=======\n<replacement lines>\n>>>REPLACE\nExample of a valid response:\nFILE: pkg/util.${ext}\n<<<SEARCH\n${prof.exampleSnippet}\n>>>REPLACE`;
+    // D1-S3 (flywheel domain-scale): an OPERATING-POLICY seam. SWE_POLICY_SYSTEM (set by the flywheel's
+    // SWE-bench runSolver from the candidate policy's levers) is appended to the system prompt so the
+    // flywheel can evolve HOW this cheap solver operates. Unset ⇒ byte-identical to before (backward-safe).
+    const POLICY_SYSTEM = (process.env.SWE_POLICY_SYSTEM || '').trim();
+    const sys = POLICY_SYSTEM ? `${sysBase}\n${POLICY_SYSTEM}` : sysBase;
     const prompt = `Fix the bug described below by editing the selected real source files. Emit one or more edit blocks in the exact format from the system message. The SEARCH text must match the file character-for-character (incl. indentation). No prose outside blocks.\n--- problem statement ---\n${inst.problem_statement.slice(0, 6000)}\n--- selected source files ---\n${seen}\n`;
     const res = await fetch(CHAT_URL, { method: 'POST', headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model: MODEL, messages: [{ role: 'system', content: sys }, { role: 'user', content: prompt }], max_tokens: 4096, temperature: 0 }) });
     const j = await res.json();

--- a/packages/darwin-mode/bench/swebench/swebench-solver-cli.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-solver-cli.mjs
@@ -1,0 +1,62 @@
+// D1-S3 (self-learning scale loop) — the REAL `runSolver` for the flywheel SWE-bench Evaluator: wrap
+// solve.mjs as a subprocess. Maps a flywheel POLICY (operating-policy levers) into the solver's system
+// prompt (via the SWE_POLICY_SYSTEM seam added to solve.mjs), runs the cheap-model search/replace solver
+// over the given instances, and parses predictions.jsonl into the `runSolver` contract. The solver never
+// runs tests — the official swebench Docker harness gold-scores (that is `gradePredictions`, D1-S4).
+//
+// This is injected into makeSwebenchEvaluator({ runSolver }). solveScript defaults to solve.mjs; tests
+// pass a $0 stub so the CLI plumbing (manifest write → policy env → predictions parse → cost) is
+// validated end-to-end WITHOUT cloning real repos or calling a model.
+import { mkdtempSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/** Default policy → system-prompt: concatenate the lever texts (skip empties). The solver appends this
+ *  to its base system message, so the flywheel evolves HOW the cheap solver operates. */
+export function defaultPolicyToSystem(policy) {
+  return Object.values(policy || {}).filter((v) => typeof v === 'string' && v.trim()).join('\n').trim();
+}
+
+export function makeCliSolver({
+  solveScript = join(HERE, 'solve.mjs'),
+  baseUrl = 'https://openrouter.ai/api/v1',
+  model = 'z-ai/glm-5.2',
+  apiKeyEnv = 'OPENROUTER_API_KEY',
+  k = 12,
+  policyToSystem = defaultPolicyToSystem,
+  nodeArgs = [],
+  timeoutMs = 20 * 60 * 1000,
+} = {}) {
+  return async function runSolver(policy, instances) {
+    const work = mkdtempSync(join(tmpdir(), 'fw-swebench-'));
+    const manifest = join(work, 'manifest.json');
+    const preds = join(work, 'preds.jsonl');
+    const report = join(work, 'report.json');
+    try {
+      writeFileSync(manifest, JSON.stringify({ instances }));
+      const res = spawnSync(
+        'node',
+        [...nodeArgs, solveScript, '--manifest', manifest, '--base-url', baseUrl, '--model', model,
+          '--api-key-env', apiKeyEnv, '--out', preds, '--report', report, '--k', String(k)],
+        { env: { ...process.env, SWE_POLICY_SYSTEM: policyToSystem(policy) }, encoding: 'utf-8', timeout: timeoutMs, maxBuffer: 1 << 28 },
+      );
+      if (res.status !== 0 && !existsSync(preds)) {
+        throw new Error(`solver exited ${res.status}: ${String(res.stderr || res.error).slice(0, 300)}`);
+      }
+      // parse predictions.jsonl (one {instance_id, model_patch} per line).
+      const lines = existsSync(preds) ? readFileSync(preds, 'utf-8').split('\n').filter(Boolean) : [];
+      const rows = lines.map((l) => JSON.parse(l));
+      // total cost from the report (best-effort) → amortized per prediction for costPerWin.
+      let totalCost = 0;
+      try { totalCost = Number(JSON.parse(readFileSync(report, 'utf-8')).totalCost) || 0; } catch { /* report optional */ }
+      const per = rows.length ? totalCost / rows.length : 0;
+      return rows.map((r) => ({ instance_id: r.instance_id, model_patch: r.model_patch ?? '', costUsd: per }));
+    } finally {
+      rmSync(work, { recursive: true, force: true });
+    }
+  };
+}

--- a/packages/darwin-mode/bench/swebench/swebench-solver-cli.test.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-solver-cli.test.mjs
@@ -1,0 +1,44 @@
+// D1-S3 dry-run ($0, node:test): validates the REAL runSolver CLI plumbing end-to-end against a stub
+// solve script — manifest write → SWE_POLICY_SYSTEM policy-injection → predictions parse → cost — and
+// that it plugs into the flywheel SWE-bench Evaluator. The stub proves the pipeline WITHOUT cloning
+// repos or calling a model; D1-S4 swaps the stub for the real solve.mjs + a cheap model + the official
+// Docker scorer. NOTHING here is a real SWE-bench result (SYNTHETIC).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { makeCliSolver, defaultPolicyToSystem } from './swebench-solver-cli.mjs';
+import { makeSwebenchEvaluator, isEmptyPatch } from './flywheel-swebench-evaluator.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const stub = join(HERE, '_stub-solve.mjs');
+const instances = [1, 2, 3, 4].map((d, i) => ({ instance_id: `stub-${i}`, difficulty: d }));
+const gradePredictions = async (preds) => ({ resolvedIds: preds.filter((p) => !isEmptyPatch(p)).map((p) => p.instance_id) });
+
+test('defaultPolicyToSystem joins non-empty lever texts', () => {
+  assert.strictEqual(defaultPolicyToSystem({ a: 'x', b: '', c: 'y' }), 'x\ny');
+});
+
+test('CLI runSolver: manifest write → policy env → predictions parse → cost, over a stub solve', async () => {
+  const runSolver = makeCliSolver({ solveScript: stub, model: 'stub-model', apiKeyEnv: 'NONE' });
+  // low-quality policy (1 '#') resolves only difficulty-1; high-quality (3 '#') resolves 1-3.
+  const low = await runSolver({ editPolicy: '#' }, instances);
+  const high = await runSolver({ editPolicy: '###' }, instances);
+  assert.strictEqual(low.length, 4);
+  assert.deepStrictEqual(low.map((p) => p.instance_id), ['stub-0', 'stub-1', 'stub-2', 'stub-3']);
+  assert.strictEqual(low.filter((p) => !isEmptyPatch(p)).length, 1); // only difficulty-1
+  assert.strictEqual(high.filter((p) => !isEmptyPatch(p)).length, 3); // difficulty 1,2,3
+  assert.ok(low.every((p) => typeof p.costUsd === 'number' && p.costUsd > 0), 'cost parsed from report');
+});
+
+test('the CLI solver plugs into makeSwebenchEvaluator → a Score reflecting the policy', async () => {
+  const runSolver = makeCliSolver({ solveScript: stub, apiKeyEnv: 'NONE' });
+  const evaluate = makeSwebenchEvaluator({ runSolver, gradePredictions });
+  const s0 = await evaluate({ editPolicy: '' }, { id: 'h', items: instances });   // quality 0 → nothing
+  const s3 = await evaluate({ editPolicy: '###' }, { id: 'h', items: instances }); // quality 3 → 3 resolve
+  assert.strictEqual(s0.primary, 0);
+  assert.strictEqual(s0.noopRate, 1);
+  assert.strictEqual(s3.primary, 3);
+  assert.strictEqual(s3.noopRate, 0.25);
+  assert.ok(s3.costPerWin < s0.costPerWin);
+});


### PR DESCRIPTION
## What — scale-loop iteration 3 (D1-S3)

Wires the **real** solver into the flywheel SWE-bench Evaluator, so D1-S4 (the budgeted live run) just swaps the endpoint.

- **`solve.mjs`** — an operating-policy **seam**: `SWE_POLICY_SYSTEM` (set by the flywheel's `runSolver` from the candidate policy's levers) is appended to the base system prompt so the flywheel can evolve *how* the cheap solver operates. Unset ⇒ byte-identical (backward-safe; `node --check` OK).
- **`swebench-solver-cli.mjs`** — `makeCliSolver({...})` → `runSolver(policy, instances)`: temp manifest → inject policy via `SWE_POLICY_SYSTEM` → spawn `solve.mjs` → parse `predictions.jsonl` → `[{instance_id, model_patch, costUsd}]` (cost amortized from the solve report). Plugs into `makeSwebenchEvaluator({runSolver})`.
- **`_stub-solve.mjs` + `swebench-solver-cli.test.mjs`** (3, `node:test`) — a **$0 stub** proves the pipeline end-to-end (manifest write → policy env → predictions parse → cost → Score) **without cloning repos or calling a model**.

**Next (D1-S4):** the budgeted live run — real `solve.mjs` + cheap model (`--base-url`) over the frozen holdout, gold-scored by the **official swebench Docker harness**. Hard $-cap, cost-confirm first. `meetsPromotionRule` untouched; `SYNTHETIC` until the real harness scores.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)