### PR TITLE
feat(evals-extract): @metaharness/evals-extract — flywheel domain adapter (multi-vertical scale-up)

### DIFF
--- a/packages/evals-extract/__tests__/adapter.test.ts
+++ b/packages/evals-extract/__tests__/adapter.test.ts
@@ -1,0 +1,154 @@
+// @metaharness/evals-extract — $0 SYNTHETIC acceptance test.
+//
+// Drives the FULL adapter through the real @metaharness/flywheel engine on a deterministic synthetic fixture
+// (dataSource 'SYNTHETIC' — never a real extraction score). Proves: (1) the harness pipeline + schema-
+// constrained proposer produce a COMPOUNDING lift curve that the composite gate admits; (2) the frozen
+// `meetsPromotionRule` is composed VERBATIM (its behaviour + fingerprint unchanged); (3) leakage fails
+// CLOSED; (4) the replay bundle verifies with the pinned composite-gate fingerprint. This is the extraction
+// analog of the SWE-bench $0 dry-run — the live gated/licensed-data run is deferred until access is granted.
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import {
+  runFlywheelGenerations, makeSigner, verifyReplayBundle, gateFingerprint, meetsPromotionRule,
+} from '@metaharness/flywheel';
+import {
+  rootGenome, genomeToPolicy,
+  makeExtractEvaluator, makeExtractProposer, type SolveFn,
+  extractPromotionRule,
+  detectLeakage, leaks,
+  splitDeterministic, manifestOf, isDisjoint,
+  type ExtractItem, type ExtractScore, type JsonSchema,
+} from '../src/index.js';
+
+// ── deterministic synthetic fixture ─────────────────────────────────────────────────────────────────────
+const hashFrac = (s: string): number => (parseInt(createHash('sha256').update(s).digest('hex').slice(0, 8), 16) % 10000) / 10000;
+
+const SCHEMA: JsonSchema = {
+  type: 'object',
+  properties: { name: { type: 'string' }, amount: { type: 'number' }, flag: { type: 'boolean' } },
+  required: ['name', 'amount'],
+  additionalProperties: false,
+};
+const goldObj = (i: number): Record<string, unknown> => ({ name: `n${i}`, amount: i, flag: i % 2 === 0 });
+
+const CATS = ['invoice', 'receipt', 'resume', 'contract', 'email', 'form', 'article', 'other'] as const;
+// N sized so each single mutation step moves BOTH accuracy and no-op monotonically (the spec's ≥300–500
+// validation guidance — below that, single-item granularity puts the two signals out of phase).
+const fixture: ExtractItem[] = Array.from({ length: 400 }, (_, i) => ({
+  id: `syn-${i}`,
+  text: `Synthetic ${CATS[i % CATS.length]} document ${i} to extract.`,
+  schema: SCHEMA,
+  gold: JSON.stringify(goldObj(i)),
+  category: CATS[i % CATS.length],
+}));
+
+/** Deterministic mock model: no network, no clock, no RNG. The effective lever is `maxCandidates` — modeled
+ *  as SELF-CONSISTENCY DEPTH (extra samples are free re-reads of the same cheap pass, so cost stays flat).
+ *  More depth (a) rescues the hardest documents from an empty/schema-invalid output (no-op ↓) and (b) lifts
+ *  borderline documents over the field-correctness bar (accuracy ↑). Cost is held flat to ISOLATE the lift
+ *  signal — real token economics are the LIVE run's job, not the $0 replay's. Self-report is high enough that
+ *  the root never escalates on committed docs, so downstream levers don't perturb cost here. */
+const mockSolve: SolveFn = async ({ text, maxCandidates }) => {
+  const id = text.match(/document (\d+)/)?.[1] ?? '0';
+  const ease = hashFrac(`syn-${id}`);
+  const depth = Math.min(3, maxCandidates - 1); // saturates at 3 → the curve plateaus (realistic)
+  const emptyBonus = depth * 0.06;
+  const candBonus = depth * 0.05;
+
+  // hardest documents produce nothing until self-consistency depth surfaces a parseable object → no-op ↓
+  if (ease + emptyBonus < 0.15) return { raw: '', selfReport: 0.7, samples: [], costUsd: 0.002 };
+
+  const correct = ease + candBonus >= 0.5;
+  const emitted = correct ? JSON.stringify(goldObj(Number(id))) : JSON.stringify({ name: `wrong-${id}`, amount: -1, flag: false });
+  const samples = Array.from({ length: Math.max(0, maxCandidates - 1) }, () => emitted);
+  return { raw: `Here is the extraction:\n${emitted}`, selfReport: 0.7, samples, costUsd: 0.002 };
+};
+
+const baseScore = (over: Partial<ExtractScore> = {}): ExtractScore => ({
+  primary: 0.5, noopRate: 0.2, costPerWin: 1, regressed: false,
+  accuracy: 0.5, costPerCorrect: 1, calibrationError: 0.1, schemaErrorRate: 0.1,
+  abstentionRate: 0, perDocTypeAccuracy: {}, n: 100, correct: 50, ...over,
+});
+
+describe('@metaharness/evals-extract — data contract', () => {
+  it('splits deterministically into four disjoint sets with stable hashes', () => {
+    const s1 = splitDeterministic(fixture);
+    const s2 = splitDeterministic(fixture);
+    expect(isDisjoint(s1)).toBe(true);
+    expect(manifestOf(s1).splitFingerprint).toBe(manifestOf(s2).splitFingerprint);
+    // frozen holdout carved first → present + non-empty
+    expect(s1.frozenHoldout.length).toBeGreaterThan(0);
+    expect(s1.privateValidation.length).toBeGreaterThan(0);
+  });
+});
+
+describe('@metaharness/evals-extract — the frozen gate is composed verbatim', () => {
+  it('extractPromotionRule calls the frozen meetsPromotionRule (base reasons surface)', () => {
+    // a candidate that regresses primary must be rejected WITH the frozen base reason present
+    const baseline = baseScore({ n: 10, correct: 5 });
+    const worse = baseScore({ primary: 0.4, accuracy: 0.4, correct: 4, n: 10 });
+    const d = extractPromotionRule({ baseline, candidate: worse });
+    expect(d.promote).toBe(false);
+    expect(d.reasons).toContain('primary_regressed'); // proves the frozen clause ran
+  });
+
+  it('the composite gate has a DIFFERENT fingerprint than the frozen default (it is a stricter superset)', () => {
+    expect(gateFingerprint(extractPromotionRule)).not.toBe(gateFingerprint(meetsPromotionRule));
+  });
+
+  it('admits an accuracy win and a cost win; rejects an immaterial change', () => {
+    const b = baseScore();
+    const accWin = baseScore({ primary: 0.53, accuracy: 0.53, noopRate: 0.15, costPerWin: 0.9, costPerCorrect: 0.9, correct: 53 });
+    const costWin = baseScore({ noopRate: 0.15, costPerWin: 0.5, costPerCorrect: 0.5 });
+    const immaterial = baseScore({ noopRate: 0.15, primary: 0.505, accuracy: 0.505, costPerWin: 0.99, costPerCorrect: 0.99 });
+    expect(extractPromotionRule({ baseline: b, candidate: accWin }).promote).toBe(true);
+    expect(extractPromotionRule({ baseline: b, candidate: costWin }).promote).toBe(true);
+    expect(extractPromotionRule({ baseline: b, candidate: immaterial }).reasons).toContain('immaterial_no_accuracy_or_cost_win');
+  });
+});
+
+describe('@metaharness/evals-extract — leakage fails closed', () => {
+  it('a policy that encodes a benchmark artifact is rejected', () => {
+    const g = rootGenome();
+    (g.docTypePolicy as any).invoice = { ...g.defaults, extractionStyle: 'answer from the gold extraction record' };
+    expect(leaks(detectLeakage(g, []))).toBe(true);
+  });
+  it('the evaluator marks a leaked policy regressed → the gate rejects it', async () => {
+    const g = rootGenome();
+    (g.docTypePolicy as any).invoice = { ...g.defaults, extractionStyle: 'gold record test split lookup' };
+    const evaluate = makeExtractEvaluator({ solve: mockSolve });
+    const score = (await evaluate(genomeToPolicy(g), { id: 'v', items: fixture.slice(0, 10) })) as ExtractScore;
+    expect(score.regressed).toBe(true);
+  });
+});
+
+describe('@metaharness/evals-extract — end-to-end flywheel produces a compounding, replayable lift curve', () => {
+  it('promotes ≥2 anchor-surviving improvements and the replay bundle verifies', async () => {
+    const split = splitDeterministic(fixture);
+    const evaluate = makeExtractEvaluator({ solve: mockSolve, publicExamples: split.publicDev.map((i) => i.text) });
+    const proposer = makeExtractProposer(); // $0 deterministic
+    const result = await runFlywheelGenerations({
+      rootPolicy: genomeToPolicy(rootGenome()),
+      proposer,
+      evaluator: evaluate,
+      promotionRule: extractPromotionRule,
+      holdout: { id: 'extract-validation', items: split.privateValidation },
+      anchor: { id: 'extract-anchor', items: split.publicDev },
+      mutationTargets: ['verificationMode', 'maxCandidates', 'confidenceRule', 'normalizeFields'],
+      maxGenerations: 8,
+      signer: makeSigner(),
+      dataSource: 'SYNTHETIC',
+    });
+
+    // compounding: final promoted primary strictly above the root
+    const curve = result.liftCurve;
+    expect(curve[curve.length - 1].primary).toBeGreaterThan(curve[0].primary);
+    expect(result.milestoneReached).toBe(true); // ≥2 anchor-surviving verified improvements
+
+    // external replay verifies against the PINNED composite-gate fingerprint
+    const v = verifyReplayBundle(result.replayBundle, { pinnedGateFingerprint: gateFingerprint(extractPromotionRule) });
+    expect(v.pass).toBe(true);
+    expect(result.replayBundle.data_source).toBe('SYNTHETIC');
+    expect(result.replayBundle.gate_fingerprint).toBe(gateFingerprint(extractPromotionRule));
+  });
+});

