### PR TITLE
feat(flywheel): dual CJS+ESM build so CommonJS consumers work natively (0.1.7)

### DIFF
--- a/packages/flywheel/package.json
+++ b/packages/flywheel/package.json
@@ -1,30 +1,47 @@
 {
   "name": "@metaharness/flywheel",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "A verifiable self-improvement loop for agent harnesses. Freeze the model. Evolve the harness. Promote only what proves lift.",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "import": "./dist/index.js",
+      "require": "./dist/cjs/index.js"
     },
     "./cli": {
       "types": "./dist/cli.d.ts",
-      "import": "./dist/cli.js"
+      "import": "./dist/cli.js",
+      "require": "./dist/cjs/cli.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && npm run build:cjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json && node -e \"require('fs').writeFileSync('dist/cjs/package.json','{\\\"type\\\":\\\"commonjs\\\"}\\n')\"",
     "test": "vitest run",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "verify:dual": "npm run build && node scripts/verify-dual.mjs"
   },
-  "keywords": ["agent", "harness", "self-improvement", "flywheel", "promotion", "lineage", "receipts", "metaharness"],
+  "keywords": [
+    "agent",
+    "harness",
+    "self-improvement",
+    "flywheel",
+    "promotion",
+    "lineage",
+    "receipts",
+    "metaharness"
+  ],
   "license": "MIT",
   "devDependencies": {
     "typescript": "^5.4.0",

--- a/packages/flywheel/scripts/verify-dual.mjs
+++ b/packages/flywheel/scripts/verify-dual.mjs
@@ -1,0 +1,16 @@
+// Verifies the dual CJS+ESM build: the package loads under BOTH module systems and the FROZEN gate is
+// byte-identical from each (same gateFingerprint) — a CJS consumer (e.g. a CommonJS server) gets exactly
+// the same meetsPromotionRule as an ESM consumer. Run after build; exits non-zero on any mismatch.
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const cjs = require('@metaharness/flywheel');
+const esm = await import('@metaharness/flywheel');
+const fns = ['meetsPromotionRule', 'runFlywheelGenerations', 'gateFingerprint', 'verifyReplayBundle', 'analyzeBundle'];
+for (const f of fns) {
+  if (typeof cjs[f] !== 'function') { console.error(`FAIL: CJS require missing ${f}`); process.exit(1); }
+  if (typeof esm[f] !== 'function') { console.error(`FAIL: ESM import missing ${f}`); process.exit(1); }
+}
+const cjsFp = cjs.gateFingerprint(cjs.meetsPromotionRule);
+const esmFp = esm.gateFingerprint(esm.meetsPromotionRule);
+if (cjsFp !== esmFp) { console.error(`FAIL: frozen gate fingerprint differs CJS(${cjsFp}) vs ESM(${esmFp})`); process.exit(1); }
+console.log(`dual-load OK — CJS+ESM both resolve; frozen gate identical (fp ${cjsFp.slice(0, 12)})`);

--- a/packages/flywheel/tsconfig.cjs.json
+++ b/packages/flywheel/tsconfig.cjs.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "outDir": "./dist/cjs",
+    "declaration": false,
+    "declarationMap": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "__tests__"]
+}


### PR DESCRIPTION
## What
Makes `@metaharness/flywheel` a **dual CJS+ESM** package. It was ESM-only (`exports` had only `import`), so `require('@metaharness/flywheel')` from a CommonJS consumer threw `ERR_PACKAGE_PATH_NOT_EXPORTED` — the root cause of the meta-llm MicroLoRA service's `host-compat matrix` failure (meta-llm is CJS + first to depend on the package). Publishing wouldn't fix it (every version was import-only).

- `tsconfig.cjs.json` -> `dist/cjs/` + `dist/cjs/package.json {type:commonjs}`.
- `exports` gains a `require` condition (`.` and `./cli`); `main` -> CJS entry.
- `scripts/verify-dual.mjs` asserts BOTH module systems load **and the FROZEN gate is byte-identical from each**.

## Verify
ESM OK · CJS OK · gate fp identical (`b730019b`) · **25/25 tests** · `meetsPromotionRule` UNCHANGED (packaging only). 0.1.6 -> 0.1.7. Pairs with publishing 0.1.7 to unblock CJS consumers without per-consumer workarounds.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)