### PR TITLE
feat(swebench): structural capability lever for the D1 flywheel — evolves solver behaviour, not just prompt prose (ADR-236 §6)

### DIFF
--- a/docs/adrs/ADR-236-swebench-domain-run-honest-null.md
+++ b/docs/adrs/ADR-236-swebench-domain-run-honest-null.md
@@ -74,3 +74,38 @@ Two honesty guards ship with it:
 - **A local-models pre-flight** (`--plan`, $0 `GET /v1/models`): because the runner shares ONE endpoint for solve *and* propose, a hosted-style `--proposer` (the default `anthropic/claude-sonnet-5`) against a local server would silently yield **zero mutations** — a wasted null run. `--plan` now reports `local models served: BLOCKED` and refuses to launch unless both the solver and proposer models are actually served locally.
 
 **This ADR is still NOT amended to "domain-proven compounding."** Removing the budget gate makes a longer/larger run *cheap to attempt*; it does not manufacture a result. The positive-compounding claim is earned only when a run produces a real, anchor-surviving, replayable lift curve (`milestone_reached=true`) — gold-scored by the official harness, as always. What changed is that attempting it no longer costs money or a confirmation — it is a one-command `$0` launch, and the machine-load of a multi-hour agentic + Docker run is the only remaining reason to run it watched rather than fire-and-forget.
+
+## 6. Structural capability levers — giving the flywheel a REAL knob (2026-07-06)
+
+§4's null and §5's ceiling analysis both point at the same root cause: the D1 policy levers (`editPolicy`,
+`escalationPolicy`, `verifierPolicy`) only **append system-prompt prose**. That is the ADR-226
+"zero-marginal-advisor" shape — a mutation adds a *hint*, and a weak base model is free to ignore it, so
+there is little for a promotion to compound on. A policy that can only talk to the solver cannot change
+what the solver *does*.
+
+So the flywheel now gets a **structural** lever, `solverCapabilities`, that evolves WHICH real solver
+capabilities are on rather than what the prompt says:
+
+- **`repro-gate`** → `--repro-gate`: write a failing reproduction test first, then iterate the patch against it.
+- **`reviewer`** → `--reviewer`: a critic sub-agent reviews the patch and drives a bounded revise loop.
+
+Both hit the *same* chat endpoint, so they stay **$0** on the local endpoint from §5 (unlike `--localize`,
+which needs a hosted embedder and is deliberately not on the menu). The lever is wired end-to-end in the
+darwin-mode SWE-bench **adapter** — `@metaharness/flywheel` and `meetsPromotionRule` are **untouched**:
+
+1. **Proposer** (`makeSwebenchProposer`): for this lever the model picks a bounded subset from a fixed
+   MENU (not free text); the pick is filtered to the menu so the stored policy / lineage stays clean.
+2. **Solver-cli** (`makeCliSolver`): the structural lever is split out of the prose levers — it maps to
+   allowlisted argv flags (behaviour), never to `SWE_POLICY_SYSTEM` (prose). `''` ⇒ no flags ⇒
+   byte-identical to the pre-lever default (backward-safe).
+3. **Security**: the lever value is produced by an LLM proposer, so it is **never passed through**.
+   `capabilitiesToFlags` keeps only exact allowlist tokens (`repro-gate`, `reviewer`) and maps them to
+   known flag strings; anything else (shell metacharacters, hallucinated flags, `--repro-gate` in flag
+   form) is dropped — fail-closed. `spawnSync` uses an argv array, so tokens are never shell-interpreted
+   even if they slipped through. Input validation at the process boundary.
+
+Tests: `capability-lever.test.mjs` 6/6 (allowlist + dedupe + injection-safety + prose/structural split +
+proposer menu); full swebench bench suite 139/139. **This still does not amend the "compounding null"
+verdict** — it removes the *reason* the null was over-determined (prose-only levers). Whether the flywheel
+now finds a genuine, anchor-surviving structural improvement is an empirical question the $0 local run
+(`--targets solverCapabilities`, §5) will answer — gold-scored by the official harness, as always.

