### PR TITLE
feat(flywheel): 'analyze' CLI — F-P2 mutation-effectiveness from a bundle

### DIFF
--- a/packages/flywheel/__tests__/units.test.ts
+++ b/packages/flywheel/__tests__/units.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
   meetsPromotionRule, gateFingerprint, makeSigner, verifyReceipt, canon,
   InMemoryLineageStore, computeLiftCurve, verifyReplayBundle,
+  analyzeBundle, formatAnalysis,
   type Score, type LineageCommit, type PromotionReceipt, type ReplayBundle,
 } from '../src/index.js';
 
@@ -128,5 +129,38 @@ describe('verifyReplayBundle — gateReExecutes: re-run the rule on sealed score
   it('backward-compatible: NO rule supplied ⇒ gateReExecutes unchecked (true)', () => {
     const b = bundleOf(promoted(S2(), S2({ primary: 6, noopRate: 0.2 })));
     expect(verifyReplayBundle(b, { pinnedGateFingerprint: gateFingerprint(meetsPromotionRule) }).checks.gateReExecutes).toBe(true);
+  });
+});
+
+describe('analyzeBundle — F-P2 mutation-effectiveness', () => {
+  const mk = (target: string, gen: number, verdict: 'PROMOTED' | 'REJECTED', primaryDelta: number, failureReasons: string[] = []): LineageCommit =>
+    ({ id: `${target}-${gen}`, generation: gen, parents: [], mutation: { target, summary: '' }, primaryDelta, anchorScore: null, verdict, failureReasons } as LineageCommit);
+  const bundle = (all: LineageCommit[]): ReplayBundle =>
+    ({ data_source: 'SYNTHETIC', root_id: 'root', chain: [], all_commits: all, lift_curve: [], gate_fingerprint: null, verified_improvements: 0, anchor_surviving_improvements: 0, milestone_reached: false, created_at: 'x' } as ReplayBundle);
+
+  it('ranks the most-promoted lever first + computes per-lever rate, avg lift, anchor-regressions', () => {
+    const a = analyzeBundle(bundle([
+      mk('edit', 1, 'PROMOTED', 2), mk('edit', 2, 'PROMOTED', 3),           // edit: 2/2 promoted, avgΔ 2.5
+      mk('escalate', 1, 'REJECTED', 0), mk('escalate', 2, 'REJECTED', -1, ['anchor_regressed']),
+      mk('verify', 3, 'PROMOTED', 1),                                        // verify: 1/1 promoted
+    ]));
+    expect(a.candidates).toBe(5);
+    expect(a.promotions).toBe(3);
+    expect(a.rejections).toBe(2);
+    expect(a.anchorRegressed).toBe(1);
+    expect(a.byTarget[0]!.target).toBe('edit');            // most promotions ranks first
+    expect(a.byTarget[0]!.promoteRate).toBe(1);
+    expect(a.byTarget[0]!.avgDeltaPromoted).toBeCloseTo(2.5);
+    const escalate = a.byTarget.find((t) => t.target === 'escalate')!;
+    expect(escalate.promotions).toBe(0);
+    expect(escalate.rejections).toBe(2);
+  });
+
+  it('an honest-null (no candidates) analyzes cleanly + formats without throwing', () => {
+    const a = analyzeBundle(bundle([]));
+    expect(a.candidates).toBe(0);
+    expect(a.byTarget).toEqual([]);
+    const lines = formatAnalysis(a, 'null-run');
+    expect(lines.join('\n')).toContain('honest-null');
   });
 });

