### PR TITLE
test(renderer): pin the {{var}} injection-safety charset so a loosening can't slip in (#4)

### DIFF
--- a/packages/create-agent-harness/__tests__/renderer.test.ts
+++ b/packages/create-agent-harness/__tests__/renderer.test.ts
@@ -30,6 +30,22 @@ describe('render', () => {
     expect(render('{{x}}-{{x}}-{{x}}', { x: 'a' }).output).toBe('a-a-a');
   });
 
+  // GH #4 (mutation finding): the {{var}} name charset is deliberately strict —
+  // `[a-zA-Z_][a-zA-Z0-9_]*` — so a template can't reference dotted/hyphenated/leading-digit keys
+  // (e.g. `{{a.b}}`, `{{../x}}`, path-like or prototype-walking names). Mutation testing showed the
+  // regex can be loosened to admit `.`/`-`/leading-digit and every existing test still passes. These
+  // pin the boundary: such tokens must be left LITERAL (not interpolated), even when vars would match.
+  it('does NOT interpolate dotted/hyphenated/leading-digit names (injection-safety, #4)', () => {
+    // A loosened regex would substitute these; the strict one leaves them untouched.
+    const dotted = render('{{foo.bar}}', { 'foo.bar': 'INJECTED', foo: 'X' });
+    expect(dotted.output).toBe('{{foo.bar}}');
+    expect(dotted.unresolved).toEqual([]);   // no var matched at all
+
+    expect(render('{{foo-bar}}', { 'foo-bar': 'INJECTED' }).output).toBe('{{foo-bar}}');
+    expect(render('{{1foo}}', { '1foo': 'INJECTED' }).output).toBe('{{1foo}}');
+    expect(render('{{a b}}', { 'a b': 'INJECTED' }).output).toBe('{{a b}}');
+  });
+
   it('ignores malformed braces', () => {
     // Single braces shouldn't trigger substitution.
     expect(render('{name}', { name: 'x' }).output).toBe('{name}');
@@ -43,6 +59,11 @@ describe('extractVarReferences', () => {
 
   it('returns [] when no vars are referenced', () => {
     expect(extractVarReferences('no template vars')).toEqual([]);
+  });
+
+  // GH #4: same strict charset as render() — dotted/hyphenated/leading-digit tokens are not references.
+  it('does not extract dotted/hyphenated/leading-digit tokens (#4)', () => {
+    expect(extractVarReferences('{{a.b}} {{c-d}} {{1e}}')).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## What / why

Closes a mutation-surfaced test gap from the AQE beta feedback (#4). `render()` / `extractVarReferences` use a deliberately **strict** var-name charset — `[a-zA-Z_][a-zA-Z0-9_]*` — so a template can't reference dotted / hyphenated / leading-digit keys (`{{a.b}}`, `{{../x}}`, prototype-walking or path-like names). Mutation testing showed the regex can be **loosened** to admit `.`/`-`/leading-digit and **every existing test still passes** — the tests only cover valid names, whitespace, coercion, and malformed braces, never the boundary.

## Change (test-only)
- `render()` leaves `{{foo.bar}}` / `{{foo-bar}}` / `{{1foo}}` / `{{a b}}` **literal** (not interpolated), even when a matching key is present in `vars`, and reports them as un-matched (not `unresolved`).
- `extractVarReferences('{{a.b}} {{c-d}} {{1e}}') === []`.

## Mutation-kill verified
Loosening the charset to `[a-zA-Z0-9_.-]+` makes both new tests **fail**; they pass on the real code. (Verified locally, then reverted.)

## Tests
Full `create-agent-harness` suite **383/383**; `tsc` clean. No behaviour change.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)