--- a/packages/darwin-mode/bench/swebench/_stub-capflags.mjs
+++ b/packages/darwin-mode/bench/swebench/_stub-capflags.mjs
@@ -1,0 +1,11 @@
+// $0 STUB solver for the structural-capability-lever test. Echoes the capability flags it ACTUALLY
+// received on argv (in order) as each prediction's model_patch, so the test can assert the allowlisted
+// flags reached the solver — and that non-allowlisted junk never did. No network, no repo, no model.
+import { readFileSync, writeFileSync } from 'node:fs';
+const arg = (n, d) => { const i = process.argv.indexOf(n); return i >= 0 ? process.argv[i + 1] : d; };
+const KNOWN = ['--repro-gate', '--reviewer']; // the only structural flags the real agentic solver reads
+const received = process.argv.filter((a) => KNOWN.includes(a)).join(' ');
+const instances = JSON.parse(readFileSync(arg('--manifest'), 'utf-8')).instances;
+const lines = instances.map((it) => JSON.stringify({ instance_id: it.instance_id, model_name_or_path: 'stub', model_patch: received }));
+writeFileSync(arg('--out'), lines.join('\n') + '\n');
+writeFileSync(arg('--report'), JSON.stringify({ totalCost: 0, n: instances.length }));

--- a/packages/darwin-mode/bench/swebench/capability-lever.test.mjs
+++ b/packages/darwin-mode/bench/swebench/capability-lever.test.mjs
@@ -1,0 +1,60 @@
+// $0 unit tests for the STRUCTURAL capability lever (ADR-236 §6). No network, no repos, no model.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { capabilitiesToFlags, CAPABILITY_ALLOWLIST, CAPABILITY_LEVER, makeCliSolver } from './swebench-solver-cli.mjs';
+import { makeSwebenchProposer } from './flywheel-swebench-evaluator.mjs';
+
+test('capabilitiesToFlags: allowlisted tokens → their flags, deduped, order-stable', () => {
+  assert.deepEqual(capabilitiesToFlags('repro-gate reviewer'), ['--repro-gate', '--reviewer']);
+  assert.deepEqual(capabilitiesToFlags('reviewer repro-gate'), ['--reviewer', '--repro-gate']); // order preserved
+  assert.deepEqual(capabilitiesToFlags('reviewer, reviewer'), ['--reviewer']);                   // deduped
+  assert.deepEqual(capabilitiesToFlags('  REPRO-GATE  '), ['--repro-gate']);                     // case/space tolerant
+});
+
+test('capabilitiesToFlags: empty/garbage ⇒ [] (solver runs at its default)', () => {
+  for (const v of ['', '   ', undefined, null, 'nope', 'localize']) assert.deepEqual(capabilitiesToFlags(v), []);
+});
+
+test('capabilitiesToFlags: injection-safe — only EXACT allowlist tokens survive; everything else dropped', () => {
+  // A malicious/hallucinated proposer value can never become arbitrary argv. Two layers of safety:
+  //   (1) every token is looked up in the allowlist — non-matches are dropped;
+  //   (2) matches map to a KNOWN flag string (spawnSync uses an argv array, so no shell interpretation).
+  assert.deepEqual(capabilitiesToFlags('repro-gate; rm -rf / --dangerous'), []); // 'repro-gate;' ≠ 'repro-gate' → fail-closed
+  assert.deepEqual(capabilitiesToFlags('reviewer && rm -rf /'), ['--reviewer']); // clean token extracted, junk dropped
+  assert.deepEqual(capabilitiesToFlags('$(whoami) reviewer'), ['--reviewer']);   // '$(whoami)' is its own token → dropped
+  assert.deepEqual(capabilitiesToFlags('--repro-gate'), []);                     // the flag form is NOT an allowlist token
+  assert.deepEqual(Object.values(CAPABILITY_ALLOWLIST), ['--repro-gate', '--reviewer']);
+});
+
+test('makeCliSolver: the capability lever maps to flags and is EXCLUDED from the prose system prompt', async () => {
+  let sawPolicy = null, sawFlags = null;
+  // A stub solve script that records its argv flags + the SWE_POLICY_SYSTEM it received, then writes an
+  // empty prediction so the plumbing completes. We spy via a custom policyToSystem + reading argv here.
+  const spyPolicyToSystem = (p) => { sawPolicy = p; return Object.values(p).filter(Boolean).join('\n'); };
+  // Use a tiny inline stub script that echoes its capability flags into the report.
+  const runSolver = makeCliSolver({
+    solveScript: new URL('./_stub-capflags.mjs', import.meta.url).pathname,
+    apiKeyEnv: 'NONE', policyToSystem: spyPolicyToSystem,
+  });
+  const out = await runSolver({ editPolicy: 'be concise', solverCapabilities: 'reviewer repro-gate' }, [{ instance_id: 'x' }]);
+  // The prose system prompt saw editPolicy but NOT the structural lever
+  assert.ok(sawPolicy && 'editPolicy' in sawPolicy, 'prose lever present');
+  assert.ok(!(CAPABILITY_LEVER in sawPolicy), 'structural lever excluded from the prose system prompt');
+  // The stub echoed the flags it actually received on argv
+  sawFlags = out[0]?.model_patch; // the stub writes the received flags as the patch text
+  assert.equal(sawFlags, '--reviewer --repro-gate', 'allowlisted flags reached the solver argv in order');
+});
+
+test('proposer: the capability lever proposes only MENU tokens (free-text/garbage filtered out)', async () => {
+  const complete = async () => 'reviewer  banana   repro-gate reviewer\nplease enable everything';
+  const propose = makeSwebenchProposer({ complete, proposerModel: 'mock' });
+  const picked = await propose({ policy: { solverCapabilities: '' } }, CAPABILITY_LEVER);
+  assert.equal(picked, 'reviewer repro-gate'); // only menu tokens, deduped, order-stable — no 'banana'/prose
+});
+
+test('proposer: a prose lever is unchanged by the capability branch', async () => {
+  const complete = async () => 'always emit a minimal search/replace edit';
+  const propose = makeSwebenchProposer({ complete, proposerModel: 'mock' });
+  const text = await propose({ policy: { editPolicy: '' } }, 'editPolicy');
+  assert.equal(text, 'always emit a minimal search/replace edit');
+});