--- a/packages/evals-extract/package.json
+++ b/packages/evals-extract/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@metaharness/evals-extract",
+  "version": "0.1.0",
+  "description": "Structured-extraction benchmark adapter for @metaharness/flywheel — evolve the extraction policy, not the model. Doc-type routing, JSON-schema verifier stack, field normalization, calibration, and a stricter composite promotion gate.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist", "README.md"],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": ["extraction", "structured-extraction", "json-schema", "benchmark", "eval", "flywheel", "metaharness", "policy-evolution", "llm", "agent-harness"],
+  "license": "MIT",
+  "dependencies": {
+    "@metaharness/flywheel": "^0.1.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "vitest": "^2.0.0"
+  }
+}

--- a/packages/evals-extract/src/calibration.ts
+++ b/packages/evals-extract/src/calibration.ts
@@ -1,0 +1,53 @@
+// @metaharness/evals-extract — CONFIDENCE CALIBRATION.
+//
+// Confidence feeds two decisions: escalate (below escalationThreshold) and abstain (below abstainThreshold).
+// The confidenceRule lever picks how it is derived. We also compute a suite-level CALIBRATION ERROR (a
+// reliability gap): a well-calibrated policy's mean confidence on the objects it commits to should track its
+// actual field-correctness. Worsening calibration blocks promotion (folded into the extract gate) — a policy
+// that extracts correctly but lies about its confidence is not an improvement.
+import type { ConfidenceRule } from './genome.js';
+
+export interface ConfidenceInput {
+  /** Model self-reported logprob-ish confidence in [0,1], if available. */
+  selfReport?: number;
+  /** Fraction of required fields the extraction actually populated, in [0,1]. */
+  fieldCoverage?: number;
+  /** Verifier stack agreement in [0,1]. */
+  verifierAgreement?: number;
+}
+
+export function confidence(rule: ConfidenceRule, x: ConfidenceInput): number {
+  const sr = clamp01(x.selfReport ?? 0.5);
+  const fc = clamp01(x.fieldCoverage ?? 0.5);
+  const va = clamp01(x.verifierAgreement ?? 0.5);
+  switch (rule) {
+    case 'selfReport': return sr;
+    case 'fieldCoverage': return fc;
+    case 'verifierAgreement': return va;
+    case 'hybrid': return clamp01(0.4 * sr + 0.3 * fc + 0.3 * va);
+  }
+}
+
+/** Expected Calibration Error over committed extractions, binned. Lower is better. Abstentions are excluded
+ *  (you cannot be mis-calibrated about an object you declined to emit). */
+export function calibrationError(
+  committed: Array<{ confidence: number; correct: boolean }>,
+  bins = 10,
+): number {
+  if (committed.length === 0) return 0;
+  const buckets: Array<{ conf: number; acc: number; n: number }> = Array.from({ length: bins }, () => ({ conf: 0, acc: 0, n: 0 }));
+  for (const c of committed) {
+    const i = Math.min(bins - 1, Math.floor(clamp01(c.confidence) * bins));
+    buckets[i].conf += c.confidence;
+    buckets[i].acc += c.correct ? 1 : 0;
+    buckets[i].n += 1;
+  }
+  let ece = 0;
+  for (const b of buckets) {
+    if (b.n === 0) continue;
+    ece += (b.n / committed.length) * Math.abs(b.conf / b.n - b.acc / b.n);
+  }
+  return ece;
+}
+
+const clamp01 = (x: number): number => Math.min(1, Math.max(0, x));

--- a/packages/evals-extract/src/classifier.ts
+++ b/packages/evals-extract/src/classifier.ts
@@ -1,0 +1,32 @@
+// @metaharness/evals-extract — the DOC-TYPE CLASSIFIER.
+//
+// Maps a document to one of the fixed DOC_TYPES so the verifier stack + schema strictness can be chosen per
+// doc type. Default is a cheap deterministic keyword heuristic (no model, no cost). An LLM classifier can be
+// injected for the live run; the heuristic is the $0 fallback + the reproducible default for replay.
+import { DOC_TYPES, type DocType } from './genome.js';
+
+export type Classifier = (text: string, hintedCategory?: string) => DocType;
+
+const KEYWORDS: Record<Exclude<DocType, 'other'>, RegExp> = {
+  invoice: /\b(invoice|bill to|amount due|net 30|purchase order|po number|tax id|subtotal|remit)\b/i,
+  receipt: /\b(receipt|total paid|change due|cashier|transaction id|card ending|merchant|refund)\b/i,
+  resume: /\b(curriculum vitae|work experience|education|skills|references|objective|employment history)\b/i,
+  contract: /\b(agreement|whereas|party of the|hereby|governing law|indemnif|termination clause|effective date)\b/i,
+  email: /\b(from:|to:|subject:|cc:|forwarded message|reply-to|dear|regards|sent from my)\b/i,
+  form: /\b(please fill|checkbox|field required|application form|date of birth|signature|section [0-9]|applicant)\b/i,
+  article: /\b(abstract|introduction|conclusion|byline|published|headline|paragraph|editor|column)\b/i,
+};
+
+/** The default $0 heuristic classifier. Honors an explicit dataset category hint when present. */
+export const heuristicClassifier: Classifier = (text, hintedCategory) => {
+  if (hintedCategory) {
+    const h = hintedCategory.toLowerCase();
+    for (const s of DOC_TYPES) if (s !== 'other' && h.includes(s)) return s;
+    if (/bill|purchase/.test(h)) return 'invoice';
+    if (/cv|candidate/.test(h)) return 'resume';
+    if (/agreement|legal/.test(h)) return 'contract';
+    if (/mail|message/.test(h)) return 'email';
+  }
+  for (const [dt, re] of Object.entries(KEYWORDS)) if (re.test(text)) return dt as DocType;
+  return 'other';
+};

--- a/packages/evals-extract/src/data.ts
+++ b/packages/evals-extract/src/data.ts
@@ -1,0 +1,113 @@
+// @metaharness/evals-extract — the DATA CONTRACT (four immutable sets) + manifests.
+//
+// Anti-overfit is procedural. Four disjoint sets, each with a role the machinery ENFORCES:
+//   publicDev        — debugging only; NEVER mutated against, NEVER promoted on. Also the leakage corpus.
+//   privateTrain     — the proposer searches policy mutations here.
+//   privateValidation— the promotion gate scores here.
+//   frozenHoldout    — NEVER visible to proposer/mutation/tuning; confirmed against EXACTLY ONCE, at the end.
+// Each set is content-hashed; the hashes go in the replay bundle so a reviewer can prove the split was fixed.
+//
+// A real extraction corpus (invoices/receipts/resumes/contracts with gold JSON per document) is typically
+// LICENSED/gated — a human must accept its terms before any token can read it. `loadExtractFromHub` reads it
+// once access is granted; until then, the adapter runs on a clearly-labelled SYNTHETIC fixture (dataSource
+// 'SYNTHETIC') so nothing here ever fabricates a real extraction score.
+import { createHash } from 'node:crypto';
+import type { DocType } from './genome.js';
+import type { JsonSchema } from './normalizer.js';
+
+export interface ExtractItem {
+  id: string;
+  /** The source document text to extract from. */
+  text: string;
+  /** The JSON schema the extraction must conform to. */
+  schema: JsonSchema;
+  /** Gold extraction object (serialized JSON) — closed-form fields → exact-match; open-ended → injected LLM
+   *  judge, never fabricated. */
+  gold: string;
+  /** Dataset category hint (feeds the classifier); optional. */
+  category?: string;
+  docType?: DocType;
+  /** True when at least one gold field is open-ended free text (needs a judge, not field-exact-match). */
+  openEnded?: boolean;
+}
+
+export interface ExtractSplit {
+  publicDev: ExtractItem[];
+  privateTrain: ExtractItem[];
+  privateValidation: ExtractItem[];
+  frozenHoldout: ExtractItem[];
+}
+
+export interface SplitManifest {
+  sizes: Record<keyof ExtractSplit, number>;
+  hashes: Record<keyof ExtractSplit, string>;
+  /** sha256 over all four hashes — the single split fingerprint for the replay bundle. */
+  splitFingerprint: string;
+}
+
+export function hashItems(items: ExtractItem[]): string {
+  const canon = items
+    .map((i) => `${i.id}␟${i.text}␟${i.gold}␟${JSON.stringify(i.schema)}`)
+    .sort()
+    .join('␞');
+  return createHash('sha256').update(canon).digest('hex');
+}
+
+export function manifestOf(split: ExtractSplit): SplitManifest {
+  const hashes = {
+    publicDev: hashItems(split.publicDev),
+    privateTrain: hashItems(split.privateTrain),
+    privateValidation: hashItems(split.privateValidation),
+    frozenHoldout: hashItems(split.frozenHoldout),
+  };
+  const sizes = {
+    publicDev: split.publicDev.length,
+    privateTrain: split.privateTrain.length,
+    privateValidation: split.privateValidation.length,
+    frozenHoldout: split.frozenHoldout.length,
+  };
+  const splitFingerprint = createHash('sha256')
+    .update([hashes.publicDev, hashes.privateTrain, hashes.privateValidation, hashes.frozenHoldout].join('␞'))
+    .digest('hex');
+  return { sizes, hashes, splitFingerprint };
+}
+
+/** Deterministic hash-sorted disjoint split (no RNG — reproducible + reviewable). The frozen holdout is
+ *  carved FIRST so it never depends on the others. */
+export function splitDeterministic(
+  items: ExtractItem[],
+  ratios: { publicDev: number; privateTrain: number; privateValidation: number; frozenHoldout: number } = {
+    publicDev: 0.1, privateTrain: 0.5, privateValidation: 0.25, frozenHoldout: 0.15,
+  },
+): ExtractSplit {
+  const sorted = [...items].sort((a, b) =>
+    createHash('sha256').update(a.id).digest('hex') < createHash('sha256').update(b.id).digest('hex') ? -1 : 1,
+  );
+  const n = sorted.length;
+  const nHold = Math.max(0, Math.round(n * ratios.frozenHoldout));
+  const nVal = Math.max(0, Math.round(n * ratios.privateValidation));
+  const nDev = Math.max(0, Math.round(n * ratios.publicDev));
+  const frozenHoldout = sorted.slice(0, nHold);
+  const privateValidation = sorted.slice(nHold, nHold + nVal);
+  const publicDev = sorted.slice(nHold + nVal, nHold + nVal + nDev);
+  const privateTrain = sorted.slice(nHold + nVal + nDev);
+  return { publicDev, privateTrain, privateValidation, frozenHoldout };
+}
+
+/** True iff the four sets are pairwise disjoint by id — an invariant the machinery must hold. */
+export function isDisjoint(split: ExtractSplit): boolean {
+  const ids = [
+    ...split.publicDev, ...split.privateTrain, ...split.privateValidation, ...split.frozenHoldout,
+  ].map((i) => i.id);
+  return new Set(ids).size === ids.length;
+}
+
+/** Loader for the real licensed corpus. Throws a clear, actionable error until access is granted — never
+ *  silently substitutes synthetic data for a real run. */
+export async function loadExtractFromHub(_opts: { token: string; dataset: string; limit?: number }): Promise<ExtractItem[]> {
+  throw new Error(
+    'A real structured-extraction corpus (documents + gold JSON) is a LICENSED/gated resource. Grant access ' +
+      'to your chosen dataset and provide a valid token, then this loader can read it. Until then, run the ' +
+      "adapter on the SYNTHETIC fixture (dataSource 'SYNTHETIC') — it never fabricates a real extraction score.",
+  );
+}

