### PR TITLE
feat(swebench): $0 LOCAL-endpoint path for the D1 run — removes the budget gate (ADR-236 §5)

### DIFF
--- a/docs/adrs/ADR-236-swebench-domain-run-honest-null.md
+++ b/docs/adrs/ADR-236-swebench-domain-run-honest-null.md
@@ -57,3 +57,20 @@ The forward-path run was executed for real (user-authorized): `d1s4-live-run.mjs
 - **The anti-Goodhart guard actively fired:** of the 2 candidate policies proposed over 2 generations, one *improved the holdout* (best Δ +1 on `editPolicy`) but **regressed the frozen anchor** — so the gate **rejected it** (`anchor-regressed=1` in `analyze-swebench.json`). The anchor suite did exactly its job: it refused a holdout-overfit.
 
 **What this does NOT prove (the honest limit):** **compounding is still NULL** — 0 promotions over 2 generations, `milestone_reached=false`. A short 2-generation run with a single mutation lever (`editPolicy`) found no *genuine* policy improvement that survived the anchor. So this ADR is amended to **MECHANISM-PROVEN on real SWE-bench with a demonstrated anti-Goodhart rejection, but compounding-null** — NOT "domain-proven compounding." Removing the "reasoning-proxy" caveat is earned (the mechanism ran on real code-repair, gold-scored); claiming compounding lift is NOT. Forward path to a *positive compounding* result: more generations, more/other mutation levers (`escalationPolicy`, `verifierPolicy`), and a base with more headroom (3/25 leaves little room for a policy to compound on 25 instances) — e.g. a larger holdout so the gate's noise floor is lower.
+
+## 5. The budget gate is removed — a $0 LOCAL endpoint path (2026-07-06)
+
+§4's forward path to *positive compounding* (more generations, more levers, a larger holdout) was blocked on ONE thing: **money.** A hosted cheap model over dozens of instances × generations × agentic steps is real $ + hours, so the flagship run stayed confirm-gated and small. That gate is now removed for anyone with a local OpenAI-compatible server (`ruvllm serve`, or an ollama endpoint at `http://localhost:11434/v1`): the SAME agentic solver and the SAME official-harness gold-scoring, at **$0 inference**.
+
+`d1s4-live-run.mjs` gained `--api-key-env` and a local-no-auth path (`swebench-endpoint.mjs → resolveEndpointAuth`, pure + unit-tested): an `--api-key-env NONE` or a `localhost` `--base-url` is treated as keyless and **$0** — the proposer's spend and the solver's `costUsd` are both zeroed, and the auth header is omitted. So a full positive-compounding run is now:
+
+```
+d1s4-live-run.mjs --solver agentic --holdout 25 --generations 4 --targets editPolicy,escalationPolicy,verifierPolicy \
+  --base-url http://localhost:11434/v1 --api-key-env NONE --model qwen2.5-coder:32b --proposer qwen2.5-coder:32b
+```
+
+Two honesty guards ship with it:
+- **Only the official swebench Docker harness gold-scores.** A local model changes the $, never the scoring — the gate, anchor, and signed replay bundle are byte-identical to a hosted run.
+- **A local-models pre-flight** (`--plan`, $0 `GET /v1/models`): because the runner shares ONE endpoint for solve *and* propose, a hosted-style `--proposer` (the default `anthropic/claude-sonnet-5`) against a local server would silently yield **zero mutations** — a wasted null run. `--plan` now reports `local models served: BLOCKED` and refuses to launch unless both the solver and proposer models are actually served locally.
+
+**This ADR is still NOT amended to "domain-proven compounding."** Removing the budget gate makes a longer/larger run *cheap to attempt*; it does not manufacture a result. The positive-compounding claim is earned only when a run produces a real, anchor-surviving, replayable lift curve (`milestone_reached=true`) — gold-scored by the official harness, as always. What changed is that attempting it no longer costs money or a confirmation — it is a one-command `$0` launch, and the machine-load of a multi-hour agentic + Docker run is the only remaining reason to run it watched rather than fire-and-forget.

