### PR TITLE
fix(swebench): solver cost tracking — send usage:{include:true} so the budget guard sees real spend

### DIFF
--- a/packages/darwin-mode/bench/swebench/solve.mjs
+++ b/packages/darwin-mode/bench/swebench/solve.mjs
@@ -97,7 +97,7 @@ async function localize(problem, work, files, buildContext, k, prof, pre = 120) 
   const prompt = `A bug is reported below. From the candidate files (path + top signatures), list ONLY the file paths most likely to contain the fix, most-likely first, one per line, at most ${k}. Output paths verbatim, nothing else.\n--- problem ---\n${problem.slice(0, 4000)}\n--- candidate files ---\n${listing.slice(0, 24000)}\n`;
   let cost = 0;
   try {
-    const res = await fetch(CHAT_URL, { method: 'POST', headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model: MODEL, messages: [{ role: 'user', content: prompt }], max_tokens: 400, temperature: 0 }) });
+    const res = await fetch(CHAT_URL, { method: 'POST', headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model: MODEL, messages: [{ role: 'user', content: prompt }], max_tokens: 400, temperature: 0, usage: { include: true } }) });
     const j = await res.json(); cost = j.usage?.cost ?? 0;
     const raw = j.choices?.[0]?.message?.content ?? '';
     const picked = raw.split('\n').map((l) => l.trim().replace(/^[-*\d.\s]+/, '')).filter((l) => files.includes(l));
@@ -138,7 +138,7 @@ for (const inst of manifest) {
     const POLICY_SYSTEM = (process.env.SWE_POLICY_SYSTEM || '').trim();
     const sys = POLICY_SYSTEM ? `${sysBase}\n${POLICY_SYSTEM}` : sysBase;
     const prompt = `Fix the bug described below by editing the selected real source files. Emit one or more edit blocks in the exact format from the system message. The SEARCH text must match the file character-for-character (incl. indentation). No prose outside blocks.\n--- problem statement ---\n${inst.problem_statement.slice(0, 6000)}\n--- selected source files ---\n${seen}\n`;
-    const res = await fetch(CHAT_URL, { method: 'POST', headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model: MODEL, messages: [{ role: 'system', content: sys }, { role: 'user', content: prompt }], max_tokens: 4096, temperature: 0 }) });
+    const res = await fetch(CHAT_URL, { method: 'POST', headers: { Authorization: `Bearer ${key}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model: MODEL, messages: [{ role: 'system', content: sys }, { role: 'user', content: prompt }], max_tokens: 4096, temperature: 0, usage: { include: true } }) });
     const j = await res.json();
     totalTok += j.usage?.total_tokens ?? 0; totalCost += j.usage?.cost ?? 0; row.cost_usd = j.usage?.cost ?? 0;
     const raw = j.choices?.[0]?.message?.content ?? '';


### PR DESCRIPTION
## Summary

The D1-S4 live run reported **spend=$0.0086** for 25 real agentic solves. Root cause: solve.mjs reads cost from `j.usage?.cost`, but **OpenRouter only returns `usage.cost` when the request sends `usage: {include: true}`** — which the two chat fetch bodies omitted. So solver cost read as **$0**, and the flywheel **budget guard was blind to solver spend** — a latent safety bug (a pricier run could overrun its hard $-cap undetected).

**Verified by a 1-call test:** glm-5.2 via OpenRouter returns `usage.cost = 0.0000398` **only** with the flag; without it, no cost field. Added `usage: {include: true}` to both the localize and solve bodies → cost flows into `totalCost` → the report → the CLI solver's amortized `costUsd` → the budget guard.

This also **unblocks a proper D1-S4 re-run** (a stronger, now cost-bounded solver) for real domain evidence — the prior `1/25` with glm-5.2 was an honest null, not proof.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)