--- a/packages/evals-extract/src/evaluator.ts
+++ b/packages/evals-extract/src/evaluator.ts
@@ -1,0 +1,205 @@
+// @metaharness/evals-extract — the EVALUATOR (harness pipeline) + the PROPOSER (schema-constrained mutation).
+//
+// These are the two seams where the model/benchmark enters the flywheel. Everything extraction-specific lives
+// HERE, in the caller — the flywheel core stays benchmark-agnostic. The evaluator runs the full policy
+// pipeline per document and projects the result onto the flywheel's `Score`; the proposer mutates ONE lever
+// within its typed schema (bounded enum / clamped number / flipped bool) — never free prose (anti-superstition).
+import type { Policy, PolicyGenome, Proposer, Evaluator, Suite } from '@metaharness/flywheel';
+import {
+  policyToGenome, policyFor, clamp01, clampInt,
+  SCHEMA_STRICTNESS, VERIFICATION_MODES, CONFIDENCE_RULES, EXTRACTION_STYLES,
+  type DocType,
+} from './genome.js';
+import { heuristicClassifier, type Classifier } from './classifier.js';
+import { normalizeExtraction, fieldMatch } from './normalizer.js';
+import { makeVerifier } from './verifier.js';
+import { confidence } from './calibration.js';
+import { shouldEscalate, shouldAbstain, nextTier, type Tier } from './routing.js';
+import { detectLeakage, leaks } from './leakage.js';
+import { projectScore, type ExtractScore, type PerDocResult } from './score.js';
+import type { ExtractItem } from './data.js';
+
+/** The MODEL SEAM: extract one document at a tier under an extraction style + schema strictness. Returns the
+ *  raw text (expected to contain a JSON object), an optional self-reported confidence, sampled alternatives
+ *  (for self-consistency), and the USD cost. For the live run this calls a real provider; for $0 replay a
+ *  deterministic mock is injected. */
+export type SolveFn = (input: {
+  tier: Tier;
+  docType: DocType;
+  text: string;
+  style: string;
+  strictness: string;
+  maxCandidates: number;
+}) => Promise<{ raw: string; selfReport?: number; samples?: string[]; costUsd: number }>;
+
+/** Judge for OPEN-ENDED gold fields (field-exact-match is only valid for closed-form fields). Never fabricate
+ *  a verdict: if an item is open-ended and no judge is injected, it is scored as not-correct (honest). */
+export type Judge = (input: { text: string; predicted: Record<string, unknown>; gold: Record<string, unknown> }) => Promise<boolean>;
+
+export interface ExtractEvaluatorOpts {
+  solve: SolveFn;
+  judge?: Judge;
+  classifier?: Classifier;
+  verifier?: ReturnType<typeof makeVerifier>;
+  /** Public-dev documents the policy must not encode (the leakage corpus). */
+  publicExamples?: string[];
+}
+
+export function makeExtractEvaluator(opts: ExtractEvaluatorOpts): Evaluator {
+  const classify = opts.classifier ?? heuristicClassifier;
+  const verify = opts.verifier ?? makeVerifier();
+  const publicExamples = opts.publicExamples ?? [];
+
+  return async function evaluate(policy: Policy, suite: Suite): Promise<ExtractScore> {
+    const genome = policyToGenome(policy);
+    const leaked = leaks(detectLeakage(genome, publicExamples));
+    const items = suite.items as ExtractItem[];
+    const results: PerDocResult[] = [];
+
+    for (const item of items) {
+      const docType = item.docType ?? classify(item.text, item.category);
+      const dp = policyFor(genome, docType);
+      const gold = safeParseObject(item.gold);
+
+      let tier: Tier = 'cheap';
+      let cost = 0;
+      let normValue: Record<string, unknown> | null = null;
+      let schemaValid = false;
+      let conf = 0;
+
+      for (let pass = 0; pass < 3; pass++) {
+        const res = await opts.solve({
+          tier, docType, text: item.text,
+          style: dp.extractionStyle, strictness: dp.schemaStrictness, maxCandidates: dp.maxCandidates,
+        });
+        cost += res.costUsd;
+
+        const norm = normalizeExtraction(res.raw, item.schema, dp.schemaStrictness, genome.global.normalizeFields);
+        normValue = norm.value; schemaValid = norm.schemaValid;
+        const normSamples = (res.samples ?? []).map((s) => normalizeExtraction(s, item.schema, dp.schemaStrictness, genome.global.normalizeFields).value);
+        const fieldCov = normValue === null ? 0 : requiredCoverageOf(normValue, item.schema.required);
+        const vres = verify(dp.verificationMode, { docType, schema: item.schema, value: normValue, samples: normSamples });
+        conf = confidence(dp.confidenceRule, { selfReport: res.selfReport, fieldCoverage: fieldCov, verifierAgreement: vres.agreement });
+
+        const escalate = shouldEscalate(
+          dp,
+          { confidence: conf, verifierDisagrees: vres.disagrees, schemaInvalid: !schemaValid, costSoFarUsd: cost },
+          genome.global.maxCostPerDocUsd,
+        );
+        if (escalate && tier !== 'frontier' && cost < genome.global.maxCostPerDocUsd) { tier = nextTier(tier); continue; }
+        break;
+      }
+
+      const abstained = shouldAbstain(dp, conf);
+      const finalValue = abstained ? null : normValue;
+      let correct = false;
+      if (finalValue !== null && schemaValid) {
+        if (item.openEnded) correct = opts.judge ? await opts.judge({ text: item.text, predicted: finalValue, gold }) : false;
+        else correct = fieldMatch(finalValue, gold, item.schema);
+      }
+      results.push({
+        docType, correct, abstained,
+        schemaInvalid: !schemaValid && !abstained,
+        confidence: conf, costUsd: cost, leaked,
+      });
+    }
+
+    return projectScore(results);
+  };
+}
+
+function safeParseObject(s: string): Record<string, unknown> {
+  try {
+    const o = JSON.parse(s);
+    return o && typeof o === 'object' && !Array.isArray(o) ? (o as Record<string, unknown>) : {};
+  } catch { return {}; }
+}
+
+function requiredCoverageOf(value: Record<string, unknown>, required: string[]): number {
+  if (required.length === 0) return 1;
+  let ok = 0;
+  for (const r of required) {
+    const v = value[r];
+    if (v !== undefined && v !== null && v !== '') ok++;
+  }
+  return ok / required.length;
+}
+
+// ── the PROPOSER — one lever, in-schema ─────────────────────────────────────────────────────────────────
+
+export interface ExtractProposerOpts {
+  /** Optional LLM seam — asked to pick an in-schema value; its output is CLAMPED to the schema regardless. */
+  complete?: (model: string, prompt: string) => Promise<string>;
+  proposerModel?: string;
+}
+
+const nextEnum = <T extends readonly string[]>(arr: T, cur: string): string => {
+  const i = (arr as readonly string[]).indexOf(cur);
+  return arr[(i + 1) % arr.length];
+};
+
+/** A deterministic, schema-respecting mutation for one lever. This is the $0 default; with `complete` the
+ *  LLM proposes and this function still CLAMPS the result to the lever's type/range. */
+export function makeExtractProposer(opts: ExtractProposerOpts = {}): Proposer {
+  return async function propose(base: PolicyGenome, target: string): Promise<string> {
+    const cur = base.policy[target] ?? '';
+
+    // With an LLM: it proposes in-schema and clampLever still forces the result into the lever's type/range.
+    if (opts.complete) {
+      let suggestion = cur;
+      try {
+        suggestion = (await opts.complete(
+          opts.proposerModel ?? 'proposer',
+          `You tune ONE lever of a structured-extraction policy. Lever="${target}", current="${cur}". Reply with ONLY the new value, in-schema. No prose.`,
+        )).trim();
+      } catch { suggestion = cur; }
+      return clampLever(target, suggestion, cur);
+    }
+
+    // $0 deterministic proposer: take one in-schema STEP so the flywheel can search without a model.
+    return deterministicStep(target, cur);
+  };
+}
+
+/** One deterministic, in-schema step for a lever — the model-free mutation used for $0 dry-runs/replay. */
+export function deterministicStep(target: string, cur: string): string {
+  const num = (v: string, d: number) => (Number.isNaN(Number(v)) ? d : Number(v));
+  switch (target) {
+    case 'extractionStyle': return nextEnum(EXTRACTION_STYLES, cur || 'direct-json');
+    case 'schemaStrictness': return nextEnum(SCHEMA_STRICTNESS, cur || 'coerce');
+    case 'verificationMode': return nextEnum(VERIFICATION_MODES, cur || 'none');
+    case 'confidenceRule': return nextEnum(CONFIDENCE_RULES, cur || 'selfReport');
+    case 'maxCandidates': return String(clampInt(num(cur, 1) + 1, 1, 8));
+    case 'escalationThreshold': return String(clamp01(num(cur, 0.5) + 0.1));
+    case 'abstainThreshold': return String(clamp01(num(cur, 0.15) + 0.05));
+    case 'maxCostPerDocUsd': return String(Math.max(0, num(cur, 0.05) + 0.02));
+    case 'normalizeFields':
+    case 'requireAllRequiredFields': return String(!(cur === 'true'));
+    default: return cur;
+  }
+}
+
+/** Force any proposed value into the lever's schema. The load-bearing anti-superstition guarantee. */
+export function clampLever(target: string, proposed: string, current: string): string {
+  const num = (v: string, d: number) => (Number.isNaN(Number(v)) ? d : Number(v));
+  switch (target) {
+    case 'extractionStyle': return valid(EXTRACTION_STYLES, proposed) ?? nextEnum(EXTRACTION_STYLES, current || 'direct-json');
+    case 'schemaStrictness': return valid(SCHEMA_STRICTNESS, proposed) ?? nextEnum(SCHEMA_STRICTNESS, current || 'coerce');
+    case 'verificationMode': return valid(VERIFICATION_MODES, proposed) ?? nextEnum(VERIFICATION_MODES, current || 'none');
+    case 'confidenceRule': return valid(CONFIDENCE_RULES, proposed) ?? nextEnum(CONFIDENCE_RULES, current || 'selfReport');
+    case 'escalationThreshold': return String(clamp01(num(proposed, num(current, 0.5))));
+    case 'abstainThreshold': return String(clamp01(num(proposed, num(current, 0.15))));
+    case 'maxCandidates': return String(clampInt(num(proposed, num(current, 1)), 1, 8));
+    case 'maxCostPerDocUsd': return String(Math.max(0, num(proposed, num(current, 0.05))));
+    case 'normalizeFields':
+    case 'requireAllRequiredFields': {
+      const b = /^(true|false)$/i.test(proposed) ? proposed.toLowerCase() : String(!(current === 'true'));
+      return b;
+    }
+    default: return current;
+  }
+}
+
+function valid<T extends readonly string[]>(arr: T, v: string): string | null {
+  return (arr as readonly string[]).includes(v) ? v : null;
+}

