### PR TITLE
fix(kernel): publish the wasm as the nodejs target so npm install reaches the wasm backend (#20)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,8 +92,15 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
-      - name: Build wasm
-        run: wasm-pack build crates/kernel-wasm --target bundler --release --out-dir ../../packages/kernel-js/pkg
+      # GH #20 — build the NODEJS target, not `bundler`. The runtime loader (kernel-js loadWasm())
+      # `import('../pkg/ruflo_kernel_wasm.js')` expects wasm-pack's --target nodejs (CommonJS shim that
+      # auto-initialises the wasm on require, + pkg/package.json {"type":"commonjs"}). A `bundler`-target
+      # artifact is ESM that needs a bundler + an explicit init() call, so loadWasm() cannot load it and
+      # the kernel silently falls back to the JS floor — the exact #20 symptom. `npm run build:wasm` is
+      # the single source of truth (correct target + the .gitignore/package.json fixups).
+      - name: Build wasm (nodejs target — matches the runtime loader)
+        working-directory: packages/kernel-js
+        run: npm run build:wasm
       - name: Upload wasm artifact
         uses: actions/upload-artifact@v4
         with:

--- a/packages/kernel-js/__tests__/loader.test.ts
+++ b/packages/kernel-js/__tests__/loader.test.ts
@@ -102,3 +102,41 @@ describe('METAHARNESS_KERNEL_BACKEND selection (GH #22)', () => {
     expect(typeof d.reasons).toBe('object');
   });
 });
+
+// GH #20 — the published @metaharness/kernel must ship a LOADABLE wasm artifact so a plain
+// `npm install` can reach the fast Rust backend, not silently fall to the JS floor. The bug was the
+// publish workflow building `wasm-pack --target bundler` while the runtime loader expects `--target
+// nodejs` (CommonJS auto-init) — an unloadable mismatch.
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const kjsRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const wasmShim = join(kjsRoot, 'pkg', 'ruflo_kernel_wasm.js');
+
+describe('GH #20 — publish ships a loadable wasm (nodejs target)', () => {
+  it('the publish workflow builds the wasm NODEJS target, not bundler', () => {
+    const wf = readFileSync(join(kjsRoot, '..', '..', '.github', 'workflows', 'publish.yml'), 'utf8');
+    // a raw bundler-target build is the #20 regression — the runtime loader can't load it
+    expect(wf).not.toMatch(/wasm-pack build[^\n]*--target\s+bundler/);
+    // it must use build:wasm (nodejs target + fixups) or an explicit --target nodejs
+    expect(/build:wasm|--target\s+nodejs/.test(wf)).toBe(true);
+  });
+
+  // Only runs where the wasm artifact has been built (locally after `npm run build:wasm`, and in the
+  // publish flow); asserts the artifact is the correct, LOADABLE target — a bundler artifact would make
+  // a `wasm`-requested load throw / fall back rather than resolve the wasm backend.
+  it.skipIf(!existsSync(wasmShim))('a present wasm artifact resolves the wasm backend', async () => {
+    const prev = process.env.METAHARNESS_KERNEL_BACKEND;
+    process.env.METAHARNESS_KERNEL_BACKEND = 'wasm';
+    _resetKernelCacheForTests();
+    try {
+      const k = await loadKernel();
+      expect(k.backend).toBe('wasm');
+    } finally {
+      if (prev === undefined) delete process.env.METAHARNESS_KERNEL_BACKEND;
+      else process.env.METAHARNESS_KERNEL_BACKEND = prev;
+      _resetKernelCacheForTests();
+    }
+  });
+});


### PR DESCRIPTION
## What & why — #20

Every generated harness silently runs the **JS floor** backend — `METAHARNESS_KERNEL_BACKEND=wasm` has no effect — even though a wasm artifact ships in the tarball. Root cause: the publish workflow builds the **wrong wasm-pack target**.

- **Publish workflow:** `wasm-pack build crates/kernel-wasm --target bundler` (`publish.yml`)
- **Runtime loader** (`kernel-js` `loadWasm()`): `import('../pkg/ruflo_kernel_wasm.js')` — expects **`--target nodejs`** (a CommonJS shim that **auto-initialises** the wasm on `require`, + `pkg/package.json {"type":"commonjs"}`).

A `bundler`-target artifact is ESM that needs a bundler + an explicit `init()` call, so `loadWasm()` throws and `loadKernel()` falls back to `js`. (The tested `build:wasm` script already uses `--target nodejs` — the publish job diverged from it.)

## Fix
The publish `Build wasm` step now runs **`npm run build:wasm`** — the single source of truth (correct `--target nodejs` + the `.gitignore`/`package.json` `type:commonjs` fixups) — instead of the raw bundler-target build.

**Verified locally:** after `npm run build:wasm`, `loadKernel()` resolves **`BACKEND: wasm`** (was `js`); `METAHARNESS_KERNEL_BACKEND=wasm` loads the wasm backend.

## Tests (`loader.test.ts`)
- A **workflow-content guard** (always runs): `publish.yml` must build the nodejs target and never `--target bundler`.
- A **wasm-backend guard** (`skipIf` no artifact; runs locally after `build:wasm` and in the publish flow): a present wasm artifact resolves the `wasm` backend — a bundler artifact would not.

kernel-js suite **45 pass**; `tsc` clean.

## Deploy
The metaharness package publishes on the next tag-triggered release (`v*.*.*`, maintainer-gated) — the fixed publish job will then ship a **loadable** wasm, so `npm install` reaches the fast Rust backend. Locally reproduced end-to-end (build:wasm → wasm backend).

Closes #20

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)