### PR TITLE
fix(score): harness score badge JSON carries a schema discriminator distinct from metaharness score (#15)

### DIFF
--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -59,8 +59,23 @@ Multi-host: pass `--host` multiple times.
 harness sign      # produce/update the witness manifest
 harness verify    # check signature
 harness doctor    # smoke-check a scaffolded harness
+harness score     # runtime-readiness badges for a local repo
 harness help
 ```
+
+### `harness score` vs `metaharness score` — two different scorecards (#15)
+
+The two CLIs both accept `score` but emit **different, purpose-specific JSON** — so check the schema
+discriminator before parsing:
+
+| Command | Purpose | JSON discriminator |
+|---|---|---|
+| `harness score <dir> --json` | Runtime-readiness **badges** (score + mcpRisk / releaseReady / testsDetected / sbom / witnessSigned) | `"schema": "harness-quickcheck-v1"` (string) |
+| `metaharness score <dir> --json` | 5-dimension harness-fit **scorecard** (harnessFit / compileConfidence / …) | `"schema": 1` (number) |
+
+They are **not interchangeable**. A consumer wiring one into a pipeline expecting the other should
+branch on `schema` (`typeof out.schema === 'string'` ⇒ harness badges; `=== 1` ⇒ metaharness
+scorecard) and refuse the wrong shape rather than silently defaulting missing fields to `0`.
 
 ## Eject from ruflo
 

--- a/packages/create-agent-harness/__tests__/score-schema.test.ts
+++ b/packages/create-agent-harness/__tests__/score-schema.test.ts
@@ -1,0 +1,47 @@
+// #15 — the `harness score` badge JSON must carry a schema discriminator that is unambiguously
+// distinct from the `metaharness score` scorecard (numeric `schema: 1`), so a downstream consumer can
+// detect the shape at the data layer instead of silently mis-parsing one as the other (which defaulted
+// every numeric field to 0 and shipped a silent bug in ruflo for 9 iterations).
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { scoreCmd, HARNESS_SCORE_SCHEMA } from '../src/score.js';
+
+const dirs: string[] = [];
+function fixture(): string {
+  const d = mkdtempSync(join(tmpdir(), 'score-schema-'));
+  writeFileSync(join(d, 'package.json'), JSON.stringify({ name: 'demo', version: '1.0.0' }));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => { while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true }); });
+
+describe('#15 — harness score schema discriminator', () => {
+  it('`harness score --json` output carries schema:"harness-quickcheck-v1" plus the badge fields', async () => {
+    const r = await scoreCmd([fixture(), '--json']);
+    const out = JSON.parse(r.lines[0]!);
+    expect(out.schema).toBe(HARNESS_SCORE_SCHEMA);
+    expect(HARNESS_SCORE_SCHEMA).toBe('harness-quickcheck-v1');
+    // the badge set is still present alongside the discriminator
+    for (const k of ['score', 'mcpRisk', 'releaseReady', 'testsDetected', 'sbom', 'witnessSigned']) {
+      expect(out).toHaveProperty(k);
+    }
+  });
+
+  it('the discriminator is DISTINCT from the metaharness scorecard schema (numeric 1) — detectable at the data layer', async () => {
+    const r = await scoreCmd([fixture(), '--json']);
+    const out = JSON.parse(r.lines[0]!);
+    // metaharness `score` (repo-scorecard) uses numeric `schema: 1`; this must NOT collide.
+    expect(typeof out.schema).toBe('string');
+    expect(out.schema).not.toBe(1);
+  });
+
+  it('`--out` writes the same discriminated badge JSON (not the bare badge blob)', async () => {
+    const dir = fixture();
+    const outPath = join(dir, 'badges.json');
+    await scoreCmd([dir, '--out', outPath]);
+    const parsed = JSON.parse(readFileSync(outPath, 'utf-8'));
+    expect(parsed.schema).toBe(HARNESS_SCORE_SCHEMA);
+  });
+});

--- a/packages/create-agent-harness/src/score.ts
+++ b/packages/create-agent-harness/src/score.ts
@@ -24,6 +24,16 @@ import { resolve, join } from 'node:path';
 
 export type SubcommandResult = { code: number; lines: string[] };
 
+/**
+ * #15 — schema discriminator for the `harness score` badge JSON (`--json` / `--out`). It lets a
+ * downstream consumer detect this shape at the data layer and REFUSE the wrong one: `harness score`
+ * (this flat badge set) and `metaharness score` (the repo-scorecard, numeric `schema: 1`) are
+ * DIFFERENT operations with different keys, and an unmarked badge blob silently mis-parsed as the
+ * metaharness scorecard (every numeric field defaulting to 0). A string id is unambiguously distinct
+ * from the numeric `schema: 1`.
+ */
+export const HARNESS_SCORE_SCHEMA = 'harness-quickcheck-v1';
+
 interface DimensionScore {
   name: string;
   weight: number; // 0..1
@@ -402,10 +412,16 @@ export async function scoreCmd(args: string[]): Promise<SubcommandResult> {
   }
 
   const sc = buildScorecard(dir);
+  // #15 — carry the schema discriminator on the badge output so a consumer can detect this shape at
+  // the DATA layer. `harness score` and `metaharness score` are DIFFERENT operations with different
+  // JSON shapes; an unmarked badge blob was silently mis-parsed as the `metaharness score` scorecard
+  // (every field defaulting to 0). The metaharness scorecard uses numeric `schema: 1`; this string id
+  // is unambiguously distinct so downstream code can refuse the wrong shape instead of guessing.
+  const badgeOutput = { schema: HARNESS_SCORE_SCHEMA, ...sc.badges };
 
   if (outPath) {
     try {
-      writeFileSync(resolve(outPath), JSON.stringify(sc.badges, null, 2) + '\n', 'utf-8');
+      writeFileSync(resolve(outPath), JSON.stringify(badgeOutput, null, 2) + '\n', 'utf-8');
     } catch (e) {
       const err = { schema: 1 as const, error: 'out-write-failed', detail: String(e), exitCode: 2 };
       return { code: 2, lines: [bundle || json ? JSON.stringify(err, null, 2) : `harness score: failed to write --out: ${String(e)}`] };
@@ -416,7 +432,7 @@ export async function scoreCmd(args: string[]): Promise<SubcommandResult> {
     return { code: sc.exitCode, lines: [JSON.stringify(sanitise(sc), null, 2)] };
   }
   if (json) {
-    return { code: sc.exitCode, lines: [JSON.stringify(sc.badges, null, 2)] };
+    return { code: sc.exitCode, lines: [JSON.stringify(badgeOutput, null, 2)] };
   }
   return { code: sc.exitCode, lines: formatScorecard(sc) };
 }


### PR DESCRIPTION
## What & why — #15

The `metaharness` and `harness` CLIs (both shipped by the `metaharness` package) each accept `score` but emit **different, purpose-specific JSON**:

| Command | Purpose | Shape |
|---|---|---|
| `metaharness score` | 5-dimension harness-**fit** scorecard (`harnessFit`/`compileConfidence`/…) | numeric `schema: 1` |
| `harness score` | flat runtime-**readiness** badges (`score`/`mcpRisk`/`releaseReady`/`testsDetected`/`sbom`/`witnessSigned`) | **no schema marker** |

Because the `harness score` badge blob carried **no discriminator**, a consumer wiring it into a pipeline expecting the `metaharness score` scorecard silently mis-parsed it — every numeric field defaulted to `0`. Per the issue, this shipped a silent bug in ruflo for **9 iterations** (similarity of two identical captures returned ~0.81 instead of 1.0).

## Fix — issue's **option 4** (non-breaking, additive)

The two `score` commands are genuinely **different operations**, so unifying (opt 1) or renaming (opt 2, breaking) is wrong. Instead, the `harness score` badge JSON (`--json` / `--out`) now carries **`"schema": "harness-quickcheck-v1"`** — a **string**, unambiguously distinct from the metaharness scorecard's numeric `schema: 1`. A consumer can now branch on `typeof out.schema` (`string` ⇒ harness badges; `=== 1` ⇒ metaharness scorecard) and **refuse the wrong shape at the data layer** instead of guessing. README documents the two side-by-side (opt 3).

## Tests
`__tests__/score-schema.test.ts` — the `--json` and `--out` outputs carry the discriminator + the badge fields, and the discriminator is a **string ≠ 1** (detectable vs the metaharness scorecard). `score.ts` is kernel-free so the suite runs $0/hermetic. 15 score tests pass.

## Deploy
Merge to main is the source-of-truth landing; the metaharness package publishes on the next tag-triggered release (`v*.*.*`, maintainer-gated), not on merge.

Closes #15

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)