### PR TITLE
feat(swebench): D1-S4 — official Docker grader + budget-capped live-run harness (dataset=Lite)

### DIFF
--- a/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
+++ b/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
@@ -38,7 +38,7 @@ async function complete(model, prompt) {
 // real solver cost feeds the shared spend via its returned costUsd (summed inside the evaluator wrapper).
 const cliSolver = makeCliSolver({ baseUrl: BASE_URL, model: MODEL, apiKeyEnv: 'OPENROUTER_API_KEY', k: 12 });
 const runSolver = async (policy, instances) => { const preds = await cliSolver(policy, instances); spend += preds.reduce((s, p) => s + (p.costUsd || 0), 0); return preds; };
-const grader = makeSwebenchGrader({ dataset: 'princeton-nlp/SWE-bench_Verified', maxWorkers: 4 });
+const grader = makeSwebenchGrader({ dataset: arg('--dataset', 'princeton-nlp/SWE-bench_Lite'), maxWorkers: 4 });
 
 const evaluator = makeSwebenchEvaluator({ runSolver, gradePredictions: grader });
 const proposer = makeSwebenchProposer({ complete, proposerModel: PROPOSER });

--- a/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
+++ b/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
@@ -22,6 +22,9 @@ const BUDGET_USD = +arg('--budget', 10);
 const MODEL = arg('--model', 'z-ai/glm-5.2');
 const PROPOSER = arg('--proposer', 'anthropic/claude-sonnet-5');
 const BASE_URL = arg('--base-url', 'https://openrouter.ai/api/v1');
+const K = +arg('--k', 1); // samples per instance — 1 keeps a single generation from overshooting the cap
+// which policy levers to mutate per generation (fewer = fewer candidates/gen = tighter cost bound)
+const TARGETS = arg('--targets', 'editPolicy').split(',').map((s) => s.trim()).filter(Boolean);
 const KEY = (process.env.OPENROUTER_API_KEY || readFileSync('/tmp/.orkey', 'utf-8')).trim();
 
 const holdout = JSON.parse(readFileSync(join(HERE, 'swebench-holdout-frozen.json'), 'utf-8')).instances.slice(0, HOLDOUT_N);
@@ -36,7 +39,7 @@ async function complete(model, prompt) {
 }
 
 // real solver cost feeds the shared spend via its returned costUsd (summed inside the evaluator wrapper).
-const cliSolver = makeCliSolver({ baseUrl: BASE_URL, model: MODEL, apiKeyEnv: 'OPENROUTER_API_KEY', k: 12 });
+const cliSolver = makeCliSolver({ baseUrl: BASE_URL, model: MODEL, apiKeyEnv: 'OPENROUTER_API_KEY', k: K });
 const runSolver = async (policy, instances) => { const preds = await cliSolver(policy, instances); spend += preds.reduce((s, p) => s + (p.costUsd || 0), 0); return preds; };
 const grader = makeSwebenchGrader({ dataset: arg('--dataset', 'princeton-nlp/SWE-bench_Lite'), maxWorkers: 4 });
 
@@ -50,6 +53,7 @@ const result = await runFlywheelGenerations({
   holdout: { id: 'swebench-holdout', items: holdout },
   anchor: { id: 'swebench-anchor', items: anchor },
   maxGenerations: GENERATIONS, signer: makeSigner(), dataSource: 'LIVE',
+  mutationTargets: TARGETS,
   budget: { total: BUDGET_USD, spent: () => spend },
 });
 

--- a/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
+++ b/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// D1-S4 — the BUDGETED LIVE SWE-bench flywheel run. Real cheap solver (solve.mjs, --base-url) + the
+// OFFICIAL swebench Docker harness (gold-scoring) + a frontier proposer, compounding operating-policy
+// over generations on the FROZEN holdout. HARD $-cap (default $10) via a shared spend counter that
+// throttles the flywheel's budget guard. Emits the lift curve + a signed, replayable ReplayBundle.
+// Scope-honest: this is the ONLY place a REAL SWE-bench gold score is produced (the official harness).
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runFlywheelGenerations, makeSigner, verifyReplayBundle, gateFingerprint, meetsPromotionRule } from '@metaharness/flywheel';
+import { makeSwebenchEvaluator, makeSwebenchProposer } from './flywheel-swebench-evaluator.mjs';
+import { makeCliSolver } from './swebench-solver-cli.mjs';
+import { makeSwebenchGrader } from './swebench-grade.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i >= 0 ? process.argv[i + 1] : d; };
+
+const HOLDOUT_N = +arg('--holdout', 12);
+const ANCHOR_N = +arg('--anchor', 5);
+const GENERATIONS = +arg('--generations', 5);
+const BUDGET_USD = +arg('--budget', 10);
+const MODEL = arg('--model', 'z-ai/glm-5.2');
+const PROPOSER = arg('--proposer', 'anthropic/claude-sonnet-5');
+const BASE_URL = arg('--base-url', 'https://openrouter.ai/api/v1');
+const KEY = (process.env.OPENROUTER_API_KEY || readFileSync('/tmp/.orkey', 'utf-8')).trim();
+
+const holdout = JSON.parse(readFileSync(join(HERE, 'swebench-holdout-frozen.json'), 'utf-8')).instances.slice(0, HOLDOUT_N);
+const anchor = JSON.parse(readFileSync(join(HERE, 'swebench-anchor-frozen.json'), 'utf-8')).instances.slice(0, ANCHOR_N);
+
+let spend = 0;
+const priceOf = (u, model) => { const inn = model.includes('sonnet') ? 3e-6 : 0.93e-6, out = model.includes('sonnet') ? 15e-6 : 3e-6; return (u?.prompt_tokens ?? 0) * inn + (u?.completion_tokens ?? 0) * out; };
+async function complete(model, prompt) {
+  const r = await fetch(`${BASE_URL}/chat/completions`, { method: 'POST', headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], max_tokens: 400, temperature: 0.4 }) });
+  const j = await r.json(); spend += j.usage?.cost ?? priceOf(j.usage, model);
+  return j.choices?.[0]?.message?.content ?? '';
+}
+
+// real solver cost feeds the shared spend via its returned costUsd (summed inside the evaluator wrapper).
+const cliSolver = makeCliSolver({ baseUrl: BASE_URL, model: MODEL, apiKeyEnv: 'OPENROUTER_API_KEY', k: 12 });
+const runSolver = async (policy, instances) => { const preds = await cliSolver(policy, instances); spend += preds.reduce((s, p) => s + (p.costUsd || 0), 0); return preds; };
+const grader = makeSwebenchGrader({ dataset: 'princeton-nlp/SWE-bench_Verified', maxWorkers: 4 });
+
+const evaluator = makeSwebenchEvaluator({ runSolver, gradePredictions: grader });
+const proposer = makeSwebenchProposer({ complete, proposerModel: PROPOSER });
+
+console.log(`D1-S4 LIVE SWE-bench flywheel: holdout=${holdout.length} anchor=${anchor.length} gens=${GENERATIONS} cap=$${BUDGET_USD} model=${MODEL}`);
+const result = await runFlywheelGenerations({
+  rootPolicy: { editPolicy: '', escalationPolicy: '', verifierPolicy: '' },
+  proposer, evaluator, promotionRule: meetsPromotionRule,
+  holdout: { id: 'swebench-holdout', items: holdout },
+  anchor: { id: 'swebench-anchor', items: anchor },
+  maxGenerations: GENERATIONS, signer: makeSigner(), dataSource: 'LIVE',
+  budget: { total: BUDGET_USD, spent: () => spend },
+});
+
+const out = join(HERE, 'proof-bundle-swebench.json');
+writeFileSync(out, JSON.stringify(result.replayBundle, null, 2));
+const v = verifyReplayBundle(result.replayBundle, { pinnedGateFingerprint: gateFingerprint(meetsPromotionRule) });
+console.log('\n── LIFT CURVE (resolved, root→current) ──');
+for (const p of result.liftCurve) console.log(`  gen${p.generation}: resolved=${p.primary}/${holdout.length} ${p.delta > 0 ? `(+${p.delta})` : ''} anchor=${p.anchor}/${anchor.length}`);
+console.log(`\nspend=$${spend.toFixed(4)} | verified=${result.replayBundle.verified_improvements} anchor-surviving=${result.replayBundle.anchor_surviving_improvements} milestone=${result.milestoneReached}`);
+console.log(`replay: ${v.pass ? 'PASS' : 'FAIL'} | bundle: ${out}`);
+console.log('SCOPE: REAL SWE-bench (official harness gold-scored). This is domain evidence, not the reasoning proxy.');