--- a/packages/evals-extract/src/gate.ts
+++ b/packages/evals-extract/src/gate.ts
@@ -1,0 +1,73 @@
+// @metaharness/evals-extract — the EXTRACT COMPOSITE PROMOTION GATE.
+//
+// CRITICAL INTEGRITY PROPERTY: the flywheel's default `meetsPromotionRule` is FROZEN and is NOT edited here.
+// This gate is a STRICTER superset — it CALLS the frozen rule and ANDs the extract-specific clauses on top.
+// The flywheel supports injecting a `PromotionRule`; the replay bundle fingerprints WHATEVER rule ran, so
+// this composite is itself frozen + verifiably unchanged for the extraction deployment. "The gate is the
+// product" holds: a promotion is only as trustworthy as the (fingerprinted) rule that admitted it.
+//
+// Extract extras (all must hold, on top of every frozen clause):
+//   MATERIALITY (disjunctive) — a promotion must be a MEANINGFUL win, one of:
+//       accuracy win:  candidate.accuracy ≥ baseline.accuracy + 0.02   (below this is noise at N~500)
+//       cost win:      accuracy held (≥ baseline) AND cost/correct ≤ 0.60 × baseline (≥40% cheaper)
+//   schema-error not worse     candidate.schemaErrorRate ≤ baseline.schemaErrorRate
+//   calibration not worse      candidate.calibrationError ≤ baseline.calibrationError + 1e-9
+//   ≤2 doc-type regressions    count(doc types where candidate acc < baseline acc) ≤ 2
+// The frozen base gate ALSO guarantees, for EVERY promotion: cost/correct never worsens, the no-commit rate
+// (schema-invalid + abstention) STRICTLY improves (the harness must make the model emit a valid object more
+// often, not merely cheaper), the anchor never regresses. We deliberately do NOT admit a "cost may rise for an
+// accuracy gain" branch — the shipped product gate never lets cost/correct rise. Stricter-on-cost is the
+// anti-overfit-safe side.
+import { meetsPromotionRule } from '@metaharness/flywheel';
+import type { PromotionEvidence, PromotionDecision } from '@metaharness/flywheel';
+import type { ExtractScore } from './score.js';
+
+/** Per-generation VALIDATION gate margin. */
+export const EXTRACT_ACCURACY_MARGIN = 0.02;
+/** A cost win must cut cost/correct by at least this fraction with no accuracy loss. */
+export const EXTRACT_COST_WIN_FRACTION = 0.4;
+export const EXTRACT_MAX_DOCTYPE_REGRESSIONS = 2;
+/** The FINAL claim bar, confirmed EXACTLY ONCE on the frozen holdout — NOT the per-generation gate.
+ *  Target claim: frontier-class field-accuracy at materially lower cost, and a measurable schema-error
+ *  reduction over the SAME model with tuned strictness + verifier + routing. A giant jump would signal
+ *  contamination/leakage — do not claim it. */
+export const FROZEN_HOLDOUT_ACCEPTANCE = {
+  minAccuracyLiftPp: 0.03,
+  maxCostPerCorrectRatio: 1.5,
+  costWinFraction: 0.4,
+} as const;
+
+/** The composite extract gate. `evidence.baseline`/`candidate` MUST be ExtractScore (they carry extra axes). */
+export function extractPromotionRule(evidence: PromotionEvidence): PromotionDecision {
+  // 1) the FROZEN default gate — untouched, called verbatim.
+  const base = meetsPromotionRule(evidence);
+  const reasons = [...base.reasons];
+
+  const b = evidence.baseline as ExtractScore;
+  const c = evidence.candidate as ExtractScore;
+
+  // 2) extract extras (guard for the case a plain Score slips through).
+  if (typeof c.accuracy === 'number' && typeof b.accuracy === 'number') {
+    // MATERIALITY: an accuracy win OR a cost win — one must hold. (The frozen base gate already ensures
+    // accuracy never regresses and cost/correct never worsens, so both branches are frozen-compatible.)
+    const accuracyWin = c.accuracy >= b.accuracy + EXTRACT_ACCURACY_MARGIN;
+    const costWin = c.accuracy >= b.accuracy && c.costPerCorrect <= b.costPerCorrect * (1 - EXTRACT_COST_WIN_FRACTION);
+    if (!accuracyWin && !costWin) reasons.push('immaterial_no_accuracy_or_cost_win');
+    if (c.schemaErrorRate > b.schemaErrorRate) reasons.push('schema_error_worsened');
+    if (c.calibrationError > b.calibrationError + 1e-9) reasons.push('calibration_worsened');
+    const regressions = docTypeRegressionCount(b, c);
+    if (regressions > EXTRACT_MAX_DOCTYPE_REGRESSIONS) reasons.push(`doctype_regressions_${regressions}`);
+  }
+
+  return { promote: reasons.length === 0, reasons };
+}
+
+/** Number of doc types whose accuracy dropped candidate-vs-baseline (only doc types present in both). */
+export function docTypeRegressionCount(baseline: ExtractScore, candidate: ExtractScore): number {
+  let count = 0;
+  for (const [dt, ba] of Object.entries(baseline.perDocTypeAccuracy)) {
+    const ca = candidate.perDocTypeAccuracy[dt as keyof typeof candidate.perDocTypeAccuracy];
+    if (typeof ca === 'number' && typeof ba === 'number' && ca < ba) count++;
+  }
+  return count;
+}

