### PR TITLE
fix(publish): fail closed when a present witness signature was never verified (#4 HIGH-1)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/ruvultra/projects/agent-harness-generator/node_modules

--- a/packages/create-agent-harness/__tests__/publish.test.ts
+++ b/packages/create-agent-harness/__tests__/publish.test.ts
@@ -34,6 +34,39 @@ describe('publishHarness (dry-run path)', () => {
   });
 });
 
+// GH #4 (HIGH-1): a present witness whose signature was NOT cryptographically verified (degraded mode —
+// no kernel verifier) must NOT publish silently as "signed". Before the fix the shape-only path returned
+// valid:true, so a shape-valid witness carrying a garbage signature published as verified.
+describe('publishHarness — fail-closed on an unverified witness (GH #4 HIGH-1)', () => {
+  async function harnessWithGarbageWitness(): Promise<string> {
+    const root = await mkdtemp(join(tmpdir(), 'cah-pub-wit-'));
+    await mkdir(join(root, '.harness'), { recursive: true });
+    await writeFile(join(root, '.harness', 'manifest.json'),
+      JSON.stringify({ schema: 1, template: 'minimal', vars: { name: 'demo' } }));
+    // Shape-valid witness with a GARBAGE signature — the exploit input.
+    await writeFile(join(root, '.harness', 'witness.json'), JSON.stringify({
+      schema: 1, harness: 'demo', version: '0.1.0', entries: [],
+      public_key: 'a'.repeat(64), signature: 'b'.repeat(128),
+    }));
+    return root;
+  }
+
+  it('refuses to publish a harness whose witness signature was never checked', async () => {
+    const root = await harnessWithGarbageWitness();
+    await expect(publishHarness({
+      harnessDir: root, pinata: { jwt: 'x' }, confirm: false,
+    })).rejects.toThrow(/NOT cryptographically verified|--allow-unverified-witness/);
+  });
+
+  it('publishes when --allow-unverified-witness is explicitly opted in', async () => {
+    const root = await harnessWithGarbageWitness();
+    const r = await publishHarness({
+      harnessDir: root, pinata: { jwt: 'x' }, confirm: false, allowUnverified: true,
+    });
+    expect(r.manifestCid).toBe('dry-run-no-pin');
+  });
+});
+
 describe('pinJson', () => {
   it('throws on missing JWT', async () => {
     await expect(pinJson({ jwt: '' }, { foo: 'bar' }, { name: 't' }))

--- a/packages/create-agent-harness/src/publish-cmd.ts
+++ b/packages/create-agent-harness/src/publish-cmd.ts
@@ -23,9 +23,13 @@ export async function publishCmd(args: string[]): Promise<SubcommandResult> {
   const positional = args.filter(a => !a.startsWith('--'));
   const dir = resolve(positional[0] ?? process.cwd());
   const confirm = args.includes('--confirm');
+  const allowUnverified = args.includes('--allow-unverified-witness');
   const nameOverride = args.find(a => a.startsWith('--name='))?.slice('--name='.length);
 
   const lines: string[] = [`harness publish — ${dir} ${confirm ? '(CONFIRMED)' : '(DRY-RUN)'}`];
+  if (allowUnverified) {
+    lines.push('  ⚠️  --allow-unverified-witness: the witness signature will NOT be cryptographically checked.');
+  }
 
   if (confirm) {
     const jwt = process.env.PINATA_JWT;
@@ -47,6 +51,7 @@ export async function publishCmd(args: string[]): Promise<SubcommandResult> {
       },
       confirm,
       name: nameOverride,
+      allowUnverified,
     });
     lines.push(`  manifest CID: ${r.manifestCid}`);
     lines.push(`  size: ${r.manifestSize} bytes`);

--- a/packages/create-agent-harness/src/publish.ts
+++ b/packages/create-agent-harness/src/publish.ts
@@ -89,6 +89,12 @@ export interface HarnessPublishOptions {
   confirm: boolean;
   /** Optional override of the harness's name (defaults to manifest.vars.name). */
   name?: string;
+  /**
+   * GH #4 (HIGH-1): explicitly publish even when a present witness could NOT be cryptographically
+   * verified (no verifier available). Off by default — publishing is fail-closed on an unverified
+   * witness so a garbage signature can't masquerade as signed. The signature is NOT checked when set.
+   */
+  allowUnverified?: boolean;
 }
 
 export interface PublishResult {
@@ -127,6 +133,17 @@ export async function publishHarness(opts: HarnessPublishOptions): Promise<Publi
     const { result } = await readAndVerify(witnessPath);
     if (!result.valid) {
       throw new Error(`witness verification failed: ${result.reason ?? 'unknown'}`);
+    }
+    // GH #4 (HIGH-1): a witness whose signature was NOT cryptographically verified (shape-only
+    // degraded mode — no kernel verifier) must NOT be published as "signed". Before this, that path
+    // returned valid:true, so a shape-valid witness carrying a garbage signature published silently as
+    // verified. Fail closed unless the caller explicitly opts in (and is then told the sig was unchecked).
+    if (result.unverified && !opts.allowUnverified) {
+      throw new Error(
+        `witness present at ${witnessPath} but its signature was NOT cryptographically verified ` +
+        `(${result.reason ?? 'no verifier available'}). Refusing to publish this harness as signed. ` +
+        `Re-run with --allow-unverified-witness to publish anyway — the signature will NOT have been checked.`,
+      );
     }
   }
 

--- a/packages/create-agent-harness/src/witness-client.ts
+++ b/packages/create-agent-harness/src/witness-client.ts
@@ -33,6 +33,13 @@ export interface WitnessManifest {
 export interface VerificationResult {
   valid: boolean;
   reason?: string;
+  /**
+   * GH #4 (HIGH-1): true when the manifest passed SHAPE checks but its signature was NOT
+   * cryptographically verified (no kernel `witnessVerify` available — the shape-only degraded mode).
+   * `valid` stays true so read-only diagnostics (`verify`/`doctor`) keep reporting shape validity, but a
+   * caller that acts on the signature (publish) MUST treat `unverified` as "not actually signed".
+   */
+  unverified?: boolean;
 }
 
 /**
@@ -83,7 +90,11 @@ export async function verifyWitness(manifest: unknown): Promise<VerificationResu
     // truth; local-dev can skip the crypto verify).
   }
 
-  return { valid: true, reason: 'shape verified; kernel not loaded (degraded)' };
+  return {
+    valid: true,
+    unverified: true,
+    reason: 'shape verified; kernel witnessVerify unavailable — signature NOT cryptographically checked (degraded)',
+  };
 }
 
 /**


### PR DESCRIPTION
## What / why

Fixes **HIGH-1** from the AQE beta-feedback (#4). Witness verification is a **guaranteed no-op**: no kernel backend exposes `witnessVerify`, so `witness-client.ts`'s crypto-verify delegate always falls through to the shape-only **degraded** path, which returned `{valid:true}`. `publish.ts` only threw on `!valid`, so a shape-valid `witness.json` carrying a **garbage signature** (64-hex key, 128-hex sig, schema 1) sailed through and the harness published as *"signed"* — a signature that was **never checked**.

## Change (JS-only — closes the publish exploit without the native verifier)
- `witness-client.ts`: `VerificationResult` gains `unverified?: boolean`; the degraded path sets it. **`valid` stays `true`** so read-only `verify`/`doctor` diagnostics are unchanged (they only assert shape).
- `publish.ts`: a **present-but-unverified** witness now **fails closed** — *"Refusing to publish this harness as signed"* — unless the caller passes `allowUnverified`, which then warns the signature was not checked.
- `publish-cmd.ts`: `--allow-unverified-witness` flag + a loud warning line.

## Live-verify (real `harness publish`)
Shape-valid witness, garbage 128-hex signature:
```
FAIL: witness present at …/witness.json but its signature was NOT cryptographically verified …
      Refusing to publish this harness as signed. Re-run with --allow-unverified-witness …
```
With `--allow-unverified-witness`: proceeds (dry-run) after the ⚠️ warning.

## Tests
- 2 new (`publish.test.ts`): the garbage-sig witness is refused; `allowUnverified` lets it proceed.
- The degraded `verify` test still reports `VALID` (diagnostics unchanged).
- Full `create-agent-harness` suite **363/363**; `tsc` clean.

## Not in this PR (native-publish-gated)
Wiring a **real** `witnessVerify` through NAPI+WASM so a *genuine* signature can actually be cryptographically checked (the rest of HIGH-1's fix). Until then, publishing a "signed" harness requires the explicit `--allow-unverified-witness` acknowledgement — no silent false "verified" claim.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)