### PR TITLE
feat(flywheel): verifyReplayBundle re-executes the gate on sealed scores (ADR-235 forward plan)

### DIFF
--- a/packages/flywheel/__tests__/units.test.ts
+++ b/packages/flywheel/__tests__/units.test.ts
@@ -86,3 +86,47 @@ describe('verifyReplayBundle — an HONEST-NULL run (0 promotions) is VALID (reg
     expect(verifyReplayBundle(bad).checks.allPromoted).toBe(false);
   });
 });
+
+describe('verifyReplayBundle — gateReExecutes: re-run the rule on sealed scores (ADR-235)', () => {
+  const signer = makeSigner();
+  const S2 = (o: Partial<Score> = {}): Score => ({ primary: 5, noopRate: 0.3, costPerWin: 1, regressed: false, ...o });
+  const root: LineageCommit = {
+    id: 'root', generation: 0, parents: [], mutation: null, primaryDelta: 0, anchorScore: null,
+    verdict: 'ROOT', failureReasons: [], receipt: signer.sign({ kind: 'root', root: 'root' }), createdAt: 'g0',
+  };
+  const promoted = (baselineScore: Score, candidateScore: Score): LineageCommit => ({
+    id: 'c1', generation: 1, parents: ['root'], mutation: { target: 't', summary: 'adapt t' }, primaryDelta: 1,
+    anchorScore: null, verdict: 'PROMOTED', failureReasons: [], receipt: signer.sign({ kind: 'candidate', id: 'c1' }),
+    createdAt: 'g1', baselineScore, candidateScore,
+  });
+  const bundleOf = (c1: LineageCommit): ReplayBundle => ({
+    data_source: 'SYNTHETIC', root_id: 'root', chain: [c1, root], all_commits: [c1],
+    lift_curve: [], gate_fingerprint: gateFingerprint(meetsPromotionRule),
+    verified_improvements: 1, anchor_surviving_improvements: 1, milestone_reached: false, created_at: 'g1',
+  });
+
+  it('a PROMOTED commit whose sealed scores RE-PASS the rule → gateReExecutes true, pass', () => {
+    const b = bundleOf(promoted(S2(), S2({ primary: 6, noopRate: 0.2 })));
+    const v = verifyReplayBundle(b, { pinnedGateFingerprint: gateFingerprint(meetsPromotionRule), promotionRule: meetsPromotionRule });
+    expect(v.checks.gateReExecutes).toBe(true);
+    expect(v.pass).toBe(true);
+  });
+
+  it('a FORGED promotion (verdict PROMOTED but scores the rule would REJECT) → gateReExecutes false', () => {
+    const b = bundleOf(promoted(S2(), S2({ primary: 4, noopRate: 0.2 }))); // primary regressed → rule.promote=false
+    const v = verifyReplayBundle(b, { promotionRule: meetsPromotionRule });
+    expect(v.checks.gateReExecutes).toBe(false);
+    expect(v.pass).toBe(false);
+  });
+
+  it('a WRONG (fingerprint-mismatched) rule → gateReExecutes false', () => {
+    const b = bundleOf(promoted(S2(), S2({ primary: 6, noopRate: 0.2 })));
+    const otherRule = () => ({ promote: true, reasons: [] as string[] }); // different source ⇒ different fingerprint
+    expect(verifyReplayBundle(b, { promotionRule: otherRule }).checks.gateReExecutes).toBe(false);
+  });
+
+  it('backward-compatible: NO rule supplied ⇒ gateReExecutes unchecked (true)', () => {
+    const b = bundleOf(promoted(S2(), S2({ primary: 6, noopRate: 0.2 })));
+    expect(verifyReplayBundle(b, { pinnedGateFingerprint: gateFingerprint(meetsPromotionRule) }).checks.gateReExecutes).toBe(true);
+  });
+});

--- a/packages/flywheel/package.json
+++ b/packages/flywheel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/flywheel",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "A verifiable self-improvement loop for agent harnesses. Freeze the model. Evolve the harness. Promote only what proves lift.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/flywheel/src/replay.ts
+++ b/packages/flywheel/src/replay.ts
@@ -1,11 +1,16 @@
 // @metaharness/flywheel — independent replay. Given ONLY a ReplayBundle (and, optionally, the pinned
-// gate fingerprint), an external reviewer establishes the run with no trust in the producer:
+// gate fingerprint + the gate rule itself), an external reviewer establishes the run with no trust in the
+// producer:
 //   (1) every promotion receipt verifies (Ed25519, recompute canon vs the embedded key);
 //   (2) the promoted lineage reconstructs current → gen-0 immutable root, contiguously;
 //   (3) every commit on the promoted chain is actually PROMOTED (no rejected node smuggled in);
-//   (4) the gate fingerprint matches the pinned value ⇒ the promotion rule was UNCHANGED.
+//   (4) the gate fingerprint matches the pinned value ⇒ the promotion rule was UNCHANGED;
+//   (5) [ADR-235] if the reviewer supplies the (fingerprint-matched) rule, every PROMOTED commit is
+//       RE-GATED on its sealed baseline+candidate scores and must STILL promote — trust the gate re-run,
+//       not the logged verdict. Catches a signed-but-forged promotion the fingerprint check cannot.
 import { verifyReceipt } from './receipts.js';
-import type { ReplayBundle } from './types.js';
+import { gateFingerprint } from './gate.js';
+import type { ReplayBundle, PromotionRule, LineageCommit } from './types.js';
 
 export interface ReplayVerdict {
   pass: boolean;
@@ -15,12 +20,16 @@ export interface ReplayVerdict {
     contiguousParents: boolean;
     allPromoted: boolean;
     gateUnchanged: boolean;
+    gateReExecutes: boolean;
   };
   failures: string[];
   chainSummary: string;
 }
 
