### PR TITLE
fix(create-agent-harness): minimal template docs no longer promise phantom memory/route CLI commands (#48)

### DIFF
--- a/packages/create-agent-harness/__tests__/generated-templates.test.ts
+++ b/packages/create-agent-harness/__tests__/generated-templates.test.ts
@@ -176,3 +176,39 @@ describe('generated templates scaffold cleanly', () => {
     });
   }
 });
+
+// Regression for issue #48: docs↔code command fidelity across EVERY scaffold-able template (not just
+// the `generate:true` catalog subset — `minimal` is `generate:false` yet ships a CLI + CLAUDE.md, and
+// was the one advertising phantom `memory`/`route` commands the CLI answers with "Unknown command").
+// A scaffold that documents a command its own bin/cli.js has no `case` for is a false promise to the
+// agent reading CLAUDE.md.
+describe('docs↔code command fidelity (#48)', () => {
+  for (const template of TEMPLATES) {
+    it(`${template}: every CLAUDE.md-documented subcommand has a CLI dispatch case`, async () => {
+      const root = await mkdtemp(join(tmpdir(), 'fidelity-'));
+      const name = 'demo-harness';
+      const target = join(root, name);
+      const r = await scaffold({
+        name, template, host: 'claude-code', description: 'demo harness', targetDir: target, generatorVersion: '0.1.0',
+      });
+      if (!r.paths.includes('CLAUDE.md')) return; // no docs to check
+      const pkg = JSON.parse(await readFile(join(target, 'package.json'), 'utf-8'));
+      const binPath = Object.values(pkg.bin ?? {})[0] as string | undefined;
+      if (!binPath) return; // no CLI to check against
+
+      const claudeMd = await readFile(join(target, 'CLAUDE.md'), 'utf-8');
+      // A documented command = the first token after the harness name in a `| `name cmd …` |` table row.
+      const documented = [
+        ...claudeMd.matchAll(new RegExp('\\|\\s*`' + name + '\\s+([a-z][\\w-]*)', 'g')),
+      ].map((m) => m[1]!);
+      const cli = await readFile(join(target, binPath), 'utf-8');
+      const cased = new Set([...cli.matchAll(/case\s+'([a-z][\w-]*)'/g)].map((m) => m[1]!));
+      for (const cmd of documented) {
+        expect(
+          cased.has(cmd),
+          `${template}: CLAUDE.md documents \`${name} ${cmd}\` but bin/cli.js has no \`case '${cmd}'\` (#48 docs↔code drift)`,
+        ).toBe(true);
+      }
+    });
+  }
+});

--- a/packages/create-agent-harness/templates/minimal/CLAUDE.md.tmpl
+++ b/packages/create-agent-harness/templates/minimal/CLAUDE.md.tmpl
@@ -5,7 +5,7 @@
 ## Behavioral rules
 
 - Use the harness's MCP tools (`mcp__{{name}}__*`) for orchestration
-- Memory and routing are handled by the kernel — you don't need to learn them
+- Memory ranking and routing are kernel primitives (`@metaharness/kernel`) the harness uses internally — there are no separate CLI subcommands for them
 - Defer destructive operations to the user
 
 ## Commands
@@ -14,9 +14,12 @@ After `{{name}} init`, the following are available:
 
 | Command | What it does |
 |---|---|
+| `{{name}} init` | Scaffold the harness into the current project |
 | `{{name}} doctor` | Health check the install |
-| `{{name}} memory search <query>` | Semantic search across stored patterns |
-| `{{name}} route <task>` | Get the routing tier recommendation |
+
+Run `{{name}} --help` for the full list. Memory ranking and routing are kernel
+primitives used programmatically (see [@metaharness/kernel](https://www.npmjs.com/package/@metaharness/kernel)),
+not CLI subcommands.
 
 ## Architecture
 


### PR DESCRIPTION
## What & why — #48

A harness generated from the **`minimal`** template shipped a `CLAUDE.md` documenting two subcommands its `bin/cli.js` never implements:

| Documented | Reality |
|---|---|
| `<name> memory search <query>` | `default:` → `Unknown command: memory` (exit 2) |
| `<name> route <task>` | `default:` → `Unknown command: route` (exit 2) |

The dispatch switch only handles `init`/`doctor`/`--version`/`--help`, and the "Memory and routing are handled by the kernel" behavioral-rules line reinforced the false promise — so an agent reading `CLAUDE.md` is misled into invoking commands that don't exist.

Per the issue's analysis: `route` **can't** be implemented (the published `@metaharness/kernel` exports no routing entry point) and `memory search` needs real query→embed→search infra — so the correct fix is **Option 1: trim the docs to match the code**.

## Fix
- Removed the two phantom rows from `templates/minimal/CLAUDE.md.tmpl`; documented the **real** commands (`init`, `doctor`) and pointed to `--help`; reworded the kernel line so it no longer implies CLI subcommands (memory ranking + routing are kernel **primitives** used programmatically).
- Added a **docs↔code fidelity regression test** over **every** scaffold-able template (`TEMPLATES` — not just the `generate:true` catalog subset, since `minimal` is `generate:false`): it scaffolds each template and asserts every subcommand advertised in its `CLAUDE.md` command table has a matching `case` in its `bin/cli.js`. Catches this drift class for all templates going forward.

## Tests
A blast-radius scan confirmed `minimal` was the **only** offender (all 20 templates otherwise clean). The new fidelity test passes for all templates with the fix and **fails on the pre-fix `minimal`** (failing-first verified: `minimal: CLAUDE.md documents \`demo-harness memory\` but bin/cli.js has no \`case 'memory'\``). `generated-templates.test.ts` → 38 tests pass.

(The 4 unrelated suites that fail to resolve `@metaharness/kernel` in a bare worktree are a pre-existing workspace-link env issue, present on unmodified `main` — my change touches only `generated-templates.test.ts` + the template, neither of which imports the kernel.)

Closes #48

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)