### PR TITLE
test(witness): pin shape-gate boundaries so a relaxed bound can't accept malformed witnesses (#4)

### DIFF
--- a/packages/create-agent-harness/__tests__/witness-client.test.ts
+++ b/packages/create-agent-harness/__tests__/witness-client.test.ts
@@ -58,6 +58,37 @@ describe('verifyWitness — shape gate', () => {
     });
     expect(r.valid).toBe(true);
   });
+
+  // GH #4 (mutation finding): the length/schema gates use EXACT checks (=== 64 / === 128 / === 1).
+  // The existing tests only cover UNDER-length ('short') and schema 999, so a boundary mutant that
+  // relaxes `!== 64` → `< 64` (or `!== 1` → `> 1`) would accept OVER-length keys/sigs and schema 0/
+  // negative and survive. These pin the OTHER side of each boundary.
+  describe('boundary bounds (mutation guard, #4)', () => {
+    const base = {
+      schema: 1, harness: 'x', version: '0.1.0', entries: [],
+      public_key: 'a'.repeat(64), signature: 'b'.repeat(128),
+    };
+
+    it('rejects an OVER-length public_key (65)', async () => {
+      const r = await verifyWitness({ ...base, public_key: 'a'.repeat(65) });
+      expect(r.valid).toBe(false);
+      expect(r.reason).toMatch(/public_key/);
+    });
+
+    it('rejects an OVER-length signature (129)', async () => {
+      const r = await verifyWitness({ ...base, signature: 'b'.repeat(129) });
+      expect(r.valid).toBe(false);
+      expect(r.reason).toMatch(/signature/);
+    });
+
+    it('rejects schema 0 and negative (not just >1)', async () => {
+      for (const schema of [0, -1]) {
+        const r = await verifyWitness({ ...base, schema });
+        expect(r.valid).toBe(false);
+        expect(r.reason).toMatch(/schema/);
+      }
+    });
+  });
 });
 
 describe('findWitness', () => {


### PR DESCRIPTION
## What / why

Closes the last mutation-surfaced test gap from the AQE beta feedback (#4). `verifyWitness`'s shape gate uses **exact** checks — `public_key.length === 64`, `signature.length === 128`, `schema === 1` — but the existing tests only cover **under-length** keys/sigs (`'short'`) and `schema: 999`. So a boundary mutant that relaxes `!== 64` → `< 64` (or `!== 1` → `> 1`) would accept **over-length** keys/sigs and **schema 0/negative** and survive the suite.

## Change (test-only)
Pins the other side of each boundary:
- over-length `public_key` (65 chars) is rejected
- over-length `signature` (129 chars) is rejected
- `schema` 0 and -1 are rejected

## Mutation-kill verified
The over-length-key test **fails** under `!== 64` → `< 64`; the schema test **fails** under `!== 1` → `> 1`; both pass on the real code. (Verified locally, then reverted.)

## Tests
Full `create-agent-harness` suite **384/384**; `tsc` clean. No behaviour change. This completes the #4 mutation-guard set (mcp-scan severity #125, renderer charset #126, witness bounds here).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)