--- a/packages/evals-extract/src/genome.ts
+++ b/packages/evals-extract/src/genome.ts
@@ -1,0 +1,163 @@
+// @metaharness/evals-extract — the STRUCTURED-EXTRACTION POLICY GENOME.
+//
+// The genome is deliberately small, typed, and auditable. The flywheel evolves the HARNESS POLICY that
+// decides how strictly to adhere to the schema, how to normalize fields, how to verify (json-schema-validate),
+// route, abstain, and calibrate — NOT the model. Models, evaluator, and the private holdout are frozen; only
+// this genome mutates. Arbitrary prose mutation is how you get benchmark superstition, so EVERY lever is a
+// bounded enum or a clamped number — never free text.
+//
+// The flywheel's engine evolves a FLAT `Policy` (Record<string,string>), one lever per generation. So the
+// typed genome round-trips through a flat string projection (`genomeToPolicy` / `policyToGenome`). The flat
+// keys ARE the mutation classes.
+
+/** How strictly an extracted JSON object must adhere to the schema. Chosen per doc type; drives the
+ *  normalizer + verifier. `lenient` coerces/ignores extras; `strict` forbids additional properties. */
+export const SCHEMA_STRICTNESS = ['lenient', 'coerce', 'strict', 'strictAdditional'] as const;
+export type SchemaStrictness = (typeof SCHEMA_STRICTNESS)[number];
+
+/** How a candidate extraction is verified. NOT a generic "critic says yes" (ADR-226: read-only advice = 0
+ *  marginal resolves at 5.4x cost). Real, deterministic checks over the JSON; `none` is the cheap default. */
+export const VERIFICATION_MODES = ['none', 'jsonSchemaValidate', 'typeCheck', 'requiredFields', 'crossFieldConsistency'] as const;
+export type VerificationMode = (typeof VERIFICATION_MODES)[number];
+
+/** How confidence is derived — feeds escalation + abstention. */
+export const CONFIDENCE_RULES = ['selfReport', 'fieldCoverage', 'verifierAgreement', 'hybrid'] as const;
+export type ConfidenceRule = (typeof CONFIDENCE_RULES)[number];
+
+/** Bounded extractor-prompt STYLES (not free prose). This is the schema that keeps mutation boring. */
+export const EXTRACTION_STYLES = ['direct-json', 'field-by-field', 'schema-first', 'validate-then-emit'] as const;
+export type ExtractionStyle = (typeof EXTRACTION_STYLES)[number];
+
+/** The document types extraction spans. The classifier maps a document to one of these; the verifier stack
+ *  is chosen per doc type. Kept fixed + small on purpose (a mutable taxonomy is a leakage surface). */
+export const DOC_TYPES = [
+  'invoice', 'receipt', 'resume', 'contract', 'email', 'form', 'article', 'other',
+] as const;
+export type DocType = (typeof DOC_TYPES)[number];
+
+export interface DocTypePolicy {
+  extractionStyle: ExtractionStyle;
+  schemaStrictness: SchemaStrictness;
+  verificationMode: VerificationMode;
+  /** Escalate to a stronger pass when confidence < this. [0,1]. */
+  escalationThreshold: number;
+  /** Max extraction candidates to sample for self-consistency. [1,8]. */
+  maxCandidates: number;
+  confidenceRule: ConfidenceRule;
+  /** Abstain (emit no object) when final confidence < this. [0,1]. Abstention counts as a no-op. */
+  abstainThreshold: number;
+}
+
+export interface GlobalPolicy {
+  normalizeFields: boolean;
+  requireAllRequiredFields: boolean;
+  allowToolUse: boolean;
+  maxCostPerDocUsd: number;
+  maxLatencyMs: number;
+}
+
+export interface ExtractPolicyGenome {
+  /** Per-doc-type overrides. A missing doc type falls back to `defaults`. */
+  docTypePolicy: Partial<Record<DocType, DocTypePolicy>>;
+  /** The default doc-type policy — what most levers actually tune (doc-type overrides layer on top). */
+  defaults: DocTypePolicy;
+  global: GlobalPolicy;
+}
+
+/** The mutation CLASSES — each is one flat lever the flywheel may evolve. Bias future proposals toward the
+ *  classes that actually promote. */
+export const MUTATION_CLASSES = [
+  'extractionStyle',
+  'schemaStrictness',
+  'verificationMode',
+  'escalationThreshold',
+  'maxCandidates',
+  'confidenceRule',
+  'abstainThreshold',
+  'normalizeFields',
+  'requireAllRequiredFields',
+  'maxCostPerDocUsd',
+] as const;
+export type MutationClass = (typeof MUTATION_CLASSES)[number];
+
+export const DEFAULT_DOCTYPE_POLICY: DocTypePolicy = {
+  extractionStyle: 'direct-json',
+  schemaStrictness: 'coerce',
+  verificationMode: 'none',
+  escalationThreshold: 0.5,
+  maxCandidates: 1,
+  confidenceRule: 'selfReport',
+  abstainThreshold: 0.15,
+};
+
+export const DEFAULT_GLOBAL_POLICY: GlobalPolicy = {
+  normalizeFields: true,
+  requireAllRequiredFields: true,
+  allowToolUse: false,
+  maxCostPerDocUsd: 0.05,
+  maxLatencyMs: 60000,
+};
+
+/** The gen-0 root genome — the immutable baseline every promotion chains back to. */
+export function rootGenome(): ExtractPolicyGenome {
+  return { docTypePolicy: {}, defaults: { ...DEFAULT_DOCTYPE_POLICY }, global: { ...DEFAULT_GLOBAL_POLICY } };
+}
+
+/** Resolve the effective DocTypePolicy for a doc type (override on top of defaults). */
+export function policyFor(genome: ExtractPolicyGenome, docType: DocType): DocTypePolicy {
+  return { ...genome.defaults, ...(genome.docTypePolicy[docType] ?? {}) };
+}
+
+// ── flat <-> typed projection (the flywheel evolves the flat form) ────────────────────────────────────
+// The flat levers tune the `defaults` block + the `global` block. Doc-type overrides are carried verbatim in
+// a single JSON lever so the round-trip is lossless without exploding the mutation surface.
+
+export function genomeToPolicy(g: ExtractPolicyGenome): Record<string, string> {
+  return {
+    extractionStyle: g.defaults.extractionStyle,
+    schemaStrictness: g.defaults.schemaStrictness,
+    verificationMode: g.defaults.verificationMode,
+    escalationThreshold: String(g.defaults.escalationThreshold),
+    maxCandidates: String(g.defaults.maxCandidates),
+    confidenceRule: g.defaults.confidenceRule,
+    abstainThreshold: String(g.defaults.abstainThreshold),
+    normalizeFields: String(g.global.normalizeFields),
+    requireAllRequiredFields: String(g.global.requireAllRequiredFields),
+    maxCostPerDocUsd: String(g.global.maxCostPerDocUsd),
+    // opaque carry-throughs (not mutated as classes)
+    __docTypeOverrides: JSON.stringify(g.docTypePolicy),
+    __allowToolUse: String(g.global.allowToolUse),
+    __maxLatencyMs: String(g.global.maxLatencyMs),
+  };
+}
+
+export function policyToGenome(p: Record<string, string>): ExtractPolicyGenome {
+  const num = (v: string | undefined, d: number) => (v === undefined || Number.isNaN(Number(v)) ? d : Number(v));
+  const bool = (v: string | undefined, d: boolean) => (v === undefined ? d : v === 'true');
+  const oneOf = <T extends readonly string[]>(arr: T, v: string | undefined, d: T[number]): T[number] =>
+    (arr as readonly string[]).includes(v ?? '') ? (v as T[number]) : d;
+  let overrides: Partial<Record<DocType, DocTypePolicy>> = {};
+  try { overrides = p.__docTypeOverrides ? JSON.parse(p.__docTypeOverrides) : {}; } catch { overrides = {}; }
+  return {
+    docTypePolicy: overrides,
+    defaults: {
+      extractionStyle: oneOf(EXTRACTION_STYLES, p.extractionStyle, DEFAULT_DOCTYPE_POLICY.extractionStyle),
+      schemaStrictness: oneOf(SCHEMA_STRICTNESS, p.schemaStrictness, DEFAULT_DOCTYPE_POLICY.schemaStrictness),
+      verificationMode: oneOf(VERIFICATION_MODES, p.verificationMode, DEFAULT_DOCTYPE_POLICY.verificationMode),
+      escalationThreshold: clamp01(num(p.escalationThreshold, DEFAULT_DOCTYPE_POLICY.escalationThreshold)),
+      maxCandidates: clampInt(num(p.maxCandidates, DEFAULT_DOCTYPE_POLICY.maxCandidates), 1, 8),
+      confidenceRule: oneOf(CONFIDENCE_RULES, p.confidenceRule, DEFAULT_DOCTYPE_POLICY.confidenceRule),
+      abstainThreshold: clamp01(num(p.abstainThreshold, DEFAULT_DOCTYPE_POLICY.abstainThreshold)),
+    },
+    global: {
+      normalizeFields: bool(p.normalizeFields, DEFAULT_GLOBAL_POLICY.normalizeFields),
+      requireAllRequiredFields: bool(p.requireAllRequiredFields, DEFAULT_GLOBAL_POLICY.requireAllRequiredFields),
+      allowToolUse: bool(p.__allowToolUse, DEFAULT_GLOBAL_POLICY.allowToolUse),
+      maxCostPerDocUsd: Math.max(0, num(p.maxCostPerDocUsd, DEFAULT_GLOBAL_POLICY.maxCostPerDocUsd)),
+      maxLatencyMs: Math.max(0, num(p.__maxLatencyMs, DEFAULT_GLOBAL_POLICY.maxLatencyMs)),
+    },
+  };
+}
+
+export const clamp01 = (x: number): number => Math.min(1, Math.max(0, x));
+export const clampInt = (x: number, lo: number, hi: number): number => Math.min(hi, Math.max(lo, Math.round(x)));