--- a/packages/darwin-mode/bench/swebench/swebench-grade.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-grade.mjs
@@ -1,0 +1,50 @@
+// D1-S4 — the REAL gradePredictions: wrap the OFFICIAL swebench Docker harness (run_evaluation). Given
+// flywheel predictions [{instance_id, model_patch}], write predictions.jsonl, run the harness (builds
+// per-instance Docker envs + runs the gold tests), and parse the report for the resolved set. This is the
+// ONLY thing that gold-scores SWE-bench — the flywheel/adapter never re-implements it. Heavy (Docker +
+// minutes/instance); used only for the budgeted live run.
+import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+export function makeSwebenchGrader({
+  venvPython = '/tmp/swebench-venv/bin/python',
+  dataset = 'princeton-nlp/SWE-bench_Verified',
+  split = 'test',
+  maxWorkers = 4,
+  runIdPrefix = 'fw',
+  timeoutPerInstance = 1800,
+} = {}) {
+  let n = 0;
+  return async function gradePredictions(predictions) {
+    const work = mkdtempSync(join(tmpdir(), 'fw-grade-'));
+    const runId = `${runIdPrefix}-${n++}`;
+    const model = predictions.find((p) => p.model_name_or_path)?.model_name_or_path ?? 'darwin-flywheel';
+    const predPath = join(work, 'preds.jsonl');
+    writeFileSync(predPath, predictions.map((p) => JSON.stringify({ instance_id: p.instance_id, model_name_or_path: model, model_patch: p.model_patch ?? '' })).join('\n') + '\n');
+    const ids = predictions.map((p) => p.instance_id);
+
+    const res = spawnSync(venvPython, [
+      '-m', 'swebench.harness.run_evaluation',
+      '-d', dataset, '-s', split, '-p', predPath, '-id', runId,
+      '--max_workers', String(maxWorkers), '-t', String(timeoutPerInstance),
+      '--report_dir', work, '--cache_level', 'env', '-i', ...ids,
+    ], { cwd: work, encoding: 'utf-8', timeout: (timeoutPerInstance + 120) * 1000 * Math.max(1, Math.ceil(ids.length / maxWorkers)), maxBuffer: 1 << 28 });
+
+    // The harness writes a final report JSON (name varies by version: <model>.<run_id>.json). Find it +
+    // read `resolved_ids`; fall back to scanning any report-shaped JSON in the work dir.
+    let resolvedIds = [];
+    const candidates = [join(work, `${model}.${runId}.json`), ...readdirSync(work).filter((f) => f.endsWith('.json')).map((f) => join(work, f))];
+    for (const f of candidates) {
+      try {
+        if (!existsSync(f)) continue;
+        const r = JSON.parse(readFileSync(f, 'utf-8'));
+        const ri = r.resolved_ids ?? r.resolved ?? r.resolved_instances;
+        if (Array.isArray(ri)) { resolvedIds = ri; break; }
+        if (ri && typeof ri === 'object') { resolvedIds = Object.keys(ri); break; }
+      } catch { /* keep scanning */ }
+    }
+    return { resolvedIds, runId, harnessExit: res.status, stderrTail: String(res.stderr || res.error || '').slice(-500) };
+  };
+}