--- a/packages/flywheel/src/analyze.ts
+++ b/packages/flywheel/src/analyze.ts
@@ -1,0 +1,91 @@
+// @metaharness/flywheel — F-P2 mutation-effectiveness analysis. Given a ReplayBundle's FULL candidate
+// ledger (`all_commits` — every promoted AND rejected candidate across all generations), report which
+// policy LEVERS actually earn promotions and how much lift each produces. This is the empirical answer to
+// "which `mutationTargets` are worth spending on" — it turns a run's diagnostic ledger into guidance for
+// the next run's `--targets`. Pure + read-only: it interprets a bundle, it never re-runs or re-gates.
+import type { ReplayBundle, LineageCommit } from './types.js';
+
+/** Per-lever effectiveness over a run. */
+export interface TargetStat {
+  target: string;
+  attempts: number;
+  promotions: number;
+  rejections: number;
+  /** promotions / attempts. */
+  promoteRate: number;
+  /** mean primaryDelta over this lever's PROMOTED candidates (0 if none promoted). */
+  avgDeltaPromoted: number;
+  /** mean primaryDelta over ALL of this lever's candidates (promoted + rejected). */
+  avgDeltaAll: number;
+  /** the single best primaryDelta this lever produced. */
+  bestDelta: number;
+}
+
+export interface BundleAnalysis {
+  generations: number;
+  candidates: number;
+  promotions: number;
+  rejections: number;
+  /** rejections specifically caused by regressing the frozen anchor (Goodhart guard fired). */
+  anchorRegressed: number;
+  /** per-lever stats, ranked most-effective first (promotions, then avg promoted lift, then avg lift). */
+  byTarget: TargetStat[];
+}
+
+const mean = (xs: number[]): number => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+
+/** Compute the mutation-effectiveness report from a bundle's candidate ledger. */
+export function analyzeBundle(bundle: ReplayBundle): BundleAnalysis {
+  const commits: LineageCommit[] = (bundle.all_commits ?? []).filter((c) => c.verdict !== 'ROOT');
+  const groups = new Map<string, LineageCommit[]>();
+  for (const c of commits) {
+    const t = c.mutation?.target ?? '(none)';
+    (groups.get(t) ?? groups.set(t, []).get(t)!).push(c);
+  }
+
+  const byTarget: TargetStat[] = [...groups.entries()].map(([target, cs]) => {
+    const promoted = cs.filter((c) => c.verdict === 'PROMOTED');
+    const rejected = cs.filter((c) => c.verdict === 'REJECTED');
+    return {
+      target,
+      attempts: cs.length,
+      promotions: promoted.length,
+      rejections: rejected.length,
+      promoteRate: cs.length ? promoted.length / cs.length : 0,
+      avgDeltaPromoted: mean(promoted.map((c) => c.primaryDelta)),
+      avgDeltaAll: mean(cs.map((c) => c.primaryDelta)),
+      bestDelta: cs.length ? Math.max(...cs.map((c) => c.primaryDelta)) : 0,
+    };
+  });
+
+  // Rank: most promotions first, then biggest average promoted lift, then biggest average lift overall.
+  byTarget.sort((a, b) => b.promotions - a.promotions || b.avgDeltaPromoted - a.avgDeltaPromoted || b.avgDeltaAll - a.avgDeltaAll);
+
+  return {
+    generations: new Set(commits.map((c) => c.generation)).size,
+    candidates: commits.length,
+    promotions: commits.filter((c) => c.verdict === 'PROMOTED').length,
+    rejections: commits.filter((c) => c.verdict === 'REJECTED').length,
+    anchorRegressed: commits.filter((c) => (c.failureReasons ?? []).includes('anchor_regressed')).length,
+    byTarget,
+  };
+}
+
+/** Human-readable lines for the `analyze` CLI verb. */
+export function formatAnalysis(a: BundleAnalysis, label: string): string[] {
+  const lines = [
+    `Mutation-effectiveness — ${label}`,
+    `  generations=${a.generations}  candidates=${a.candidates}  promotions=${a.promotions}  rejections=${a.rejections}  anchor-regressed=${a.anchorRegressed}`,
+    '',
+    `  ${'lever'.padEnd(22)} ${'att'.padStart(4)} ${'prom'.padStart(5)} ${'rate'.padStart(6)} ${'avgΔ(prom)'.padStart(11)} ${'avgΔ(all)'.padStart(10)} ${'best'.padStart(6)}`,
+  ];
+  if (!a.byTarget.length) { lines.push('  (no candidates in this bundle — an honest-null / root-only run)'); return lines; }
+  for (const t of a.byTarget) {
+    lines.push(
+      `  ${t.target.padEnd(22)} ${String(t.attempts).padStart(4)} ${String(t.promotions).padStart(5)} ${(t.promoteRate * 100).toFixed(0).padStart(5)}% ` +
+      `${t.avgDeltaPromoted.toFixed(2).padStart(11)} ${t.avgDeltaAll.toFixed(2).padStart(10)} ${t.bestDelta.toFixed(0).padStart(6)}`,
+    );
+  }
+  lines.push('', `  → most effective lever: ${a.byTarget[0]!.promotions > 0 ? a.byTarget[0]!.target : '(none promoted — widen the proposer or targets)'}`);
+  return lines;
+}