--- a/packages/evals-extract/src/index.ts
+++ b/packages/evals-extract/src/index.ts
@@ -1,0 +1,20 @@
+// @metaharness/evals-extract — a benchmark ADAPTER for @metaharness/flywheel.
+//
+// Structured JSON extraction from text treated as a POLICY-EVOLUTION problem, not a model-training problem:
+// freeze the models, the evaluator, and the private holdout; let the flywheel evolve ONLY the harness policy
+// that decides how strictly to adhere to the schema, how to normalize fields, verify (json-schema-validate),
+// route, abstain, and calibrate. The policy — not the model — is the genome.
+//
+// This package is NOT core logic: it exports a `Proposer` + `Evaluator` (+ a stricter composite gate) that
+// plug into the benchmark-agnostic flywheel. The flywheel never learns what "extraction" is.
+export * from './genome.js';
+export * from './classifier.js';
+export * from './normalizer.js';
+export * from './verifier.js';
+export * from './calibration.js';
+export * from './routing.js';
+export * from './leakage.js';
+export * from './score.js';
+export * from './gate.js';
+export * from './data.js';
+export * from './evaluator.js';

--- a/packages/evals-extract/src/leakage.ts
+++ b/packages/evals-extract/src/leakage.ts
@@ -1,0 +1,80 @@
+// @metaharness/evals-extract — the LEAKAGE DETECTOR (fail-closed).
+//
+// The single biggest failure mode of benchmark policy evolution is overfit-by-leakage: a policy that encodes
+// document-specific hacks, memorized gold objects, or dataset-artifact language. This detector runs on every
+// candidate policy BEFORE it can be scored/promoted. Any positive signal fails the candidate CLOSED — it is
+// marked `regressed` so the frozen gate rejects it outright. Anti-overfit is procedural, not aspirational.
+import type { ExtractPolicyGenome } from './genome.js';
+
+export interface LeakageCheck {
+  /** Max n-gram overlap between any policy string and any known public example. [0,1]. */
+  ngramOverlapWithPublicExamples: number;
+  /** A policy string reproduces a specific holdout/dev document verbatim. */
+  exactDocumentSeen: boolean;
+  /** Policy mentions a benchmark artifact (dataset ids, split names, "gold record"). */
+  policyMentionsBenchmarkArtifact: boolean;
+  /** Policy embeds a dataset-specific hack (per-document field lookups, hardcoded values). */
+  promptContainsDatasetSpecificHack: boolean;
+}
+
+const ARTIFACT_RE = /\b(gold (record|extraction|answer|json|object)|frozen[- ]?holdout|private[- ]?validation|test split|validation split|dev split|eval corpus)\b/i;
+const HACK_RE = /\b(if (the )?(document|doc|text) (contains|is|mentions)|field\s*(is|=)\s*["']|lookup table|memoized (record|answer)|hardcod|answer\s*(is|=)\s*["'])/i;
+
+/** Scan a candidate genome for leakage. `publicExamples` are dev-set documents the policy MUST NOT encode. */
+export function detectLeakage(genome: ExtractPolicyGenome, publicExamples: string[] = []): LeakageCheck {
+  const strings = collectStrings(genome);
+  const joined = strings.join('  ').toLowerCase();
+
+  let maxOverlap = 0;
+  let exact = false;
+  for (const ex of publicExamples) {
+    const q = ex.toLowerCase().trim();
+    if (!q) continue;
+    if (joined.includes(q)) { exact = true; maxOverlap = 1; break; }
+    const o = ngramOverlap(joined, q, 5);
+    if (o > maxOverlap) maxOverlap = o;
+  }
+
+  return {
+    ngramOverlapWithPublicExamples: maxOverlap,
+    exactDocumentSeen: exact,
+    policyMentionsBenchmarkArtifact: strings.some((s) => ARTIFACT_RE.test(s)),
+    promptContainsDatasetSpecificHack: strings.some((s) => HACK_RE.test(s)),
+  };
+}
+
+/** Fail-closed verdict: true if the candidate must be rejected. */
+export function leaks(check: LeakageCheck, ngramThreshold = 0.5): boolean {
+  return (
+    check.exactDocumentSeen ||
+    check.policyMentionsBenchmarkArtifact ||
+    check.promptContainsDatasetSpecificHack ||
+    check.ngramOverlapWithPublicExamples >= ngramThreshold
+  );
+}
+
+function collectStrings(g: ExtractPolicyGenome): string[] {
+  const out: string[] = [];
+  const walk = (v: unknown) => {
+    if (typeof v === 'string') out.push(v);
+    else if (Array.isArray(v)) v.forEach(walk);
+    else if (v && typeof v === 'object') Object.values(v).forEach(walk);
+  };
+  walk(g);
+  return out;
+}
+
+function ngramOverlap(haystack: string, needle: string, n: number): number {
+  const grams = (s: string): Set<string> => {
+    const toks = s.split(/\s+/).filter(Boolean);
+    const set = new Set<string>();
+    for (let i = 0; i + n <= toks.length; i++) set.add(toks.slice(i, i + n).join(' '));
+    return set;
+  };
+  const ng = grams(needle);
+  if (ng.size === 0) return 0;
+  const hg = grams(haystack);
+  let hits = 0;
+  for (const g of ng) if (hg.has(g)) hits++;
+  return hits / ng.size;
+}

--- a/packages/evals-extract/src/normalizer.ts
+++ b/packages/evals-extract/src/normalizer.ts
@@ -1,0 +1,164 @@
+// @metaharness/evals-extract — the FIELD / JSON NORMALIZER + json-schema validator.
+//
+// Extracts + canonicalizes a structured object from an extractor's raw output so field-correctness scoring is
+// fair (a valid object buried in prose, or "0.50" vs ".5" in a numeric field, should not be scored wrong).
+// Schema-aware. Returns `schemaValid: false` when no object matching the schema shape can be extracted — that
+// is the SCHEMA-INVALID signal (a no-op) the routing + scoring layers act on. Deterministic + $0.
+import type { SchemaStrictness } from './genome.js';
+
+/** A minimal, deterministic JSON-schema subset — enough for the extraction verifier without a validator dep. */
+export interface JsonSchema {
+  type: 'object';
+  properties: Record<string, { type: 'string' | 'number' | 'integer' | 'boolean' }>;
+  required: string[];
+  /** When false, keys not in `properties` make the object schema-invalid (under strict strictness). */
+  additionalProperties?: boolean;
+}
+
+export interface NormalizedExtraction {
+  /** Canonical extracted object, or null if none could be parsed (format-invalid → no-op). */
+  value: Record<string, unknown> | null;
+  /** True if raw output parsed into a JSON object at all (regardless of schema conformance). */
+  formatValid: boolean;
+  /** True if the parsed object validates against the schema under the active strictness. */
+  schemaValid: boolean;
+}
+
+// Pull the first balanced `{ ... }` span out of a raw output (extractors often wrap JSON in prose/fences).
+// Linear scan over braces — no backtracking regex, no ReDoS surface.
+function extractJsonSpan(raw: string): string | null {
+  const start = raw.indexOf('{');
+  if (start < 0) return null;
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = start; i < raw.length; i++) {
+    const ch = raw[i];
+    if (inStr) {
+      if (esc) esc = false;
+      else if (ch === '\\') esc = true;
+      else if (ch === '"') inStr = false;
+      continue;
+    }
+    if (ch === '"') inStr = true;
+    else if (ch === '{') depth++;
+    else if (ch === '}') { depth--; if (depth === 0) return raw.slice(start, i + 1); }
+  }
+  return null;
+}
+
+/** Parse + normalize + schema-validate one raw extraction. */
+export function normalizeExtraction(
+  raw: string,
+  schema: JsonSchema,
+  strictness: SchemaStrictness,
+  normalize: boolean,
+): NormalizedExtraction {
+  const span = extractJsonSpan((raw ?? '').trim());
+  if (!span) return { value: null, formatValid: false, schemaValid: false };
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(span); } catch { return { value: null, formatValid: false, schemaValid: false }; }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { value: null, formatValid: false, schemaValid: false };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const value = normalize ? normalizeFields(obj, schema, strictness) : obj;
+  const schemaValid = validateSchema(value, schema, strictness);
+  return { value, formatValid: true, schemaValid };
+}
+
+/** Canonicalize field values per the declared property types (coerce numeric strings, trim, lower booleans). */
+export function normalizeFields(
+  obj: Record<string, unknown>,
+  schema: JsonSchema,
+  strictness: SchemaStrictness,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    const p = schema.properties[k];
+    if (!p) {
+      // keep unknown keys unless a strict-additional policy will reject them at validate time
+      if (strictness !== 'strictAdditional') out[k] = v;
+      continue;
+    }
+    out[k] = canonValue(v, p.type, strictness);
+  }
+  return out;
+}
+
+function canonValue(v: unknown, type: JsonSchema['properties'][string]['type'], strictness: SchemaStrictness): unknown {
+  // `strict`/`strictAdditional` do NOT coerce — a wrong-typed field must stay wrong (and fail validation).
+  const coerce = strictness === 'lenient' || strictness === 'coerce';
+  switch (type) {
+    case 'string':
+      return typeof v === 'string' ? v.trim() : coerce ? String(v) : v;
+    case 'number':
+    case 'integer': {
+      if (typeof v === 'number') return type === 'integer' ? Math.trunc(v) : canonNumber(v);
+      if (coerce && typeof v === 'string') {
+        const n = Number(v.replace(/[, $]/g, ''));
+        if (!Number.isNaN(n)) return type === 'integer' ? Math.trunc(n) : canonNumber(n);
+      }
+      return v;
+    }
+    case 'boolean':
+      if (typeof v === 'boolean') return v;
+      if (coerce && typeof v === 'string') {
+        if (/^true$/i.test(v.trim())) return true;
+        if (/^false$/i.test(v.trim())) return false;
+      }
+      return v;
+  }
+}
+
+function canonNumber(n: number): number {
+  return n === 0 ? 0 : n; // normalize -0 → 0
+}
+
+/** Deterministic schema validation over the minimal subset. Strictness modulates additionalProperties. */
+export function validateSchema(obj: Record<string, unknown>, schema: JsonSchema, strictness: SchemaStrictness): boolean {
+  for (const req of schema.required) if (!(req in obj)) return false;
+  const forbidExtra = strictness === 'strictAdditional' || (schema.additionalProperties === false && strictness !== 'lenient');
+  for (const [k, v] of Object.entries(obj)) {
+    const p = schema.properties[k];
+    if (!p) { if (forbidExtra) return false; else continue; }
+    if (!typeMatches(v, p.type)) return false;
+  }
+  return true;
+}
+
+export function typeMatches(v: unknown, type: JsonSchema['properties'][string]['type']): boolean {
+  switch (type) {
+    case 'string': return typeof v === 'string';
+    case 'boolean': return typeof v === 'boolean';
+    case 'number': return typeof v === 'number' && !Number.isNaN(v);
+    case 'integer': return typeof v === 'number' && Number.isInteger(v);
+  }
+}
+
+/** Field-correctness: every property declared in the schema matches the gold object exactly (post-normalize).
+ *  This is the deterministic extraction grader for closed-form fields. Open-ended fields (free text) get an
+ *  injected LLM judge instead — never fabricate a judge verdict. */
+export function fieldMatch(predicted: Record<string, unknown> | null, gold: Record<string, unknown>, schema: JsonSchema): boolean {
+  if (predicted === null) return false;
+  for (const key of Object.keys(schema.properties)) {
+    if (!deepEqual(predicted[key], gold[key])) return false;
+  }
+  return true;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a && b && typeof a === 'object') return JSON.stringify(a) === JSON.stringify(b);
+  return false;
+}
+
+/** Canonical JSON string of an extraction (stable key order) — used for self-consistency comparison. */
+export function canonicalJson(obj: Record<string, unknown> | null): string | null {
+  if (obj === null) return null;
+  const keys = Object.keys(obj).sort();
+  return JSON.stringify(keys.map((k) => [k, obj[k]]));
+}