--- a/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
+++ b/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
@@ -13,6 +13,7 @@ import { runFlywheelGenerations, makeSigner, verifyReplayBundle, gateFingerprint
 import { makeSwebenchEvaluator, makeSwebenchProposer } from './flywheel-swebench-evaluator.mjs';
 import { makeCliSolver } from './swebench-solver-cli.mjs';
 import { makeSwebenchGrader } from './swebench-grade.mjs';
+import { resolveEndpointAuth } from './swebench-endpoint.mjs';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const arg = (n, d) => { const i = process.argv.indexOf(n); return i >= 0 ? process.argv[i + 1] : d; };
@@ -27,9 +28,17 @@ const BASE_URL = arg('--base-url', 'https://openrouter.ai/api/v1');
 const K = +arg('--k', 1); // samples per instance — 1 keeps a single generation from overshooting the cap
 // which policy levers to mutate per generation (fewer = fewer candidates/gen = tighter cost bound)
 const TARGETS = arg('--targets', 'editPolicy').split(',').map((s) => s.trim()).filter(Boolean);
-// Tolerant key read: the live run needs it, but `--plan` (dry-run) does not — so a missing key reports
-// as a pre-flight gap instead of crashing before the plan can print.
-const KEY = (process.env.OPENROUTER_API_KEY || (existsSync('/tmp/.orkey') ? readFileSync('/tmp/.orkey', 'utf-8') : '')).trim();
+// Endpoint auth: hosted (OpenRouter default) needs a key; a LOCAL no-auth endpoint (`--api-key-env NONE`
+// or a localhost --base-url, e.g. `ruvllm serve` / ollama at http://localhost:11434/v1) needs none and
+// costs $0. This removes the budget gate from the D1 positive-compounding run — same real solver + REAL
+// official-harness gold-scoring, $0 inference. Tolerant read: `--plan` reports a missing hosted key as a
+// pre-flight gap instead of crashing. (Only the official swebench harness gold-scores — a local model
+// changes the $, never the honesty.)
+const API_KEY_ENV = arg('--api-key-env', 'OPENROUTER_API_KEY');
+const { noAuth: NO_AUTH, key: KEY } = resolveEndpointAuth({
+  apiKeyEnv: API_KEY_ENV, baseUrl: BASE_URL, env: process.env,
+  orkey: existsSync('/tmp/.orkey') ? readFileSync('/tmp/.orkey', 'utf-8') : '',
+});
 
 const holdout = JSON.parse(readFileSync(join(HERE, 'swebench-holdout-frozen.json'), 'utf-8')).instances.slice(0, HOLDOUT_N);
 const anchor = JSON.parse(readFileSync(join(HERE, 'swebench-anchor-frozen.json'), 'utf-8')).instances.slice(0, ANCHOR_N);
@@ -52,8 +61,9 @@ async function fetchJSON(url, init, tries = 5) {
 }
 async function complete(model, prompt) {
   try {
-    const j = await fetchJSON(`${BASE_URL}/chat/completions`, { method: 'POST', headers: { Authorization: `Bearer ${KEY}`, 'Content-Type': 'application/json' }, body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], max_tokens: 400, temperature: 0.4 }) });
-    spend += j.usage?.cost ?? priceOf(j.usage, model);
+    const headers = { 'Content-Type': 'application/json', ...(KEY ? { Authorization: `Bearer ${KEY}` } : {}) };
+    const j = await fetchJSON(`${BASE_URL}/chat/completions`, { method: 'POST', headers, body: JSON.stringify({ model, messages: [{ role: 'user', content: prompt }], max_tokens: 400, temperature: 0.4 }) });
+    spend += NO_AUTH ? 0 : (j.usage?.cost ?? priceOf(j.usage, model)); // local inference is $0
     return j.choices?.[0]?.message?.content ?? '';
   } catch (e) {
     // Degrade: an unrecoverable proposer error yields NO mutation (safe) rather than killing the run.
@@ -76,9 +86,9 @@ const solverExtraArgs = SOLVER === 'agentic'
 // real solver cost feeds the shared spend via its returned costUsd (summed inside the evaluator wrapper).
 const cliSolver = makeCliSolver({
   solveScript: new URL(SOLVER_SCRIPT, import.meta.url).pathname,
-  baseUrl: BASE_URL, model: MODEL, apiKeyEnv: 'OPENROUTER_API_KEY', k: K, extraArgs: solverExtraArgs,
+  baseUrl: BASE_URL, model: MODEL, apiKeyEnv: API_KEY_ENV, k: K, extraArgs: solverExtraArgs,
 });
-const runSolver = async (policy, instances) => { const preds = await cliSolver(policy, instances); spend += preds.reduce((s, p) => s + (p.costUsd || 0), 0); return preds; };
+const runSolver = async (policy, instances) => { const preds = await cliSolver(policy, instances); spend += NO_AUTH ? 0 : preds.reduce((s, p) => s + (p.costUsd || 0), 0); return preds; };
 const grader = makeSwebenchGrader({ dataset: arg('--dataset', 'princeton-nlp/SWE-bench_Lite'), maxWorkers: 4 });
 
 const evaluator = makeSwebenchEvaluator({ runSolver, gradePredictions: grader });
@@ -109,11 +119,31 @@ if (process.argv.includes('--plan') || process.argv.includes('--dry-run')) {
   const dockerOk = spawnSync('docker', ['ps'], { stdio: 'ignore' }).status === 0;
   const harnessOk = existsSync(venvPython);
   const suitesOk = holdout.length >= HOLDOUT_N && anchor.length >= ANCHOR_N;
-  const keyOk = KEY.length > 0;
+  const keyOk = NO_AUTH || KEY.length > 0;
   const candPerGen = TARGETS.length;
   const holdoutEvals = 1 + GENERATIONS * candPerGen;              // root + one per candidate
   const solverInstanceRuns = holdoutEvals * holdout.length + GENERATIONS * anchor.length; // holdout + winner-anchor evals
   const ck = (ok) => (ok ? 'GREEN' : 'BLOCKED');
+  // Local-endpoint model check: the runner shares ONE endpoint for solve + propose, so a hosted-style
+  // --proposer (e.g. the default anthropic/claude-sonnet-5) against a local server would silently yield
+  // NO mutations — a wasted null run. For a $0 local run, verify BOTH models are actually served ($0 GET).
+  let localModelsOk = true, localModelsLine = null;
+  if (NO_AUTH) {
+    let served = null;
+    try {
+      const r = await fetch(`${BASE_URL}/models`, { signal: AbortSignal.timeout(5000) });
+      served = new Set(((await r.json())?.data ?? []).map((m) => m.id));
+    } catch { served = null; }
+    if (!served) {
+      localModelsOk = false;
+      localModelsLine = `  local models served:      BLOCKED  — ${BASE_URL}/models unreachable (is the local server up?)`;
+    } else {
+      const hasSolver = served.has(MODEL), hasProposer = served.has(PROPOSER);
+      localModelsOk = hasSolver && hasProposer;
+      localModelsLine = `  local models served:      ${ck(localModelsOk)}  (solver ${MODEL} ${hasSolver ? '✓' : '✗ NOT SERVED'}, proposer ${PROPOSER} ${hasProposer ? '✓' : '✗ NOT SERVED → pick a local --proposer or the run gets 0 mutations'})`;
+    }
+  }
+  const ready = dockerOk && harnessOk && suitesOk && keyOk && localModelsOk;
   const lines = [
     '── D1-S4 RUN PLAN (dry-run — no spend) ──',
     `  solver=${SOLVER}${SOLVER === 'agentic' ? ` (max-steps=${arg('--max-steps', '20')}, concurrency=${arg('--concurrency', '2')})` : ''}  model=${MODEL}  proposer=${PROPOSER}`,
@@ -127,13 +157,15 @@ if (process.argv.includes('--plan') || process.argv.includes('--dry-run')) {
     `  Docker daemon:            ${ck(dockerOk)}`,
     `  swebench gold-scorer venv: ${ck(harnessOk)}  (${venvPython})`,
     `  frozen holdout+anchor:    ${ck(suitesOk)}`,
-    `  OpenRouter key available: ${ck(keyOk)}${keyOk ? ` (prefix ${KEY.slice(0, 12)})` : ' — set OPENROUTER_API_KEY or /tmp/.orkey'}`,
+    `  endpoint:                 ${MODEL} @ ${BASE_URL}`,
+    `  auth:                     ${ck(keyOk)}${NO_AUTH ? '  — LOCAL no-auth endpoint ($0 inference)' : (keyOk ? ` (key ${API_KEY_ENV} prefix ${KEY.slice(0, 12)})` : ` — set ${API_KEY_ENV} or /tmp/.orkey`)}`,
+    ...(localModelsLine ? [localModelsLine] : []),
     '',
-    `  READY TO LAUNCH: ${dockerOk && harnessOk && suitesOk && keyOk ? 'YES — drop --plan to run for real' : 'NO — resolve the BLOCKED item(s) above'}`,
+    `  READY TO LAUNCH: ${ready ? 'YES — drop --plan to run for real' : 'NO — resolve the BLOCKED item(s) above'}`,
     '  SCOPE: only the official swebench harness gold-scores; nothing here is a real result (dry-run).',
   ];
   console.log(lines.join('\n'));
-  process.exit(dockerOk && harnessOk && suitesOk && keyOk ? 0 : 1);
+  process.exit(ready ? 0 : 1);
 }
 
 console.log(`D1-S4 LIVE SWE-bench flywheel: solver=${SOLVER} holdout=${holdout.length} anchor=${anchor.length} gens=${GENERATIONS} cap=$${BUDGET_USD} model=${MODEL}${resumeFrom ? ' [RESUME]' : ''}`);

--- a/packages/darwin-mode/bench/swebench/endpoint-auth.test.mjs
+++ b/packages/darwin-mode/bench/swebench/endpoint-auth.test.mjs
@@ -1,0 +1,39 @@
+// $0 unit test for the D1 endpoint/auth resolver. No network, no process.env, no fs — pure logic only.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { isLocalNoAuth, resolveEndpointAuth } from './swebench-endpoint.mjs';
+
+test('localhost base URL ⇒ no-auth (key ignored even if present in env)', () => {
+  const r = resolveEndpointAuth({ baseUrl: 'http://localhost:11434/v1', env: { OPENROUTER_API_KEY: 'sk-should-be-ignored' } });
+  assert.equal(r.noAuth, true);
+  assert.equal(r.key, ''); // a local endpoint never carries a key — honest $0/keyless
+});
+
+test('127.0.0.1 with a port ⇒ no-auth', () => {
+  assert.equal(isLocalNoAuth('OPENROUTER_API_KEY', 'http://127.0.0.1:8080/v1'), true);
+  assert.equal(resolveEndpointAuth({ baseUrl: 'http://127.0.0.1:8080/v1' }).noAuth, true);
+});
+
+test('explicit --api-key-env NONE ⇒ no-auth even for a hosted URL', () => {
+  const r = resolveEndpointAuth({ apiKeyEnv: 'NONE', baseUrl: 'https://openrouter.ai/api/v1', env: { NONE: 'x' } });
+  assert.equal(r.noAuth, true);
+  assert.equal(r.key, '');
+});
+
+test('hosted default + env key ⇒ auth, key from env (trimmed)', () => {
+  const r = resolveEndpointAuth({ baseUrl: 'https://openrouter.ai/api/v1', env: { OPENROUTER_API_KEY: '  sk-or-v1-abc  ' } });
+  assert.equal(r.noAuth, false);
+  assert.equal(r.key, 'sk-or-v1-abc');
+});
+
+test('hosted + no env key ⇒ falls back to orkey', () => {
+  const r = resolveEndpointAuth({ baseUrl: 'https://openrouter.ai/api/v1', env: {}, orkey: 'sk-from-orkey' });
+  assert.equal(r.noAuth, false);
+  assert.equal(r.key, 'sk-from-orkey');
+});
+
+test('a hosted https endpoint is NOT treated as local', () => {
+  assert.equal(isLocalNoAuth('OPENROUTER_API_KEY', 'https://api.example.com/v1'), false);
+  // "localhost" appearing mid-host (not as the actual host) must not false-positive
+  assert.equal(isLocalNoAuth('OPENROUTER_API_KEY', 'https://localhost.evil.com/v1'), false);
+});

--- a/packages/darwin-mode/bench/swebench/swebench-endpoint.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-endpoint.mjs
@@ -1,0 +1,36 @@
+// swebench-endpoint.mjs — pure endpoint/auth resolution for the D1 SWE-bench runner (d1s4-live-run.mjs).
+//
+// Two endpoint shapes, one resolver:
+//   • HOSTED (default, e.g. OpenRouter) — needs an API key from its env var, with a /tmp/.orkey fallback.
+//   • LOCAL NO-AUTH — a `ruvllm serve` or an ollama OpenAI-compatible server at localhost, OR any endpoint
+//     the caller explicitly marks keyless with `--api-key-env NONE`. It needs no key and costs $0.
+//
+// WHY THIS EXISTS: the D1 positive-compounding run (agentic solver, REAL official-harness gold-scoring) was
+// gated ONLY on budget — a hosted cheap model costs real $. A local model at localhost removes that gate:
+// SAME real solver, SAME real gold-scoring (the official swebench Docker harness is the ONLY scorer — a
+// local model changes the $, never the honesty), $0 inference. This resolver is the seam that lets the
+// runner target either without a key requirement blocking the local case. Pure + injected env so it is
+// unit-testable at $0 (no network, no process.env coupling).
+
+/** True when the endpoint needs no API key: an explicit `NONE` sentinel, or a localhost base URL. */
+export function isLocalNoAuth(apiKeyEnv, baseUrl) {
+  if (apiKeyEnv === 'NONE') return true;
+  return /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?(\/|$)/i.test(baseUrl || '');
+}
+
+/**
+ * Resolve { noAuth, key } for a run. Injected `env`/`orkey` keep it pure (no process.env / fs coupling).
+ * @param {object} o
+ * @param {string} [o.apiKeyEnv='OPENROUTER_API_KEY'] env var holding the key (or 'NONE' for a keyless endpoint)
+ * @param {string} [o.baseUrl='']  the chat-completions base URL (localhost ⇒ no-auth)
+ * @param {Record<string,string>} [o.env={}]  the environment to read the key from
+ * @param {string} [o.orkey='']  a fallback key (e.g. the contents of /tmp/.orkey); ignored for no-auth
+ * @returns {{ noAuth: boolean, key: string }}
+ */
+export function resolveEndpointAuth({ apiKeyEnv = 'OPENROUTER_API_KEY', baseUrl = '', env = {}, orkey = '' } = {}) {
+  const noAuth = isLocalNoAuth(apiKeyEnv, baseUrl);
+  // A local no-auth endpoint never carries a key — not even a stale /tmp/.orkey — so the run's spend and
+  // provenance stay honestly $0/keyless.
+  const key = noAuth ? '' : (env[apiKeyEnv] || orkey || '').trim();
+  return { noAuth, key };
+}


### PR DESCRIPTION
## What

D1's positive-compounding forward path (agentic solver + more generations/levers, [ADR-236 §4](docs/adrs/ADR-236-swebench-domain-run-honest-null.md)) was blocked on **money** — a hosted cheap model over dozens of instances × generations × agentic steps is real \$ + hours, so the flagship run stayed confirm-gated and small.

This **removes the budget gate** for anyone with a local OpenAI-compatible server (`ruvllm serve`, or an ollama endpoint at `http://localhost:11434/v1`): the **same** agentic solver, the **same** official-harness gold-scoring, at **\$0 inference**.

A full positive-compounding run is now one \$0 command:
```
d1s4-live-run.mjs --solver agentic --holdout 25 --generations 4 \
  --targets editPolicy,escalationPolicy,verifierPolicy \
  --base-url http://localhost:11434/v1 --api-key-env NONE \
  --model qwen2.5-coder:32b --proposer qwen2.5-coder:32b
```

## Changes

- **`swebench-endpoint.mjs`** (new, pure + unit-tested) — `resolveEndpointAuth`: `--api-key-env NONE` or a `localhost` `--base-url` ⇒ keyless + \$0; hosted keeps the OpenRouter-key (or `/tmp/.orkey`) behaviour. Injected env ⇒ \$0-testable.
- **`d1s4-live-run.mjs`** — `--api-key-env` flag; proposer spend + solver `costUsd` zeroed for a local endpoint; auth header omitted when keyless.
- **Local-models pre-flight** (`--plan`, \$0 `GET /v1/models`) — the runner shares **one** endpoint for solve *and* propose, so a hosted-style `--proposer` (the default `claude-sonnet-5`) against a local server would silently yield **0 mutations** (a wasted null run). `--plan` now reports `local models served: BLOCKED` and refuses to launch unless **both** the solver and proposer models are served locally.

## Honesty (unchanged)

- **Only the official swebench Docker harness gold-scores** — a local model changes the \$, never the scoring. Gate / anchor / signed replay bundle are byte-identical to a hosted run.
- `meetsPromotionRule` **UNTOUCHED**.
- This does **NOT** amend the ADR-236 "compounding null" verdict. It makes *attempting* a longer/larger run cost \$0 + no confirmation; a positive-compounding claim is still earned only by a real, anchor-surviving, replayable `milestone_reached=true` lift curve.

## Verification

- `endpoint-auth.test.mjs` **6/6**; full swebench bench suite **133/133**.
- `--plan` against the live local ollama endpoint (`qwen2.5-coder:32b`): **READY YES** fully-local; the hosted-proposer-vs-local footgun **correctly BLOCKED**; hosted no-key path unchanged (no regression, no network call).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)