### PR TITLE
ci: add timeout-minutes to every matrix job so a hung job can't block merges for 6h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,10 @@ jobs:
   rust:
     name: Rust / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    # No CI job should be able to hang for the 6h GitHub default — a slow/stuck Windows `cargo test`
+    # once blocked every open PR from merging. Generous ceiling (observed worst ~45min) that fails a
+    # genuinely-hung job fast enough to rerun, without false-failing a legitimately-slow run.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -64,6 +68,7 @@ jobs:
   wasm:
     name: WASM / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -117,6 +122,7 @@ jobs:
   node:
     name: Node ${{ matrix.node }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: [wasm]
     strategy:
       fail-fast: false
@@ -177,6 +183,7 @@ jobs:
   pack-install:
     name: pack+install / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     needs: [node]
     strategy:
       fail-fast: false
@@ -204,6 +211,7 @@ jobs:
   bench:
     name: Bench (smoke)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [node]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What / why

The CI matrix jobs (`rust`, `wasm`, `node`, `pack-install`, `bench`) had **no `timeout-minutes`**, so they inherit GitHub's **360-minute (6h)** default. When a Windows `cargo test` ran slow/stuck recently, it left **every open PR un-mergeable** with no fail-fast signal — you couldn't distinguish a hung job from a slow one, and nothing would end it short of the 6h cap.

## Change (config-only)
A generous per-job ceiling, set well above each job's observed duration so a legitimately-slow run **never false-fails**, while a genuinely-hung one fails fast enough to rerun:

| job | timeout | rationale |
|---|---|---|
| rust | 90 | observed worst ~45min on Windows → 2× margin |
| wasm | 45 | |
| node / pack-install | 30 | JS suites, minutes even on Windows |
| bench | 20 | synthetic corpus |

No gate is weakened — a timeout only bounds runtime, caps the worst case at 90min instead of 360, and makes a true hang a visible, rerunnable failure. YAML validated (all 6 jobs parse).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)