--- a/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
+++ b/packages/darwin-mode/bench/swebench/d1s4-live-run.mjs
@@ -170,7 +170,9 @@ if (process.argv.includes('--plan') || process.argv.includes('--dry-run')) {
 
 console.log(`D1-S4 LIVE SWE-bench flywheel: solver=${SOLVER} holdout=${holdout.length} anchor=${anchor.length} gens=${GENERATIONS} cap=$${BUDGET_USD} model=${MODEL}${resumeFrom ? ' [RESUME]' : ''}`);
 const result = await runFlywheelGenerations({
-  rootPolicy: { editPolicy: '', escalationPolicy: '', verifierPolicy: '' },
+  // solverCapabilities = the STRUCTURAL lever (ADR-236 §6): '' ⇒ no capability flags ⇒ byte-identical
+  // default. Add it to --targets (agentic solver only) to let the flywheel evolve --repro-gate/--reviewer.
+  rootPolicy: { editPolicy: '', escalationPolicy: '', verifierPolicy: '', solverCapabilities: '' },
   proposer, evaluator, promotionRule: meetsPromotionRule,
   holdout: { id: 'swebench-holdout', items: holdout },
   anchor: { id: 'swebench-anchor', items: anchor },

--- a/packages/darwin-mode/bench/swebench/flywheel-swebench-evaluator.mjs
+++ b/packages/darwin-mode/bench/swebench/flywheel-swebench-evaluator.mjs
@@ -58,13 +58,33 @@ export function makeSwebenchEvaluator({ runSolver, gradePredictions, emptyPatch 
 
 /**
  * Build a @metaharness/flywheel `Proposer` for SWE-bench operating-policy levers. Frontier call that
- * improves ONE lever's text. INJECTED `complete(model, prompt) -> text`. (Real = an OpenRouter/cognitum
- * chat call; mock in tests.) The proposer is domain-flavored only in its PROMPT — the flywheel core
- * never sees it.
+ * improves ONE lever. INJECTED `complete(model, prompt) -> text`. (Real = an OpenRouter/cognitum chat
+ * call; mock in tests.) The proposer is domain-flavored only in its PROMPT — the flywheel core never
+ * sees it.
+ *
+ * Most levers are PROSE (free-text system-prompt instructions). The STRUCTURAL capability lever
+ * (`capabilityLever`, default 'solverCapabilities') is different: the model picks a bounded subset from a
+ * fixed MENU of real solver capabilities, and the pick is filtered to the menu so the stored policy /
+ * lineage stays clean (the solver-cli re-allowlists it too — defence in depth). ADR-236 §6.
  */
-export function makeSwebenchProposer({ complete, proposerModel }) {
+export function makeSwebenchProposer({ complete, proposerModel, capabilityLever = 'solverCapabilities', capabilityMenu = ['repro-gate', 'reviewer'] }) {
   return async function swebenchPropose(base, target) {
     const current = base.policy?.[target] ?? '(none)';
+    if (target === capabilityLever) {
+      const menu = new Set(capabilityMenu);
+      const prompt =
+        `You tune a cheap code-repair agent's STRUCTURAL capabilities to resolve more SWE-bench instances. ` +
+        `Choose a subset (space-separated) of these capability tokens to enable — or fewer/none:\n` +
+        `  repro-gate = write a failing reproduction test FIRST, then iterate the patch against it\n` +
+        `  reviewer   = a critic sub-agent reviews the patch and drives a bounded revise loop\n` +
+        `More capabilities are more thorough but slower (more model calls). Current: "${current || '(none)'}".\n` +
+        `Return ONLY space-separated tokens from the list above (or an empty line for none), no preamble.`;
+      const text = (await complete(proposerModel, prompt)) || '';
+      // Keep only menu tokens (deduped, order-stable) so the policy value can NEVER carry anything else.
+      const seen = new Set();
+      const picked = text.split(/[\s,]+/).map((t) => t.trim().toLowerCase()).filter((t) => menu.has(t) && !seen.has(t) && seen.add(t));
+      return picked.join(' '); // '' = none (byte-identical default); a valid subset otherwise
+    }
     const prompt =
       `You optimize a cheap code-repair agent's OPERATING POLICY so it resolves more SWE-bench ` +
       `instances (tests pass) and gives up less often (fewer empty patches). Improve ONLY its "${target}" ` +

--- a/packages/darwin-mode/bench/swebench/swebench-solver-cli.mjs
+++ b/packages/darwin-mode/bench/swebench/swebench-solver-cli.mjs
@@ -21,6 +21,32 @@ export function defaultPolicyToSystem(policy) {
   return Object.values(policy || {}).filter((v) => typeof v === 'string' && v.trim()).join('\n').trim();
 }
 
+// ── STRUCTURAL capability lever (ADR-236 §6) ────────────────────────────────────────────────────────
+// The prose levers (editPolicy/…) only ADD system-prompt text — the ADR-226 "zero-marginal-advisor" risk,
+// and the documented root cause of the D1 compounding-null (prompt-only hints ⇒ little headroom). This
+// lever lets the flywheel evolve WHICH real solver capabilities are ON — structural behaviour, not prose:
+// `repro-gate` = write a failing reproduction test first and iterate against it; `reviewer` = a critic
+// sub-agent reviews and revises the patch. Both hit the SAME chat endpoint (so they stay $0 on a local
+// endpoint). Not `localize` — it needs a hosted embedder.
+//
+// SECURITY: the lever value is produced by an LLM PROPOSER, so it is NEVER passed through to the spawned
+// solver's argv. Only tokens on this fixed allowlist become flags — no arbitrary arg/flag/command
+// injection (input validation at the process boundary).
+export const CAPABILITY_LEVER = 'solverCapabilities';
+export const CAPABILITY_ALLOWLIST = { 'repro-gate': '--repro-gate', reviewer: '--reviewer' };
+
+/** Map an (untrusted) capability-lever value to a deduped, order-stable list of ALLOWLISTED solver flags.
+ *  Anything not on the allowlist is dropped. Empty/garbage ⇒ [] ⇒ the solver runs at its default. */
+export function capabilitiesToFlags(value, allowlist = CAPABILITY_ALLOWLIST) {
+  const toks = String(value ?? '').split(/[\s,]+/).map((t) => t.trim().toLowerCase()).filter(Boolean);
+  const seen = new Set();
+  const flags = [];
+  for (const t of toks) {
+    if (Object.prototype.hasOwnProperty.call(allowlist, t) && !seen.has(t)) { seen.add(t); flags.push(allowlist[t]); }
+  }
+  return flags;
+}
+
 export function makeCliSolver({
   solveScript = join(HERE, 'solve.mjs'),
   baseUrl = 'https://openrouter.ai/api/v1',
@@ -30,6 +56,8 @@ export function makeCliSolver({
   policyToSystem = defaultPolicyToSystem,
   nodeArgs = [],
   extraArgs = [], // appended to the solver argv (e.g. agentic's --max-steps/--concurrency); unknown flags are ignored
+  capabilityLever = CAPABILITY_LEVER,   // the structural lever's key in the policy (excluded from the prose system prompt)
+  capabilityAllowlist = CAPABILITY_ALLOWLIST,
   timeoutMs = 20 * 60 * 1000,
 } = {}) {
   return async function runSolver(policy, instances) {
@@ -39,11 +67,16 @@ export function makeCliSolver({
     const report = join(work, 'report.json');
     try {
       writeFileSync(manifest, JSON.stringify({ instances }));
+      // Split the STRUCTURAL lever out of the prose levers: it maps to allowlisted argv flags (behaviour),
+      // NOT to system-prompt text. So it never leaks into SWE_POLICY_SYSTEM, and untrusted proposer output
+      // can only ever become a known flag.
+      const { [capabilityLever]: capValue, ...proseLevers } = policy || {};
+      const capFlags = capabilitiesToFlags(capValue, capabilityAllowlist);
       const res = spawnSync(
         'node',
         [...nodeArgs, solveScript, '--manifest', manifest, '--base-url', baseUrl, '--model', model,
-          '--api-key-env', apiKeyEnv, '--out', preds, '--report', report, '--k', String(k), ...extraArgs],
-        { env: { ...process.env, SWE_POLICY_SYSTEM: policyToSystem(policy) }, encoding: 'utf-8', timeout: timeoutMs, maxBuffer: 1 << 28 },
+          '--api-key-env', apiKeyEnv, '--out', preds, '--report', report, '--k', String(k), ...extraArgs, ...capFlags],
+        { env: { ...process.env, SWE_POLICY_SYSTEM: policyToSystem(proseLevers) }, encoding: 'utf-8', timeout: timeoutMs, maxBuffer: 1 << 28 },
       );
       if (res.status !== 0 && !existsSync(preds)) {
         throw new Error(`solver exited ${res.status}: ${String(res.stderr || res.error).slice(0, 300)}`);


### PR DESCRIPTION
## What

The D1 compounding-null ([ADR-236 §4](docs/adrs/ADR-236-swebench-domain-run-honest-null.md)) is **over-determined by the lever shape**: the policy levers (`editPolicy`/`escalationPolicy`/`verifierPolicy`) only **append system-prompt prose** — the ADR-226 "zero-marginal-advisor" trap. A weak base model can ignore a hint, so a promotion has little to compound on. *A policy that can only talk to the solver can't change what the solver does.*

This adds a **structural** lever, `solverCapabilities`, that evolves **which real solver capabilities are on**:

| token | flag | behaviour |
|---|---|---|
| `repro-gate` | `--repro-gate` | write a failing reproduction test first, iterate the patch against it |
| `reviewer` | `--reviewer` | a critic sub-agent reviews the patch + drives a bounded revise loop |

Both hit the **same chat endpoint**, so they stay **\$0** on the local endpoint (§5). `--localize` is deliberately off the menu (needs a hosted embedder).

## Wiring (darwin-mode ADAPTER only — `@metaharness/flywheel` + `meetsPromotionRule` UNTOUCHED)

- **Proposer** — for this lever the model picks a bounded subset from a fixed **MENU** (not free text); filtered to the menu so lineage stays clean.
- **Solver-cli** — the structural lever is **split out** of the prose levers: it maps to allowlisted argv flags (behaviour), never to `SWE_POLICY_SYSTEM` (prose). `''` ⇒ no flags ⇒ **byte-identical** to the pre-lever default.
- **Security** — the lever value is **LLM-proposed**, so it is **never passed through**. `capabilitiesToFlags` keeps only exact allowlist tokens and maps them to known flag strings; shell metacharacters, hallucinated flags, and the `--flag` form are all **dropped (fail-closed)**. `spawnSync` uses an argv array → no shell interpretation even if something slipped through.

## Honesty (unchanged)

This does **NOT** amend the "compounding null" verdict — it removes the *reason the null was over-determined* (prose-only levers). Whether the flywheel now finds a genuine, anchor-surviving **structural** improvement is an empirical question the \$0 local run answers (`--targets solverCapabilities`, §5) — gold-scored by the official harness, as always.

## Verification

- `capability-lever.test.mjs` **6/6** — allowlist mapping, dedupe/order, injection-safety, prose/structural split (structural lever excluded from the system prompt; allowlisted flags reach argv in order), proposer menu-filtering.
- Full swebench bench suite **139/139** (was 133; backward-compat — existing `editPolicy`-only tests unchanged).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)