--- a/packages/evals-extract/src/routing.ts
+++ b/packages/evals-extract/src/routing.ts
@@ -1,0 +1,45 @@
+// @metaharness/evals-extract — COST-AWARE 3-PASS ROUTING.
+//
+// Pass 1: cheap model, direct-json extraction, no verifier.
+// Pass 2: same/mid model + schema verifier + field normalization.
+// Pass 3: frontier model — ONLY when uncertainty remains high.
+// The win condition is NOT "highest field-accuracy at any cost"; it is frontier-class extraction accuracy at
+// materially lower cost with better calibration. Escalation is gated by confidence + verifier disagreement +
+// schema validity.
+import type { DocTypePolicy } from './genome.js';
+
+export interface EscalationSignals {
+  confidence: number;
+  verifierDisagrees: boolean;
+  schemaInvalid: boolean;
+  /** Optional prior: this doc type is high-error for the cheap model. */
+  docTypeIsHighErrorForCheap?: boolean;
+  /** USD spent on this document so far — hard stop against the per-doc cap. */
+  costSoFarUsd: number;
+}
+
+export function shouldEscalate(policy: DocTypePolicy, sig: EscalationSignals, maxCostPerDocUsd: number): boolean {
+  if (sig.costSoFarUsd >= maxCostPerDocUsd) return false; // cost cap wins — never escalate past budget
+  return (
+    sig.confidence < policy.escalationThreshold ||
+    sig.verifierDisagrees ||
+    sig.schemaInvalid ||
+    !!sig.docTypeIsHighErrorForCheap
+  );
+}
+
+/** Whether to abstain: after the last affordable pass, confidence still under the abstain floor. Abstention
+ *  is a COMMITTED no-op — better a null than a confident schema-invalid object (protects calibration + the
+ *  noop gate, but too much abstention worsens the noopRate the frozen gate requires to strictly improve). */
+export function shouldAbstain(policy: DocTypePolicy, finalConfidence: number): boolean {
+  return finalConfidence < policy.abstainThreshold;
+}
+
+/** The three routing tiers, cheapest first. The caller maps a tier to a concrete model. */
+export const TIERS = ['cheap', 'mid', 'frontier'] as const;
+export type Tier = (typeof TIERS)[number];
+
+export function nextTier(current: Tier): Tier {
+  const i = TIERS.indexOf(current);
+  return TIERS[Math.min(TIERS.length - 1, i + 1)];
+}

--- a/packages/evals-extract/src/score.ts
+++ b/packages/evals-extract/src/score.ts
@@ -1,0 +1,91 @@
+// @metaharness/evals-extract — the SCORE VECTOR and its projection onto the flywheel's four frozen axes.
+//
+// Extraction is not optimized on raw field-accuracy. We measure a vector (accuracy, cost/correct, calibration
+// error, schema-error rate, per-doc-type accuracy) and PROJECT it onto the flywheel's opaque `Score`:
+//   primary     = accuracy (schema-valid AND field-correct)
+//   noopRate    = schema-invalid + abstention rate  ("commit a valid object" — the frozen gate needs this ↓)
+//   costPerWin  = cost per CORRECT extraction        (999 sentinel when 0 correct, so 0-win is never "cheap")
+//   regressed   = a hard stop: leakage (fail-closed) OR total schema collapse
+// The richer axes (calibrationError, perDocTypeAccuracy, schemaErrorRate) ride ALONG on `ExtractScore` so the
+// composite extract gate can enforce its extra clauses — the base `Score` fields alone drive the frozen gate.
+import type { Score } from '@metaharness/flywheel';
+import type { DocType } from './genome.js';
+
+export interface ExtractScore extends Score {
+  accuracy: number;
+  costPerCorrect: number;
+  calibrationError: number;
+  schemaErrorRate: number;
+  abstentionRate: number;
+  perDocTypeAccuracy: Partial<Record<DocType, number>>;
+  n: number;
+  correct: number;
+}
+
+export interface PerDocResult {
+  docType: DocType;
+  correct: boolean;
+  abstained: boolean;
+  schemaInvalid: boolean;
+  confidence: number;
+  costUsd: number;
+  leaked: boolean;
+}
+
+const COST_SENTINEL = 999;
+
+/** Aggregate per-document results into an ExtractScore (which IS a valid flywheel Score). */
+export function projectScore(results: PerDocResult[]): ExtractScore {
+  const n = results.length || 1;
+  const correct = results.filter((r) => r.correct).length;
+  const abstained = results.filter((r) => r.abstained).length;
+  const schemaInvalid = results.filter((r) => r.schemaInvalid && !r.abstained).length;
+  const totalCost = results.reduce((s, r) => s + r.costUsd, 0);
+  const anyLeak = results.some((r) => r.leaked);
+
+  // per-doc-type accuracy
+  const byType: Partial<Record<DocType, { c: number; n: number }>> = {};
+  for (const r of results) {
+    const b = (byType[r.docType] ??= { c: 0, n: 0 });
+    b.n += 1; if (r.correct) b.c += 1;
+  }
+  const perDocTypeAccuracy: Partial<Record<DocType, number>> = {};
+  for (const [t, b] of Object.entries(byType)) perDocTypeAccuracy[t as DocType] = b!.c / b!.n;
+
+  const accuracy = correct / n;
+  const noopRate = (abstained + schemaInvalid) / n;
+  const costPerCorrect = correct > 0 ? totalCost / correct : COST_SENTINEL;
+
+  const committed = results.filter((r) => !r.abstained && !r.schemaInvalid);
+  const calErr = calibrationErrorOf(committed);
+
+  // hard stop: leakage (fail-closed) or a total schema collapse (nobody produced a valid object)
+  const regressed = anyLeak || (schemaInvalid + abstained) === results.length;
+
+  return {
+    primary: accuracy,
+    noopRate,
+    costPerWin: costPerCorrect,
+    regressed,
+    accuracy,
+    costPerCorrect,
+    calibrationError: calErr,
+    schemaErrorRate: schemaInvalid / n,
+    abstentionRate: abstained / n,
+    perDocTypeAccuracy,
+    n: results.length,
+    correct,
+  };
+}
+
+function calibrationErrorOf(committed: Array<{ confidence: number; correct: boolean }>, bins = 10): number {
+  if (committed.length === 0) return 0;
+  const buckets = Array.from({ length: bins }, () => ({ conf: 0, acc: 0, n: 0 }));
+  for (const c of committed) {
+    const i = Math.min(bins - 1, Math.floor(Math.min(1, Math.max(0, c.confidence)) * bins));
+    buckets[i].conf += c.confidence; buckets[i].acc += c.correct ? 1 : 0; buckets[i].n += 1;
+  }
+  let ece = 0;
+  for (const b of buckets) if (b.n) ece += (b.n / committed.length) * Math.abs(b.conf / b.n - b.acc / b.n);
+  return ece;
+}