-export function verifyReplayBundle(bundle: ReplayBundle, opts: { pinnedGateFingerprint?: string } = {}): ReplayVerdict {
+export function verifyReplayBundle(
+  bundle: ReplayBundle,
+  opts: { pinnedGateFingerprint?: string; promotionRule?: PromotionRule } = {},
+): ReplayVerdict {
   const failures: string[] = [];
   const chain = bundle.chain;
 
@@ -49,9 +58,36 @@ export function verifyReplayBundle(bundle: ReplayBundle, opts: { pinnedGateFinge
   const gateUnchanged = opts.pinnedGateFingerprint ? bundle.gate_fingerprint === opts.pinnedGateFingerprint : true;
   if (!gateUnchanged) failures.push('gateUnchanged');
 
+  // (5) RE-EXECUTE the gate. Only when the reviewer supplies the rule (otherwise unchecked → true, so
+  // existing fingerprint-only callers are unaffected). The supplied rule must be the SAME one (its
+  // fingerprint must match the pinned/bundled value) or re-execution is meaningless. Then every PROMOTED
+  // commit that carries its sealed scores must RE-PASS the rule — a logged promotion the frozen gate would
+  // NOT grant is a forgery.
+  let gateReExecutes = true;
+  if (opts.promotionRule) {
+    const suppliedFp = gateFingerprint(opts.promotionRule);
+    const expectedFp = opts.pinnedGateFingerprint ?? bundle.gate_fingerprint ?? undefined;
+    if (expectedFp && suppliedFp !== expectedFp) {
+      gateReExecutes = false; // wrong rule supplied — cannot re-execute the run's gate
+    } else {
+      const seen = new Set<string>();
+      for (const c of [...chain, ...bundle.all_commits] as LineageCommit[]) {
+        if (seen.has(c.id)) continue;
+        seen.add(c.id);
+        if (c.verdict === 'PROMOTED' && c.baselineScore && c.candidateScore) {
+          if (!opts.promotionRule({ baseline: c.baselineScore, candidate: c.candidateScore }).promote) {
+            gateReExecutes = false;
+            break;
+          }
+        }
+      }
+    }
+  }
+  if (!gateReExecutes) failures.push('gateReExecutes');
+
   return {
     pass: failures.length === 0,
-    checks: { receipts, reachesRoot, contiguousParents, allPromoted, gateUnchanged },
+    checks: { receipts, reachesRoot, contiguousParents, allPromoted, gateUnchanged, gateReExecutes },
     failures,
     chainSummary: chain.map((c) => `gen${c.generation}${c.mutation ? `(${c.mutation.target})` : '(root)'}`).join(' → '),
   };

--- a/packages/flywheel/src/run.ts
+++ b/packages/flywheel/src/run.ts
@@ -105,6 +105,8 @@ export async function runFlywheelGenerations(cfg: FlywheelConfig): Promise<Flywh
         failureReasons: isWinner ? [] : c === winner && !anchorSurvives ? ['anchor_regressed'] : c.reasons,
         receipt: cfg.signer.sign({ kind: 'candidate', id, target: c.target, verdict: isWinner ? 'PROMOTED' : 'REJECTED', primaryDelta }),
         createdAt: now(gen),
+        baselineScore: score,       // ADR-235 — sealed so the gate can be re-run in replay
+        candidateScore: c.score,
       };
       await store.append(commit);
       allCommits.push(commit);

--- a/packages/flywheel/src/types.ts
+++ b/packages/flywheel/src/types.ts
@@ -101,6 +101,11 @@ export interface LineageCommit {
   failureReasons: string[];
   receipt: PromotionReceipt;
   createdAt: string;
+  /** ADR-235 — the sealed baseline+candidate Score this commit's verdict was decided from. Lets an
+   *  external reviewer RE-RUN the promotion rule and confirm the verdict reproduces (trust the gate
+   *  re-run, not the logged verdict). Absent on the gen-0 root (nothing was compared). */
+  baselineScore?: Score;
+  candidateScore?: Score;
 }
 
 export interface LineageStore {


### PR DESCRIPTION
## Summary

Completes **ADR-235 §2**: `verifyReplayBundle` can now **re-run the promotion rule on each commit's sealed scores** and confirm the verdict reproduces — *trust the gate re-run, not the logged verdict* (the PR #64 "trust no logs" discipline, applied to promotion decisions).

- **`LineageCommit`** gains optional `baselineScore`/`candidateScore` (additive; absent on the gen-0 root). `run.ts` seals both on every candidate commit.
- **`verifyReplayBundle(bundle, { promotionRule? })`** — when the reviewer supplies the **same** rule (its `gateFingerprint` must match the pinned/bundled value), every **PROMOTED** commit is **re-gated on its sealed scores and must still promote**. A logged promotion the frozen gate would *not* grant is a forgery → `gateReExecutes: false`. This catches a **signed-but-wrong promotion** that the fingerprint check alone cannot.
- **Backward-compatible**: no rule supplied ⇒ `gateReExecutes` unchecked (`true`), so existing fingerprint-only callers (e.g. the SWE-bench runner) are unaffected.

4 new tests (re-pass→true, **forged promotion→false**, wrong-rule→false, no-rule→true); flywheel suite **19/19**; healthcheck 8/8. `@metaharness/flywheel` **0.1.3**. **`meetsPromotionRule` UNCHANGED.**

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)