### PR TITLE
fix(swebench): durable harness venv path + loud missing-venv guard

### DIFF
--- a/packages/darwin-mode/bench/swebench/swebench-grade-venv.test.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-grade-venv.test.mjs
@@ -1,0 +1,18 @@
+// $0 node:test — the grader's harness-venv guard. The swebench venv is the ONLY gold-scorer; a missing
+// venv (e.g. the ephemeral /tmp one wiped on reboot) must fail LOUDLY with setup instructions, never be
+// mistaken for "0 resolved". Verifies the pre-flight throw (no Docker / no harness invoked).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { makeSwebenchGrader } from './swebench-grade.mjs';
+
+test('makeSwebenchGrader throws an actionable error when the harness venv is missing', () => {
+  assert.throws(
+    () => makeSwebenchGrader({ venvPython: '/definitely/not/a/venv/bin/python' }),
+    (e) => /swebench harness venv not found/.test(e.message) && /pip install swebench/.test(e.message),
+  );
+});
+
+test('makeSwebenchGrader constructs when the venv python exists (uses this interpreter as a stand-in)', () => {
+  const g = makeSwebenchGrader({ venvPython: process.execPath }); // node exists → passes the existence guard
+  assert.strictEqual(typeof g, 'function');
+});

--- a/packages/darwin-mode/bench/swebench/swebench-grade.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-grade.mjs
@@ -4,12 +4,18 @@
 // ONLY thing that gold-scores SWE-bench — the flywheel/adapter never re-implements it. Heavy (Docker +
 // minutes/instance); used only for the budgeted live run.
 import { mkdtempSync, writeFileSync, readFileSync, readdirSync, existsSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { tmpdir, homedir } from 'node:os';
 import { join } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
+// The venv holding the official `swebench` harness. DURABLE by default: `/tmp` is wiped on reboot, which
+// silently deleted the harness between sessions (a run then can't gold-score). Default to a persistent
+// path under $HOME; override with SWEBENCH_VENV_PYTHON. One-time setup:
+//   python3 -m venv ~/.cache/swebench-venv && ~/.cache/swebench-venv/bin/pip install swebench
+const DEFAULT_VENV_PYTHON = process.env.SWEBENCH_VENV_PYTHON || join(homedir(), '.cache', 'swebench-venv', 'bin', 'python');
+
 export function makeSwebenchGrader({
-  venvPython = '/tmp/swebench-venv/bin/python',
+  venvPython = DEFAULT_VENV_PYTHON,
   // The frozen holdout/anchor (from full-300.json) are SWE-bench_LITE instance IDs — verified 40/40 ∩ Lite
   // vs only 11/40 ∩ Verified. The grader MUST pass the dataset that actually contains the IDs, or
   // run_evaluation aborts with "Some prediction IDs not found in dataset!" (the D1-S4 smoke's exact failure).
@@ -20,6 +26,16 @@ export function makeSwebenchGrader({
   timeoutPerInstance = 1800,
 } = {}) {
   let n = 0;
+  // Fail LOUDLY + actionably if the harness venv is missing, rather than a cryptic spawn ENOENT mid-run
+  // (this is the ONLY gold-scorer — a missing venv must never be mistaken for "0 resolved").
+  if (!existsSync(venvPython)) {
+    throw new Error(
+      `swebench harness venv not found at ${venvPython}. It is the official gold-scorer and cannot be skipped.\n` +
+      `Set it up once (durable, survives reboot):\n` +
+      `  python3 -m venv ${join(homedir(), '.cache', 'swebench-venv')} && ${join(homedir(), '.cache', 'swebench-venv', 'bin', 'pip')} install swebench\n` +
+      `Or point SWEBENCH_VENV_PYTHON at an existing venv's python.`,
+    );
+  }
   return async function gradePredictions(predictions) {
     const work = mkdtempSync(join(tmpdir(), 'fw-grade-'));
     const runId = `${runIdPrefix}-${n++}`;


### PR DESCRIPTION
## What
The grader defaulted the swebench gold-scorer venv to `/tmp/swebench-venv`, but `/tmp` is wiped on reboot — so the official harness silently vanished between sessions (`import swebench` → ModuleNotFoundError) and a D1 run couldn't gold-score.

- Default `venvPython` → `$HOME/.cache/swebench-venv/bin/python` (durable), overridable via `SWEBENCH_VENV_PYTHON`. One-time setup documented inline.
- `makeSwebenchGrader` now throws a **loud, actionable** error (with the exact setup command) when the venv is missing, instead of a cryptic spawn ENOENT mid-run. This is the ONLY gold-scorer — a missing venv must never look like '0 resolved'.

## Verify
- Recreated the durable venv + `pip install swebench` (**4.1.0**), `import swebench` OK; grader `node --check` clean.
- Tests **2/2** ($0): missing venv → throws with setup instructions; present venv → constructs.
- No gold-scoring performed here; nothing fabricated.

Unblocks the D1 gold-scorer durably (part of the pre-flight for the budget-gated flagship run).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)