--- a/packages/evals-extract/src/verifier.ts
+++ b/packages/evals-extract/src/verifier.ts
@@ -1,0 +1,100 @@
+// @metaharness/evals-extract — the DOC-TYPE-SPECIFIC VERIFIER STACK.
+//
+// The verifier returns an AGREEMENT signal used by routing (escalate on disagreement) + calibration. It is
+// deliberately NOT a generic "critic says yes" model — ADR-226 measured that read-only strong advice added
+// ZERO marginal resolves at 5.4x cost. The useful lever is EXECUTOR policy + real checks: json-schema
+// validation, per-field type checks, required-field presence, cross-field consistency — all deterministic,
+// cheap, and doc-type-appropriate. Each check returns [0,1] agreement; the mode selects which check(s) run.
+import type { DocType, VerificationMode } from './genome.js';
+import { validateSchema, typeMatches, canonicalJson, type JsonSchema } from './normalizer.js';
+
+export interface VerifyInput {
+  docType: DocType;
+  schema: JsonSchema;
+  /** The normalized candidate extraction. */
+  value: Record<string, unknown> | null;
+  /** Additional sampled extractions (for multi-solver / self-consistency agreement). */
+  samples?: (Record<string, unknown> | null)[];
+}
+
+export interface VerifyResult {
+  /** [0,1] — how much the verifier stack agrees the extraction is sound. */
+  agreement: number;
+  /** True when the stack actively disagrees (agreement below a floor) → a routing escalation trigger. */
+  disagrees: boolean;
+  checksRun: string[];
+}
+
+/** Injectable domain verifier for the live run (e.g. a business-rule checker). The default is a structural
+ *  approximation so the adapter runs at $0 for replay; a real check is strictly better. */
+export type DomainChecker = (docType: DocType, value: Record<string, unknown>) => number | undefined;
+
+export function makeVerifier(opts: { domain?: DomainChecker } = {}) {
+  return function verify(mode: VerificationMode, input: VerifyInput): VerifyResult {
+    if (mode === 'none' || input.value === null) {
+      return { agreement: input.value === null ? 0 : 0.5, disagrees: input.value === null, checksRun: [] };
+    }
+    const checks: string[] = [];
+    const scores: number[] = [];
+
+    if (mode === 'jsonSchemaValidate') {
+      scores.push(validateSchema(input.value, input.schema, 'strict') ? 1 : 0.1);
+      checks.push('jsonSchemaValidate');
+    }
+    if (mode === 'typeCheck') {
+      scores.push(typeAgreement(input.value, input.schema));
+      checks.push('typeCheck');
+    }
+    if (mode === 'requiredFields') {
+      scores.push(requiredCoverage(input.value, input.schema));
+      checks.push('requiredFields');
+    }
+    if (mode === 'crossFieldConsistency') {
+      scores.push(selfConsistency(input.value, input.samples ?? []));
+      scores.push(opts.domain?.(input.docType, input.value) ?? crossFieldPlausibility(input.docType, input.value));
+      checks.push(opts.domain ? 'crossField:domain' : 'crossField~structural');
+    }
+    const agreement = scores.length ? scores.reduce((a, b) => a + b, 0) / scores.length : 0.5;
+    return { agreement, disagrees: agreement < 0.34, checksRun: checks };
+  };
+}
+
+/** Fraction of declared fields whose value type matches the schema. */
+function typeAgreement(value: Record<string, unknown>, schema: JsonSchema): number {
+  const keys = Object.keys(schema.properties);
+  if (keys.length === 0) return 0.5;
+  let ok = 0;
+  for (const k of keys) if (k in value && typeMatches(value[k], schema.properties[k].type)) ok++;
+  return ok / keys.length;
+}
+
+/** Fraction of REQUIRED fields present + non-empty. */
+function requiredCoverage(value: Record<string, unknown>, schema: JsonSchema): number {
+  if (schema.required.length === 0) return 1;
+  let ok = 0;
+  for (const r of schema.required) {
+    const v = value[r];
+    if (v !== undefined && v !== null && v !== '') ok++;
+  }
+  return ok / schema.required.length;
+}
+
+/** Fraction of samples canonically matching the chosen extraction — the multi-solver agreement. */
+function selfConsistency(value: Record<string, unknown>, samples: (Record<string, unknown> | null)[]): number {
+  const target = canonicalJson(value);
+  const all = [target, ...samples.map(canonicalJson).filter((s): s is string => s !== null)];
+  if (all.length <= 1) return 0.5;
+  return all.filter((s) => s === target).length / all.length;
+}
+
+/** Cheap cross-field sanity floor — not a truth check, a shape check (non-degenerate, plausibly consistent). */
+function crossFieldPlausibility(docType: DocType, value: Record<string, unknown>): number {
+  const keys = Object.keys(value);
+  if (keys.length === 0) return 0;
+  // invoices/receipts: a numeric total should be non-negative when present
+  if (docType === 'invoice' || docType === 'receipt') {
+    const total = value.total ?? value.amount ?? value.subtotal;
+    if (typeof total === 'number' && total < 0) return 0.2;
+  }
+  return 0.5;
+}

--- a/packages/evals-extract/tsconfig.json
+++ b/packages/evals-extract/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}

--- a/scripts/build-ordered.mjs
+++ b/scripts/build-ordered.mjs
@@ -25,9 +25,10 @@ const PHASES = [
   // create-agent-harness imports its /cli — so it MUST build here in phase 1.
   ['kernel-js', 'router', 'harness', 'darwin-mode', 'projects', 'redblue', 'weight-eft', 'jujutsu', 'flywheel'],
   // Phase 2: vertical-base — vertical-trading imports from it. evals-hle
-  // (@metaharness/evals-hle) depends on @metaharness/flywheel's dist, so it must
-  // build AFTER phase 1 (a same-phase parallel build would race the .d.ts).
-  ['vertical-base', 'evals-hle'],
+  // (@metaharness/evals-hle) and evals-extract (@metaharness/evals-extract) each
+  // depend on @metaharness/flywheel's dist, so they must build AFTER phase 1 (a
+  // same-phase parallel build would race the .d.ts).
+  ['vertical-base', 'evals-hle', 'evals-extract'],
   // Phase 3: hosts + sdk + cli — all depend on kernel-js
   [
     'host-claude-code',

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -82,6 +82,9 @@ const CHECKS = {
       // @metaharness/evals-hle (HLE benchmark adapter for the flywheel, ADR-233) is a
       // standalone published adapter on its own semver — not core, not umbrella-bundled.
       '@metaharness/evals-hle',
+      // @metaharness/evals-extract (structured-extraction benchmark adapter for the
+      // flywheel) is likewise a standalone published adapter on its own semver.
+      '@metaharness/evals-extract',
       '@metaharness/kernel',
       '@metaharness/host-claude-code',
       '@metaharness/host-codex',


### PR DESCRIPTION
## @metaharness/evals-extract — a new flywheel domain adapter

Structured JSON extraction — schema-adherence + format normalization + json-schema-validate. Mirrors the shipped `evals-hle` template (genome + classifier + normalizer + verifier + calibration + routing + leakage + score + composite gate + $0 synthetic test). Part of scaling the flywheel's multi-vertical generality proof (SWE-bench + HLE + math + toolcall + sql + extract).

**Adversarially verified** (independent agent re-ran everything):
- **Frozen core untouched** — 0 files changed under `packages/flywheel/`.
- **`meetsPromotionRule` called verbatim** — `gate.ts` imports it from `@metaharness/flywheel` and `const base = meetsPromotionRule(evidence)`; the composite only **ANDs stricter domain clauses** (a strict superset, fingerprint differs from the frozen default). Never weakened.
- **Tests pass; real compounding** — `npm test` green; instrumented run shows lift compounding, ≥2 promotions, `anchor_surviving≥2`, `milestone_reached=true`, `verifyReplayBundle.pass=true`.
- **Honest** — `dataSource: 'SYNTHETIC'`; the live-data loader **throws** rather than substituting synthetic data; no fabricated real benchmark scores.

Note: all 4 sibling adapter PRs touch `scripts/build-ordered.mjs` + `scripts/healthcheck.mjs` (each registers its own package) — they merge sequentially with a trivial rebase.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)