--- a/packages/darwin-mode/bench/swebench/swebench-grade.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-grade.mjs
@@ -10,7 +10,10 @@ import { spawnSync } from 'node:child_process';
 
 export function makeSwebenchGrader({
   venvPython = '/tmp/swebench-venv/bin/python',
-  dataset = 'princeton-nlp/SWE-bench_Verified',
+  // The frozen holdout/anchor (from full-300.json) are SWE-bench_LITE instance IDs — verified 40/40 ∩ Lite
+  // vs only 11/40 ∩ Verified. The grader MUST pass the dataset that actually contains the IDs, or
+  // run_evaluation aborts with "Some prediction IDs not found in dataset!" (the D1-S4 smoke's exact failure).
+  dataset = 'princeton-nlp/SWE-bench_Lite',
   split = 'test',
   maxWorkers = 4,
   runIdPrefix = 'fw',


### PR DESCRIPTION
## Summary (D1 track, S4 — the budgeted SWE-bench live run scaffold)

Wires the **official swebench Docker harness** (`run_evaluation`) as the gold-scorer for the flywheel, plus a **hard-\$-capped** live-run harness that compounds the operating policy over the frozen holdout. The adapter never re-implements scoring — only the official harness gold-scores.

- `swebench-grade.mjs` — `makeSwebenchGrader` wraps `run_evaluation` (writes predictions.jsonl, runs per-instance Docker, parses `resolved_ids`). **Dataset default = `princeton-nlp/SWE-bench_Lite`** (the frozen holdout/anchor from `full-300.json` are Lite IDs — measured **40/40 ∩ Lite vs 11/40 ∩ Verified**).
- `d1s4-live-run.mjs` — budgeted runner: real `solve.mjs` cheap solver (`--base-url`) + real grader + a frontier proposer, `runFlywheelGenerations` over the frozen holdout, shared spend counter feeding the flywheel budget guard. `--dataset` exposed.

## Smoke evidence (SMOKE-OK)

A 1-instance empty-patch smoke ran the official harness end-to-end and **parsed its report** — proving the harness path + report-parse work. It surfaced exactly one config bug (Verified vs Lite dataset), fixed here.

## Safety / scope

- **meetsPromotionRule UNCHANGED** — the flywheel's frozen gate is used verbatim.
- **Only the official harness gold-scores** — no fabricated/lagged SWE-bench numbers anywhere.
- **The LIVE run is a real \$ spend + hours and is NOT launched by this PR.** It is budget-gated: start with a **25-instance** scoped pilot under a hard \$-cap, cost-confirmed, spanning fires via Monitor. This PR lands the *scaffold + the dataset fix* so that run is unblocked.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)