### PR TITLE
feat(flywheel): analyze reports cost-per-win economics (0.1.6)

### DIFF
--- a/packages/flywheel/__tests__/units.test.ts
+++ b/packages/flywheel/__tests__/units.test.ts
@@ -133,8 +133,8 @@ describe('verifyReplayBundle — gateReExecutes: re-run the rule on sealed score
 });
 
 describe('analyzeBundle — F-P2 mutation-effectiveness', () => {
-  const mk = (target: string, gen: number, verdict: 'PROMOTED' | 'REJECTED', primaryDelta: number, failureReasons: string[] = []): LineageCommit =>
-    ({ id: `${target}-${gen}`, generation: gen, parents: [], mutation: { target, summary: '' }, primaryDelta, anchorScore: null, verdict, failureReasons } as LineageCommit);
+  const mk = (target: string, gen: number, verdict: 'PROMOTED' | 'REJECTED', primaryDelta: number, failureReasons: string[] = [], costPerWin = 1): LineageCommit =>
+    ({ id: `${target}-${gen}`, generation: gen, parents: [], mutation: { target, summary: '' }, primaryDelta, anchorScore: null, verdict, failureReasons, candidateScore: { primary: 0, noopRate: 0, costPerWin, regressed: false } } as LineageCommit);
   const bundle = (all: LineageCommit[]): ReplayBundle =>
     ({ data_source: 'SYNTHETIC', root_id: 'root', chain: [], all_commits: all, lift_curve: [], gate_fingerprint: null, verified_improvements: 0, anchor_surviving_improvements: 0, milestone_reached: false, created_at: 'x' } as ReplayBundle);
 
@@ -151,9 +151,20 @@ describe('analyzeBundle — F-P2 mutation-effectiveness', () => {
     expect(a.byTarget[0]!.target).toBe('edit');            // most promotions ranks first
     expect(a.byTarget[0]!.promoteRate).toBe(1);
     expect(a.byTarget[0]!.avgDeltaPromoted).toBeCloseTo(2.5);
+    expect(a.byTarget[0]!.avgCostPerWinPromoted).toBeCloseTo(1); // edit's promoted candidates each cost 1/win
+    expect(a.byTarget[0]!.bestCostPerWin).toBe(1);
     const escalate = a.byTarget.find((t) => t.target === 'escalate')!;
     expect(escalate.promotions).toBe(0);
     expect(escalate.rejections).toBe(2);
+  });
+
+  it('cost-per-win trajectory follows the promoted chain root→current + flags the direction', () => {
+    // chain is stored current→root; wins get cheaper toward the root's original 3 → 2 → 1
+    const chain = [mk('t', 2, 'PROMOTED', 1, [], 1), mk('t', 1, 'PROMOTED', 1, [], 2), mk('root', 0, 'PROMOTED', 0, [], 3)];
+    const b = { ...bundle([]), chain };
+    const a = analyzeBundle(b);
+    expect(a.costPerWinTrend).toEqual([3, 2, 1]);                 // root→current
+    expect(formatAnalysis(a, 'trend').join('\n')).toContain('cheaper ↓');
   });
 
   it('an honest-null (no candidates) analyzes cleanly + formats without throwing', () => {

--- a/packages/flywheel/package.json
+++ b/packages/flywheel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/flywheel",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A verifiable self-improvement loop for agent harnesses. Freeze the model. Evolve the harness. Promote only what proves lift.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/flywheel/src/analyze.ts
+++ b/packages/flywheel/src/analyze.ts
@@ -19,6 +19,11 @@ export interface TargetStat {
   avgDeltaAll: number;
   /** the single best primaryDelta this lever produced. */
   bestDelta: number;
+  /** mean sealed candidateScore.costPerWin over this lever's PROMOTED candidates — the cost-per-accepted-
+   *  task for wins this lever bought (lower is better). 0 when none promoted or cost not sealed. */
+  avgCostPerWinPromoted: number;
+  /** the lowest (cheapest) sealed costPerWin among this lever's PROMOTED candidates. */
+  bestCostPerWin: number;
 }
 
 export interface BundleAnalysis {
@@ -30,6 +35,9 @@ export interface BundleAnalysis {
   anchorRegressed: number;
   /** per-lever stats, ranked most-effective first (promotions, then avg promoted lift, then avg lift). */
   byTarget: TargetStat[];
+  /** sealed costPerWin along the PROMOTED chain (root→current) — the cost-per-accepted-task trajectory.
+   *  A DOWNWARD trend means the flywheel is buying wins more cheaply over generations. Empty if unsealed. */
+  costPerWinTrend: number[];
 }
 
 const mean = (xs: number[]): number => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
@@ -43,9 +51,11 @@ export function analyzeBundle(bundle: ReplayBundle): BundleAnalysis {
     (groups.get(t) ?? groups.set(t, []).get(t)!).push(c);
   }
 
+  const costOf = (c: LineageCommit): number | undefined => c.candidateScore?.costPerWin;
   const byTarget: TargetStat[] = [...groups.entries()].map(([target, cs]) => {
     const promoted = cs.filter((c) => c.verdict === 'PROMOTED');
     const rejected = cs.filter((c) => c.verdict === 'REJECTED');
+    const promotedCosts = promoted.map(costOf).filter((x): x is number => typeof x === 'number');
     return {
       target,
       attempts: cs.length,
@@ -55,6 +65,8 @@ export function analyzeBundle(bundle: ReplayBundle): BundleAnalysis {
       avgDeltaPromoted: mean(promoted.map((c) => c.primaryDelta)),
       avgDeltaAll: mean(cs.map((c) => c.primaryDelta)),
       bestDelta: cs.length ? Math.max(...cs.map((c) => c.primaryDelta)) : 0,
+      avgCostPerWinPromoted: mean(promotedCosts),
+      bestCostPerWin: promotedCosts.length ? Math.min(...promotedCosts) : 0,
     };
   });
 
@@ -68,6 +80,9 @@ export function analyzeBundle(bundle: ReplayBundle): BundleAnalysis {
     rejections: commits.filter((c) => c.verdict === 'REJECTED').length,
     anchorRegressed: commits.filter((c) => (c.failureReasons ?? []).includes('anchor_regressed')).length,
     byTarget,
+    // Promoted chain is stored current→root; reverse to root→current for the trajectory.
+    costPerWinTrend: [...(bundle.chain ?? []).filter((c) => c.verdict === 'PROMOTED')].reverse()
+      .map(costOf).filter((x): x is number => typeof x === 'number'),
   };
 }
 
@@ -77,15 +92,24 @@ export function formatAnalysis(a: BundleAnalysis, label: string): string[] {
     `Mutation-effectiveness — ${label}`,
     `  generations=${a.generations}  candidates=${a.candidates}  promotions=${a.promotions}  rejections=${a.rejections}  anchor-regressed=${a.anchorRegressed}`,
     '',
-    `  ${'lever'.padEnd(22)} ${'att'.padStart(4)} ${'prom'.padStart(5)} ${'rate'.padStart(6)} ${'avgΔ(prom)'.padStart(11)} ${'avgΔ(all)'.padStart(10)} ${'best'.padStart(6)}`,
+    `  ${'lever'.padEnd(22)} ${'att'.padStart(4)} ${'prom'.padStart(5)} ${'rate'.padStart(6)} ${'avgΔ(prom)'.padStart(11)} ${'avgΔ(all)'.padStart(10)} ${'best'.padStart(6)} ${'cpw(prom)'.padStart(10)} ${'cpw(best)'.padStart(10)}`,
   ];
-  if (!a.byTarget.length) { lines.push('  (no candidates in this bundle — an honest-null / root-only run)'); return lines; }
-  for (const t of a.byTarget) {
-    lines.push(
-      `  ${t.target.padEnd(22)} ${String(t.attempts).padStart(4)} ${String(t.promotions).padStart(5)} ${(t.promoteRate * 100).toFixed(0).padStart(5)}% ` +
-      `${t.avgDeltaPromoted.toFixed(2).padStart(11)} ${t.avgDeltaAll.toFixed(2).padStart(10)} ${t.bestDelta.toFixed(0).padStart(6)}`,
-    );
+  if (!a.byTarget.length) {
+    lines.push('  (no candidates in this bundle — an honest-null / root-only run)');
+  } else {
+    for (const t of a.byTarget) {
+      lines.push(
+        `  ${t.target.padEnd(22)} ${String(t.attempts).padStart(4)} ${String(t.promotions).padStart(5)} ${(t.promoteRate * 100).toFixed(0).padStart(5)}% ` +
+        `${t.avgDeltaPromoted.toFixed(2).padStart(11)} ${t.avgDeltaAll.toFixed(2).padStart(10)} ${t.bestDelta.toFixed(0).padStart(6)} ` +
+        `${(t.promotions ? t.avgCostPerWinPromoted.toFixed(2) : '—').padStart(10)} ${(t.promotions ? t.bestCostPerWin.toFixed(2) : '—').padStart(10)}`,
+      );
+    }
+    lines.push('', `  → most effective lever: ${a.byTarget[0]!.promotions > 0 ? a.byTarget[0]!.target : '(none promoted — widen the proposer or targets)'}`);
   }
-  lines.push('', `  → most effective lever: ${a.byTarget[0]!.promotions > 0 ? a.byTarget[0]!.target : '(none promoted — widen the proposer or targets)'}`);
+  if (a.costPerWinTrend.length > 1) {
+    const [first, last] = [a.costPerWinTrend[0]!, a.costPerWinTrend[a.costPerWinTrend.length - 1]!];
+    const dir = last < first ? 'cheaper ↓' : last > first ? 'costlier ↑' : 'flat →';
+    lines.push(`  → cost-per-win trajectory (root→current): ${a.costPerWinTrend.map((c) => c.toFixed(2)).join(' → ')}  [${dir}]`);
+  }
   return lines;
 }


### PR DESCRIPTION
## What
Extends `analyze` (#104) with the **cost-per-accepted-task** dimension, using the sealed `candidateScore.costPerWin` on every commit:
- **TargetStat**: `avgCostPerWinPromoted` + `bestCostPerWin` per lever — which lever buys wins *cheaply*, not just often.
- **BundleAnalysis**: `costPerWinTrend` along the promoted chain (root→current) with a direction flag (`cheaper ↓` / `costlier ↑` / flat) — is the flywheel buying wins more cheaply over generations?
- Formatter: two cost columns + a trajectory line; robust when `byTarget` is empty.

## Safety / tests
Read-only, no engine change; `meetsPromotionRule` **untouched**. Tests **25/25** (+2). Smoke-verified on the real D1 honest-null bundle (0 promotions → cpw shows `—`).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)