--- a/packages/flywheel/src/cli.ts
+++ b/packages/flywheel/src/cli.ts
@@ -9,6 +9,7 @@ import { pathToFileURL } from 'node:url';
 import { runFlywheelGenerations, type FlywheelConfig } from './run.js';
 import { verifyReplayBundle } from './replay.js';
 import { makeSigner } from './receipts.js';
+import { analyzeBundle, formatAnalysis } from './analyze.js';
 import type { ReplayBundle } from './types.js';
 
 export interface CliResult {
@@ -25,6 +26,8 @@ const USAGE = [
   '      Independently verify a bundle: receipts + lineage-to-root + (optional) frozen-gate fingerprint.',
   '  metaharness flywheel graph <proof-bundle.json>',
   '      Print the promoted lineage chain and the compounding lift curve.',
+  '  metaharness flywheel analyze <proof-bundle.json>',
+  '      F-P2 mutation-effectiveness: which policy levers earn promotions and how much lift each produces.',
 ];
 
 function loadBundle(path?: string): ReplayBundle {
@@ -52,6 +55,11 @@ async function replay(args: string[]): Promise<CliResult> {
     `ACCEPTANCE: ${v.pass ? 'PASS' : 'FAIL (' + v.failures.join(', ') + ')'}`,
   ];
   return { code: v.pass ? 0 : 1, lines };
+}
+
+function analyze(args: string[]): CliResult {
+  const bundle = loadBundle(args[0]);
+  return { code: 0, lines: formatAnalysis(analyzeBundle(bundle), `${args[0]}  [data_source=${bundle.data_source}]`) };
 }
 
 function graph(args: string[]): CliResult {
@@ -89,6 +97,7 @@ export async function dispatch(sub: string | undefined, args: string[]): Promise
   switch (sub) {
     case 'replay': return replay(args);
     case 'graph': return graph(args);
+    case 'analyze': return analyze(args);
     case 'run': return run(args);
     case undefined:
     case 'help':

--- a/packages/flywheel/src/index.ts
+++ b/packages/flywheel/src/index.ts
@@ -12,6 +12,8 @@ export { makeSigner, verifyReceipt, canon } from './receipts.js';
 export { InMemoryLineageStore, computeLiftCurve, liftPoint } from './lineage.js';
 export { verifyReplayBundle } from './replay.js';
 export type { ReplayVerdict } from './replay.js';
+export { analyzeBundle, formatAnalysis } from './analyze.js';
+export type { BundleAnalysis, TargetStat } from './analyze.js';
 
 export type {
   Policy,


### PR DESCRIPTION
## What
Adds `metaharness flywheel analyze <proof-bundle.json>` — the F-P2 mutation-effectiveness view the CLI was missing (it had run|replay|graph). From a bundle's full candidate ledger (`all_commits`) it reports, per policy lever: attempts, promotions, promote-rate, avg lift (promoted + overall), best delta — ranked most-effective first — plus run totals and anchor-regression count.

## Why
Answers 'which `mutationTargets` are worth spending on?' — turning a run's diagnostic ledger into guidance for the next run's `--targets`. Pure + read-only (interprets a bundle; never re-runs or re-gates).

## Verify
- Smoke-tested on the **real D1 honest-null bundle**: 4 candidates, 0 promotions, `editPolicy` avgΔ −1.00 / `escalationPolicy` avgΔ −0.50 → "none promoted — widen the proposer or targets" (matches the D1-S5 diagnosis).
- flywheel **23/23** (+2 unit tests: ranking + per-lever stats; honest-null analyzes/formats cleanly). No engine change; `meetsPromotionRule` untouched. Independent of #103 (touches only cli/analyze/index).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)