### PR TITLE
fix(diag): surface the resolved kernel backend + why a faster tier is unavailable (#22)

### DIFF
--- a/packages/create-agent-harness/__tests__/diag-backend.test.ts
+++ b/packages/create-agent-harness/__tests__/diag-backend.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+//
+// GH #22: `harness diag` must surface WHICH kernel backend actually answers
+// (native/wasm/js) and, when a faster tier is unavailable, WHY — instead of a
+// silent js fallback the operator can't see. These tests pin the surfacing
+// (formatDiagReport) and the end-to-end resolution (buildDiagReport).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildDiagReport, formatDiagReport, type DiagReport } from '../src/diag.js';
+
+function baseReport(over: Partial<DiagReport>): DiagReport {
+  return {
+    dir: '/tmp/h',
+    surface: 'cli',
+    manifestKernelVersion: '0.1.2',
+    localKernelVersion: '0.1.2',
+    verdict: 'match',
+    actionable: undefined,
+    manifestGeneratorVersion: '0.3.1',
+    localGeneratorVersion: '0.3.1',
+    generatorVerdict: 'match',
+    kernelBackend: undefined,
+    requestedBackend: null,
+    backendReasons: {},
+    ...over,
+  };
+}
+
+describe('diag surfaces the kernel backend (GH #22)', () => {
+  it('prints the resolved backend', () => {
+    const { lines } = formatDiagReport(baseReport({ kernelBackend: 'wasm' }));
+    expect(lines.some(l => /kernel backend:\s+wasm/.test(l))).toBe(true);
+  });
+
+  it('explains why each faster tier was unavailable (the silent-fallback fix)', () => {
+    const { lines } = formatDiagReport(baseReport({
+      kernelBackend: 'js',
+      backendReasons: {
+        native: 'no native package mapping for platform "sunos-x64"',
+        wasm: 'wasm artifact (pkg/ruflo_kernel_wasm.js) not present',
+      },
+    }));
+    const text = lines.join('\n');
+    expect(text).toMatch(/kernel backend:\s+js/);
+    expect(text).toMatch(/native unavailable — no native package mapping/);
+    expect(text).toMatch(/wasm unavailable — wasm artifact/);
+  });
+
+  it('shows the requested backend when METAHARNESS_KERNEL_BACKEND is set', () => {
+    const { lines } = formatDiagReport(baseReport({ kernelBackend: 'js', requestedBackend: 'native' }));
+    expect(lines.some(l => /kernel backend:\s+js\s+\[requested: native\]/.test(l))).toBe(true);
+  });
+
+  it('does NOT claim the tier that answered is unavailable', () => {
+    // native answered — even if a stale reason were present, we must not print it.
+    const { lines } = formatDiagReport(baseReport({
+      kernelBackend: 'native',
+      backendReasons: { native: 'should-not-appear' },
+    }));
+    expect(lines.join('\n')).not.toMatch(/native unavailable/);
+  });
+
+  it('reports "(not loadable)" when no backend could be resolved and none was requested', () => {
+    const { lines } = formatDiagReport(baseReport({ kernelBackend: undefined, requestedBackend: null }));
+    expect(lines.some(l => /kernel backend:\s+\(not loadable/.test(l))).toBe(true);
+  });
+
+  it('distinguishes a requested-but-unavailable backend from an uninstalled kernel', () => {
+    const { lines } = formatDiagReport(baseReport({
+      kernelBackend: undefined,
+      requestedBackend: 'wasm',
+      backendReasons: { wasm: 'kernel backend "wasm" was requested but is unavailable: ...' },
+    }));
+    const text = lines.join('\n');
+    expect(text).toMatch(/kernel backend:\s+\(requested backend unavailable/);
+    expect(text).toMatch(/\[requested: wasm\]/);
+    expect(text).not.toMatch(/kernel not installed/);
+  });
+});
+
+describe('buildDiagReport resolves a real backend (GH #22 integration)', () => {
+  const prev = process.env.METAHARNESS_KERNEL_BACKEND;
+  afterEach(() => {
+    if (prev === undefined) delete process.env.METAHARNESS_KERNEL_BACKEND;
+    else process.env.METAHARNESS_KERNEL_BACKEND = prev;
+  });
+
+  it('honors METAHARNESS_KERNEL_BACKEND=js end-to-end and never throws', async () => {
+    process.env.METAHARNESS_KERNEL_BACKEND = 'js';
+    const dir = await mkdtemp(join(tmpdir(), 'cah-diag-'));
+    const report = await buildDiagReport(dir);
+    expect(report.requestedBackend).toBe('js');
+    expect(report.backendReasons).toBeTypeOf('object');
+    // The js floor is always loadable when the kernel resolves. If the workspace
+    // kernel can't be resolved in this environment at all, backend is undefined —
+    // but buildDiagReport must never throw regardless.
+    if (report.kernelBackend !== undefined) {
+      expect(report.kernelBackend).toBe('js');
+    }
+  });
+});

--- a/packages/create-agent-harness/src/diag.ts
+++ b/packages/create-agent-harness/src/diag.ts
@@ -20,7 +20,7 @@ import { createRequire } from 'node:module';
 import { readFile } from 'node:fs/promises';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 /** Mirror of subcommands.ts's exported shape — kept local to avoid a
  *  cyclic import (subcommands.ts imports from diag.ts via diagCmd). */
 export type SubcommandResult = { code: number; lines: string[] };
@@ -50,6 +50,69 @@ export function skewVerdict(manifestVer: string | undefined, localVer: string | 
   if (m.minor !== l.minor) return 'minor-diff';
   if (m.patch !== l.patch) return 'patch-diff';
   return 'match';
+}
+
+/** GH #22: the kernel backend that actually answered on this machine. */
+export type KernelBackendTier = 'native' | 'wasm' | 'js';
+
+/**
+ * GH #22: resolve WHICH kernel backend the harness actually loads on this
+ * machine (native > wasm > js), the backend explicitly requested via
+ * METAHARNESS_KERNEL_BACKEND (if any), and the reason each higher tier was
+ * unavailable. The version diagnostic above answers "is the kernel the right
+ * VERSION?"; this answers "am I getting the FAST kernel, and if not, why not?"
+ * — the #1 support question after version skew (silent js fallback, GH #22).
+ *
+ * Never throws — consistent with the rest of diag. Two ways the fast path is
+ * absent are BOTH captured: (a) auto mode fell through to js → `kernelDiagnostics`
+ * carries the per-tier reasons; (b) a specific backend was REQUESTED but can't
+ * load → `loadKernel` throws, and we surface that throw under the requested tier
+ * (that throw message IS the diagnostic the operator asked for).
+ */
+async function resolveKernelBackend(harnessDir: string): Promise<{
+  backend: KernelBackendTier | undefined;
+  requested: string | null;
+  reasons: { native?: string; wasm?: string };
+}> {
+  const requested = (process.env.METAHARNESS_KERNEL_BACKEND || '').trim().toLowerCase() || null;
+  const entry = resolveKernelEntry(harnessDir);
+  if (!entry) return { backend: undefined, requested, reasons: {} };
+  try {
+    const mod = (await import(pathToFileURL(entry).href)) as {
+      kernelDiagnostics?: () => Promise<{
+        resolved: KernelBackendTier;
+        requested: string | null;
+        reasons: { native?: string; wasm?: string };
+      }>;
+    };
+    if (typeof mod.kernelDiagnostics === 'function') {
+      const d = await mod.kernelDiagnostics();
+      return { backend: d.resolved, requested: d.requested ?? requested, reasons: d.reasons ?? {} };
+    }
+    // Kernel present but predates kernelDiagnostics() (GH #22) — can't report the backend.
+    return { backend: undefined, requested, reasons: {} };
+  } catch (e) {
+    // A REQUESTED-but-unavailable backend makes loadKernel throw — capture that
+    // reason under the requested tier so the operator sees exactly why.
+    const reasons: { native?: string; wasm?: string } = {};
+    if (requested === 'native' || requested === 'wasm') reasons[requested] = (e as Error).message;
+    return { backend: undefined, requested, reasons };
+  }
+}
+
+/**
+ * Resolve the @metaharness/kernel entry module the same way we resolve its
+ * version — from the harness's own node_modules first, then the workspace
+ * checkout — so the reported backend matches the kernel the harness loads.
+ */
+function resolveKernelEntry(harnessDir: string): string | undefined {
+  try {
+    const require = createRequire(join(harnessDir, 'package.json'));
+    return require.resolve('@metaharness/kernel');
+  } catch {
+    const wsEntry = resolve(__dirname, '..', '..', 'kernel-js', 'dist', 'index.js');
+    return existsSync(wsEntry) ? wsEntry : undefined;
+  }
 }
 
 /**
@@ -131,6 +194,13 @@ export interface DiagReport {
   manifestGeneratorVersion: string | undefined;
   localGeneratorVersion: string | undefined;
   generatorVerdict: SkewVerdict;
+  // GH #22: which kernel backend actually answers on this machine (native/wasm/js),
+  // the backend requested via METAHARNESS_KERNEL_BACKEND (null if unset), and why a
+  // higher tier was unavailable. `kernelBackend` is undefined when the kernel can't
+  // be loaded at all (not installed, or a requested backend that threw).
+  kernelBackend: KernelBackendTier | undefined;
+  requestedBackend: string | null;
+  backendReasons: { native?: string; wasm?: string };
 }
 
 export async function buildDiagReport(harnessDir: string): Promise<DiagReport> {
@@ -155,6 +225,7 @@ export async function buildDiagReport(harnessDir: string): Promise<DiagReport> {
   const verdict = skewVerdict(manifestKernelVersion, localKernelVersion);
   const localGeneratorVersion = resolveLocalGeneratorVersion();
   const generatorVerdict = skewVerdict(manifestGeneratorVersion, localGeneratorVersion);
+  const kb = await resolveKernelBackend(harnessDir);
   let actionable: string | undefined;
   if (verdict === 'major-diff') {
     actionable = `Run: npm install @metaharness/kernel@${manifestKernelVersion} (major skew — APIs may break)`;
@@ -175,6 +246,9 @@ export async function buildDiagReport(harnessDir: string): Promise<DiagReport> {
     manifestGeneratorVersion,
     localGeneratorVersion,
     generatorVerdict,
+    kernelBackend: kb.backend,
+    requestedBackend: kb.requested,
+    backendReasons: kb.reasons,
   };
 }
 
@@ -195,6 +269,23 @@ export function formatDiagReport(report: DiagReport): SubcommandResult {
   lines.push(`  surface:              ${report.surface ?? '(unknown — pre-iter-56 manifest)'}`);
   lines.push(`  manifest kernel:      ${report.manifestKernelVersion ?? '(unset — pre-iter-58 manifest)'}`);
   lines.push(`  installed kernel:     ${report.localKernelVersion ?? '(not installed)'}`);
+  // GH #22: which backend actually answers + (if a specific one was requested) that request.
+  const reqSuffix = report.requestedBackend ? `  [requested: ${report.requestedBackend}]` : '';
+  // When no backend resolved, the reason differs: a REQUESTED tier that threw
+  // (kernel is installed, that tier just isn't) vs. the kernel not resolving at all.
+  const unresolvedLabel = report.requestedBackend
+    ? '(requested backend unavailable — see below)'
+    : '(not loadable — kernel not installed?)';
+  lines.push(`  kernel backend:       ${report.kernelBackend ?? unresolvedLabel}${reqSuffix}`);
+  // GH #22: WHY the faster tiers didn't answer — the whole point of the issue
+  // (a silent js fallback with no explanation). Only show a tier that failed
+  // AND isn't the one that ended up answering.
+  if (report.backendReasons.native && report.kernelBackend !== 'native') {
+    lines.push(`     native unavailable — ${report.backendReasons.native}`);
+  }
+  if (report.backendReasons.wasm && report.kernelBackend !== 'wasm') {
+    lines.push(`     wasm unavailable — ${report.backendReasons.wasm}`);
+  }
   lines.push(`  manifest generator:   ${report.manifestGeneratorVersion ?? '(unset)'}`);
   lines.push(`  installed generator:  ${report.localGeneratorVersion ?? '(not installed)'}`);
   lines.push('');


### PR DESCRIPTION
## What / why

Closes the primary observed symptom of #22: `harness diag` reported the kernel **version** but never **which backend actually answers** (native/wasm/js). An operator who set `METAHARNESS_KERNEL_BACKEND=wasm`, or simply expected the fast native/wasm path, got the silent `js` floor with **no signal and no reason** — *"doctor → still reports js, silently; nothing tells the operator why."*

The backend-selection env, fail-loud behavior, and `kernelDiagnostics()` all already shipped in `@metaharness/kernel`. This PR wires the **last mile**: the diagnostic command now surfaces them.

## Change
- `buildDiagReport()` calls `kernelDiagnostics()` **defensively** — it never throws; an uninstalled/unloadable kernel just leaves `kernelBackend` undefined (consistent with diag's "a missing kernel is the whole point" philosophy).
- `DiagReport` gains `kernelBackend` / `requestedBackend` / `backendReasons`; these flow into `diag --json` and `diag --bundle` automatically (they spread the report).
- A **requested-but-unavailable** tier makes `loadKernel` throw — that throw message *is* the diagnostic the operator asked for, so it's captured under the requested tier with a distinct `(requested backend unavailable)` label (vs. `(not loadable — kernel not installed?)` when nothing was requested).

## Live-verify (real `harness diag` output)

Auto mode (no env):
```
  kernel backend:       js
     native unavailable — optional dependency "@metaharness/kernel-linux-x64-gnu" not installed (...)
     wasm unavailable — wasm artifact (pkg/ruflo_kernel_wasm.js) not present (...)
```

`METAHARNESS_KERNEL_BACKEND=wasm` (fail-loud):
```
  kernel backend:       (requested backend unavailable — see below)  [requested: wasm]
     wasm unavailable — kernel backend "wasm" was requested but is unavailable: ... Unset METAHARNESS_KERNEL_BACKEND to fall back to js.
```

`--json` carries `kernelBackend` / `requestedBackend` / `backendReasons`.

## Tests
- 7 new tests: surfacing (`formatDiagReport`), end-to-end resolution (`buildDiagReport` honoring `METAHARNESS_KERNEL_BACKEND=js`, never throwing), and the requested-vs-uninstalled label distinction.
- Full `create-agent-harness` suite **361/361**; `tsc` clean.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)