### PR TITLE
feat(cli): signed Meta-Proxy routing and worktree policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4344,7 +4344,7 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@metaharness/darwin": "^0.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4344,7 +4344,7 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "dependencies": {
         "@metaharness/darwin": "^0.2.2",

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -77,6 +77,28 @@ They are **not interchangeable**. A consumer wiring one into a pipeline expectin
 branch on `schema` (`typeof out.schema === 'string'` ⇒ harness badges; `=== 1` ⇒ metaharness
 scorecard) and refuse the wrong shape rather than silently defaulting missing fields to `0`.
 
+## Optional Cognitum Meta-Proxy sidecar
+
+Meta-Proxy is an optional local Rust sidecar, not an npm dependency and not part
+of normal harness scaffolding. Install it only when you want a locally bound,
+Claude-compatible routing endpoint with Meta-Proxy's own Cognitum OAuth flow:
+
+```bash
+npx metaharness proxy install --yes   # signed v0.3.0 download; checksum + Ed25519 verified
+npx metaharness proxy login           # browser or headless Cognitum OAuth, owned by Meta-Proxy
+npx metaharness proxy start
+npx metaharness proxy status
+```
+
+`proxy install` downloads the platform archive from the public
+[`meta-proxy-dist`](https://github.com/cognitum-one/meta-proxy-dist) release
+channel only after explicit `--yes` consent. The CLI verifies the signed
+`SHA256SUMS` manifest against a public key pinned in MetaHarness before it
+extracts or replaces a binary. The sidecar is installed under
+`~/.metaharness/meta-proxy/`; credentials remain in Meta-Proxy's own storage.
+
+Other commands: `proxy stop`, `proxy path`, and `proxy logout`.
+
 ## Eject from ruflo
 
 If you've been using ruflo and want your own focused harness from it:

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -84,11 +84,38 @@ of normal harness scaffolding. Install it only when you want a locally bound,
 Claude-compatible routing endpoint with Meta-Proxy's own Cognitum OAuth flow:
 
 ```bash
-npx metaharness proxy install --yes   # signed v0.3.0 download; checksum + Ed25519 verified
-npx metaharness proxy login           # browser or headless Cognitum OAuth, owned by Meta-Proxy
-npx metaharness proxy start
-npx metaharness proxy status
+npx metaharness proxy install --yes   # signed v0.4.0 download; checksum + Ed25519 verified
+npx metaharness proxy run -- claude   # starts the sidecar and routes this Claude session through it
+npx metaharness proxy run --policy critical -- claude -p "review this migration"
 ```
+
+`proxy run` is the activation path: it supplies `ANTHROPIC_BASE_URL` and the
+local proxy bearer token only to the child process. It does not modify global
+Claude settings, project files, or persisted client configuration. With the
+Meta-Proxy automatic-failover release installed, ordinary requests use the
+user's Claude Passthrough identity; trusted rate-limit telemetry can then
+select consented Cloud or Sponsored capacity per request. Cognitum login is
+needed only for Cloud routing, not for installation or normal Passthrough.
+
+Use `npx metaharness proxy login` to authorize Cognitum Cloud routing, and
+`npx metaharness proxy status` to inspect the managed sidecar.
+
+### Per-worktree routing policy
+
+`proxy run` attaches a short-lived, HMAC-signed local capability to the
+launched process. The policy is scoped to a one-way fingerprint of the current
+worktree; neither its path nor repository metadata leaves the machine.
+
+- `critical` — suppress automatic Power Saver and Sponsored failover for this
+  worktree. Explicit manual controls still apply.
+- `standard` — the normal automatic policy: Power Saver at 80% utilization,
+  Sponsored only after exhaustion and only with consent.
+- `economy` — Power Saver may start at 60% utilization; it retains all consent
+  gates and the Sponsored-at-exhaustion limit.
+
+The capability is verified by Meta-Proxy, not inferred from `.claude`, a Git
+branch name, or any repository-controlled file. Meta-Proxy v0.4.0 or later is
+required for per-worktree policies; older releases reject the scoped token.
 
 `proxy install` downloads the platform archive from the public
 [`meta-proxy-dist`](https://github.com/cognitum-one/meta-proxy-dist) release

--- a/packages/create-agent-harness/__tests__/meta-proxy.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy.test.ts
@@ -3,14 +3,21 @@ import { describe, expect, it } from 'vitest';
 
 import {
   META_PROXY_VERSION,
+  createMetaProxyPolicyToken,
   isValidReleaseVersion,
+  metaProxyClientEnvironment,
   metaProxyCmd,
+  metaProxyEndpoint,
   parseSha256Sums,
   resolveMetaProxyAsset,
   sha256Hex,
   verifyMetaProxyChecksum,
   verifyMetaProxyManifest,
+  worktreeFingerprint,
 } from '../src/meta-proxy.js';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 describe('optional Meta-Proxy integration', () => {
   it('maps each supported platform to the signed v0.3.0 asset name', () => {
@@ -50,6 +57,42 @@ describe('optional Meta-Proxy integration', () => {
 
     const help = await metaProxyCmd(['help']);
     expect(help.code).toBe(0);
-    expect(help.lines.join('\n')).toMatch(/install.*status.*start.*stop.*login.*logout/i);
+    expect(help.lines.join('\n')).toMatch(/install.*status.*start.*stop.*login.*logout.*run/i);
+  });
+
+  it('passes the local proxy token only to a literal loopback endpoint', () => {
+    const home = mkdtempSync(join(tmpdir(), 'metaharness-proxy-env-'));
+    const priorState = process.env.RUFLO_STATE_DIR;
+    try {
+      const state = join(home, '.ruflo');
+      mkdirSync(state, { recursive: true });
+      process.env.RUFLO_STATE_DIR = state;
+      writeFileSync(join(state, 'proxy-token'), 'local-token\n');
+      writeFileSync(join(state, 'proxy-config.toml'), 'bind = "127.0.0.1:22435"\n');
+
+      expect(metaProxyEndpoint(home)).toBe('http://127.0.0.1:22435');
+      expect(metaProxyClientEnvironment(home)).toEqual({
+        ANTHROPIC_BASE_URL: 'http://127.0.0.1:22435',
+        ANTHROPIC_AUTH_TOKEN: 'local-token',
+      });
+
+      writeFileSync(join(state, 'proxy-config.toml'), 'bind = "0.0.0.0:11435"\n');
+      expect(() => metaProxyEndpoint(home)).toThrow(/non-loopback/i);
+    } finally {
+      if (priorState === undefined) delete process.env.RUFLO_STATE_DIR;
+      else process.env.RUFLO_STATE_DIR = priorState;
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('mints a scoped, signed worktree policy capability without exposing a path', () => {
+    const token = createMetaProxyPolicyToken('local-proxy-secret', 'economy', worktreeFingerprint('C:/tmp/herd/agent-a'), 0);
+    const [prefix, encoded, signature] = token.split('.');
+    expect(prefix).toBe('mh1');
+    expect(signature).toMatch(/^[A-Za-z0-9_-]+$/);
+    const claim = JSON.parse(Buffer.from(encoded!, 'base64url').toString('utf8'));
+    expect(claim).toMatchObject({ policy: 'economy', exp: 28_800 });
+    expect(claim.worktree).toMatch(/^[a-f0-9]{32}$/);
+    expect(JSON.stringify(claim)).not.toContain('C:/tmp/herd/agent-a');
   });
 });

--- a/packages/create-agent-harness/__tests__/meta-proxy.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+import { describe, expect, it } from 'vitest';
+
+import {
+  META_PROXY_VERSION,
+  isValidReleaseVersion,
+  metaProxyCmd,
+  parseSha256Sums,
+  resolveMetaProxyAsset,
+  sha256Hex,
+  verifyMetaProxyChecksum,
+  verifyMetaProxyManifest,
+} from '../src/meta-proxy.js';
+
+describe('optional Meta-Proxy integration', () => {
+  it('maps each supported platform to the signed v0.3.0 asset name', () => {
+    expect(resolveMetaProxyAsset('win32', 'x64')).toMatchObject({
+      target: 'x86_64-pc-windows-msvc',
+      archive: 'zip',
+      assetName: `meta-proxy-${META_PROXY_VERSION}-x86_64-pc-windows-msvc.zip`,
+    });
+    expect(resolveMetaProxyAsset('darwin', 'arm64').assetName).toContain('aarch64-apple-darwin.tar.gz');
+    expect(resolveMetaProxyAsset('linux', 'x64').assetName).toContain('x86_64-unknown-linux-gnu.tar.gz');
+    expect(() => resolveMetaProxyAsset('freebsd', 'x64')).toThrow(/No signed Meta-Proxy release/);
+  });
+
+  it('only accepts release version values, never arbitrary path-like input', () => {
+    expect(isValidReleaseVersion('0.3.0')).toBe(true);
+    expect(isValidReleaseVersion('1.2.3-rc.1')).toBe(true);
+    expect(isValidReleaseVersion('../0.3.0')).toBe(false);
+    expect(isValidReleaseVersion('v0.3.0')).toBe(false);
+    expect(isValidReleaseVersion('0.3.0/../../other')).toBe(false);
+  });
+
+  it('checks both the named archive checksum and the signature gate', () => {
+    const archive = Buffer.from('trusted-release-bytes');
+    const asset = 'meta-proxy-0.3.0-x86_64-pc-windows-msvc.zip';
+    const sums = Buffer.from(`${sha256Hex(archive)}  ${asset}\n`);
+
+    expect(parseSha256Sums(sums.toString())).toEqual(new Map([[asset, sha256Hex(archive)]]));
+    expect(verifyMetaProxyChecksum(archive, asset, sums)).toBe(true);
+    expect(verifyMetaProxyChecksum(Buffer.from('tampered'), asset, sums)).toBe(false);
+    expect(verifyMetaProxyManifest(sums, 'not-a-valid-ed25519-signature')).toBe(false);
+  });
+
+  it('requires explicit consent before a binary download and documents the optional surface', async () => {
+    const refused = await metaProxyCmd(['install']);
+    expect(refused.code).toBe(2);
+    expect(refused.lines.join('\n')).toMatch(/explicit consent/i);
+
+    const help = await metaProxyCmd(['help']);
+    expect(help.code).toBe(0);
+    expect(help.lines.join('\n')).toMatch(/install.*status.*start.*stop.*login.*logout/i);
+  });
+});

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/src/index.ts
+++ b/packages/create-agent-harness/src/index.ts
@@ -629,6 +629,14 @@ async function runMetaHarnessSubcommand(sub: string, rest: string[]): Promise<nu
       for (const line of r.lines) console.log(line);
       return r.code;
     }
+    case 'proxy': {
+      // Optional Meta-Proxy integration. The signed Rust sidecar is downloaded
+      // only through its explicit `install --yes` command, never while scaffolding.
+      const { metaProxyCmd } = await import('./meta-proxy.js');
+      const r = await metaProxyCmd(rest);
+      for (const line of r.lines) console.log(line);
+      return r.code;
+    }
     default:
       return null; // not a known subcommand
   }
@@ -710,6 +718,7 @@ export async function main(argv: string[]): Promise<number> {
     console.log('       npx metaharness analyze <repo>           (recommend a harness plan, no-exec)');
     console.log('       npx metaharness genome <repo>            (7-section repo readiness)');
     console.log('       npx metaharness learn --host <h> --model <m> --slice <manifest>   (ADR-235 GEPA learning run — $0 dry-run by default, --run to spend; needs a repo checkout)');
+    console.log('       npx metaharness proxy <install|status|start|stop|path|login|logout>  (optional signed Cognitum Meta-Proxy sidecar)');
     console.log('       npx metaharness --from-existing [./path]');
     console.log('       npx metaharness --wizard          (iter 100 — interactive picker)');
     console.log('       npx metaharness --list            (browse all templates)');

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -1,0 +1,386 @@
+/**
+ * Optional Meta-Proxy integration for the published `metaharness` CLI.
+ *
+ * Meta-Proxy is deliberately not an npm dependency: it is a separately released
+ * Rust binary. This module downloads its public, signed release only when the
+ * user explicitly asks for `metaharness proxy install --yes`, verifies the
+ * signed SHA256 manifest with a pinned Ed25519 public key, and then installs it
+ * under the user's MetaHarness state directory.
+ */
+import { spawn, spawnSync } from 'node:child_process';
+import { createHash, createPublicKey, verify as verifySignature } from 'node:crypto';
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
+
+export const META_PROXY_VERSION = '0.3.0';
+export const META_PROXY_RELEASE_BASE = 'https://github.com/cognitum-one/meta-proxy-dist/releases/download';
+
+/** The release signing key, pinned in the client rather than fetched from GitHub. */
+export const META_PROXY_SIGNING_PUBKEY_PEM = `-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAjhLDomjIGdcltYC7j+aiESQFD4LWoHaULietG1PuDjw=
+-----END PUBLIC KEY-----
+`;
+
+export interface PlatformAsset {
+  target: string;
+  archive: 'tar.gz' | 'zip';
+  assetName: string;
+}
+
+const PLATFORM_TABLE: Record<string, { target: string; archive: PlatformAsset['archive'] }> = {
+  'darwin-arm64': { target: 'aarch64-apple-darwin', archive: 'tar.gz' },
+  'darwin-x64': { target: 'x86_64-apple-darwin', archive: 'tar.gz' },
+  'linux-arm64': { target: 'aarch64-unknown-linux-gnu', archive: 'tar.gz' },
+  'linux-x64': { target: 'x86_64-unknown-linux-gnu', archive: 'tar.gz' },
+  'win32-x64': { target: 'x86_64-pc-windows-msvc', archive: 'zip' },
+};
+
+export function resolveMetaProxyAsset(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+  version = META_PROXY_VERSION,
+): PlatformAsset {
+  const entry = PLATFORM_TABLE[`${platform}-${arch}`];
+  if (!entry) {
+    throw new Error(
+      `No signed Meta-Proxy release for ${platform}-${arch}. Supported: ${Object.keys(PLATFORM_TABLE).join(', ')}.`,
+    );
+  }
+  return {
+    ...entry,
+    assetName: `meta-proxy-${version}-${entry.target}.${entry.archive}`,
+  };
+}
+
+export function isValidReleaseVersion(value: string): boolean {
+  return /^\d+\.\d+\.\d+(?:[-+][A-Za-z0-9.-]+)?$/.test(value);
+}
+
+export function sha256Hex(bytes: Buffer): string {
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+export function parseSha256Sums(text: string): Map<string, string> {
+  const entries = new Map<string, string>();
+  for (const line of text.split(/\r?\n/)) {
+    const match = line.trim().match(/^([0-9a-fA-F]{64})[ \t]+\*?(.+)$/);
+    if (match) entries.set(match[2]!.trim(), match[1]!.toLowerCase());
+  }
+  return entries;
+}
+
+export function verifyMetaProxyChecksum(archive: Buffer, assetName: string, sums: Buffer): boolean {
+  return parseSha256Sums(sums.toString('utf8')).get(assetName) === sha256Hex(archive);
+}
+
+/** Verify the raw SHA256SUMS bytes against the pinned Ed25519 release key. */
+export function verifyMetaProxyManifest(sums: Buffer, signatureBase64: string): boolean {
+  try {
+    const signature = Buffer.from(signatureBase64.trim(), 'base64');
+    return signature.length > 0 && verifySignature(null, sums, createPublicKey(META_PROXY_SIGNING_PUBKEY_PEM), signature);
+  } catch {
+    return false;
+  }
+}
+
+export function metaProxyDataDir(home = homedir()): string {
+  return process.env.METAHARNESS_META_PROXY_DIR?.trim() || join(home, '.metaharness', 'meta-proxy');
+}
+
+export function metaProxyBinaryPath(
+  platform: NodeJS.Platform = process.platform,
+  home = homedir(),
+): string {
+  return join(metaProxyDataDir(home), 'bin', platform === 'win32' ? 'meta-proxy.exe' : 'meta-proxy');
+}
+
+function pidPath(home = homedir()): string {
+  return join(metaProxyDataDir(home), 'meta-proxy.pid');
+}
+
+function versionPath(bin: string): string {
+  return `${bin}.version`;
+}
+
+export interface FetchResponse {
+  ok: boolean;
+  status: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+}
+
+export type Fetcher = (url: string) => Promise<FetchResponse>;
+
+export interface InstallMetaProxyOptions {
+  version?: string;
+  releaseBase?: string;
+  platform?: NodeJS.Platform;
+  arch?: string;
+  home?: string;
+  fetcher?: Fetcher;
+}
+
+export interface MetaProxyInstallResult {
+  ok: boolean;
+  message: string;
+  binaryPath?: string;
+  version?: string;
+}
+
+async function fetchBytes(fetcher: Fetcher, url: string): Promise<Buffer | null> {
+  try {
+    const response = await fetcher(url);
+    return response.ok ? Buffer.from(await response.arrayBuffer()) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Download, authenticate, extract, and atomically install a Meta-Proxy release. */
+export async function installMetaProxy(options: InstallMetaProxyOptions = {}): Promise<MetaProxyInstallResult> {
+  const version = options.version ?? META_PROXY_VERSION;
+  if (!isValidReleaseVersion(version)) return { ok: false, message: `Invalid Meta-Proxy version "${version}".` };
+
+  let asset: PlatformAsset;
+  try {
+    asset = resolveMetaProxyAsset(options.platform, options.arch, version);
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  }
+
+  const base = `${(options.releaseBase ?? META_PROXY_RELEASE_BASE).replace(/\/$/, '')}/v${version}`;
+  const fetcher = options.fetcher ?? (globalThis.fetch as unknown as Fetcher);
+  const [archive, sums, signature] = await Promise.all([
+    fetchBytes(fetcher, `${base}/${asset.assetName}`),
+    fetchBytes(fetcher, `${base}/SHA256SUMS`),
+    fetchBytes(fetcher, `${base}/SHA256SUMS.sig`),
+  ]);
+
+  if (!archive || !sums || !signature) {
+    return { ok: false, message: `Signed Meta-Proxy v${version} release assets were not available for ${asset.target}.` };
+  }
+  if (!verifyMetaProxyManifest(sums, signature.toString('utf8'))) {
+    return { ok: false, message: 'Meta-Proxy SHA256SUMS signature verification failed; refusing to install.' };
+  }
+  if (!verifyMetaProxyChecksum(archive, asset.assetName, sums)) {
+    return { ok: false, message: `Meta-Proxy checksum verification failed for ${asset.assetName}; refusing to install.` };
+  }
+
+  const root = metaProxyDataDir(options.home);
+  const binDir = join(root, 'bin');
+  mkdirSync(binDir, { recursive: true, mode: 0o700 });
+  const work = mkdtempSync(join(root, '.install-'));
+  try {
+    const archivePath = join(work, asset.assetName);
+    writeFileSync(archivePath, archive, { mode: 0o600 });
+    extractArchive(archivePath, asset.archive, work);
+    const binaryName = (options.platform ?? process.platform) === 'win32' ? 'meta-proxy.exe' : 'meta-proxy';
+    const extractedBinary = findFile(work, binaryName);
+    if (!extractedBinary) return { ok: false, message: `Verified archive did not contain ${binaryName}.` };
+
+    const destination = metaProxyBinaryPath(options.platform, options.home);
+    if (existsSync(destination)) rmSync(destination, { force: true });
+    renameSync(extractedBinary, destination);
+    if ((options.platform ?? process.platform) !== 'win32') chmodSync(destination, 0o755);
+    writeFileSync(versionPath(destination), `${version}\n`, { encoding: 'utf8', mode: 0o600 });
+    return { ok: true, message: `Installed verified Meta-Proxy v${version} at ${destination}.`, binaryPath: destination, version };
+  } catch (error) {
+    return { ok: false, message: error instanceof Error ? error.message : String(error) };
+  } finally {
+    rmSync(work, { recursive: true, force: true });
+  }
+}
+
+function extractArchive(archivePath: string, archive: PlatformAsset['archive'], work: string): void {
+  const command = archive === 'zip' ? 'tar' : 'tar';
+  const args = archive === 'zip'
+    ? ['-xf', archivePath, '-C', work]
+    : ['-xzf', archivePath, '-C', work];
+  const result = spawnSync(command, args, { encoding: 'utf8', timeout: 60_000 });
+  if (result.error || result.status !== 0) {
+    throw new Error(`Could not extract the Meta-Proxy archive: ${result.error?.message ?? result.stderr ?? `tar exited ${result.status}`}`);
+  }
+}
+
+function findFile(dir: string, basename: string): string | null {
+  for (const entry of readdirSync(dir)) {
+    const candidate = join(dir, entry);
+    const stat = statSync(candidate);
+    if (stat.isDirectory()) {
+      const nested = findFile(candidate, basename);
+      if (nested) return nested;
+    } else if (entry === basename) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+export interface MetaProxyStatus {
+  installed: boolean;
+  running: boolean;
+  binaryPath: string;
+  version: string | null;
+  pid: number | null;
+}
+
+function processExists(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+/**
+ * A pid file alone is not sufficient authority to terminate a process: operating
+ * systems eventually reuse PIDs. Confirm that it is still our exact executable
+ * before reporting it as managed or sending a stop signal.
+ */
+function processMatchesBinary(pid: number, binaryPath: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (platform === 'linux') {
+      const result = spawnSync('readlink', ['-f', `/proc/${pid}/exe`], { encoding: 'utf8', timeout: 2_000 });
+      return result.status === 0 && result.stdout.trim() === binaryPath;
+    }
+    if (platform === 'win32') {
+      const command = `$p = Get-CimInstance Win32_Process -Filter 'ProcessId = ${pid}'; if ($null -ne $p) { [Console]::Out.Write($p.ExecutablePath) }`;
+      const result = spawnSync('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', command], { encoding: 'utf8', timeout: 2_000, windowsHide: true });
+      return result.status === 0 && result.stdout.trim().toLowerCase() === binaryPath.toLowerCase();
+    }
+    const result = spawnSync('ps', ['-p', String(pid), '-o', 'comm='], { encoding: 'utf8', timeout: 2_000 });
+    return result.status === 0 && result.stdout.trim().endsWith(basename(binaryPath));
+  } catch {
+    return false;
+  }
+}
+
+export function metaProxyStatus(home = homedir(), platform: NodeJS.Platform = process.platform): MetaProxyStatus {
+  const binaryPath = metaProxyBinaryPath(platform, home);
+  const installed = existsSync(binaryPath);
+  let version: string | null = null;
+  try { version = readFileSync(versionPath(binaryPath), 'utf8').trim() || null; } catch { /* no sidecar */ }
+
+  let pid: number | null = null;
+  try {
+    const parsed = Number.parseInt(readFileSync(pidPath(home), 'utf8').trim(), 10);
+    if (Number.isSafeInteger(parsed) && parsed > 0 && processExists(parsed) && processMatchesBinary(parsed, binaryPath, platform)) pid = parsed;
+  } catch { /* no managed process */ }
+  return { installed, running: pid !== null, binaryPath, version, pid };
+}
+
+export function startMetaProxy(home = homedir(), platform: NodeJS.Platform = process.platform): MetaProxyInstallResult {
+  const status = metaProxyStatus(home, platform);
+  if (!status.installed) return { ok: false, message: 'Meta-Proxy is not installed. Run `metaharness proxy install --yes` first.' };
+  if (status.running) return { ok: true, message: `Meta-Proxy is already running (pid ${status.pid}).`, binaryPath: status.binaryPath, version: status.version ?? undefined };
+
+  const root = metaProxyDataDir(home);
+  mkdirSync(root, { recursive: true, mode: 0o700 });
+  const log = openSync(join(root, 'meta-proxy.log'), 'a', 0o600);
+  try {
+    const child = spawn(status.binaryPath, [], { detached: true, stdio: ['ignore', log, log], windowsHide: true });
+    if (!child.pid) return { ok: false, message: 'Meta-Proxy did not return a process id.' };
+    child.unref();
+    writeFileSync(pidPath(home), `${child.pid}\n`, { encoding: 'utf8', mode: 0o600 });
+    return { ok: true, message: `Meta-Proxy started (pid ${child.pid}).`, binaryPath: status.binaryPath, version: status.version ?? undefined };
+  } finally {
+    closeSync(log);
+  }
+}
+
+export function stopMetaProxy(home = homedir()): MetaProxyInstallResult {
+  let pid: number;
+  try { pid = Number.parseInt(readFileSync(pidPath(home), 'utf8').trim(), 10); } catch {
+    return { ok: true, message: 'Meta-Proxy is not running (no managed pid file).' };
+  }
+  const status = metaProxyStatus(home);
+  if (!Number.isSafeInteger(pid) || pid <= 0 || !status.running || status.pid !== pid) {
+    rmSync(pidPath(home), { force: true });
+    return { ok: true, message: 'Meta-Proxy is not running under this managed binary (stale pid file removed).' };
+  }
+  try {
+    process.kill(pid, 'SIGTERM');
+    rmSync(pidPath(home), { force: true });
+    return { ok: true, message: `Meta-Proxy stop requested (pid ${pid}).` };
+  } catch (error) {
+    return { ok: false, message: `Could not stop Meta-Proxy pid ${pid}: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}
+
+export interface ProxyCommandResult { code: number; lines: string[]; }
+
+/** `metaharness proxy` command surface. OAuth remains inside the Meta-Proxy binary. */
+export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> {
+  const subcommand = args[0] ?? 'help';
+  if (subcommand === 'help' || subcommand === '--help' || subcommand === '-h') {
+    return {
+      code: 0,
+      lines: [
+        'Usage: metaharness proxy <install|status|start|stop|path|login|logout> [options]',
+        '',
+        'Optional signed Meta-Proxy sidecar for local Claude-compatible routing.',
+        `  install [--version ${META_PROXY_VERSION}] --yes  download, verify, and install`,
+        '  status                                      show installed version and managed process state',
+        '  start | stop | path                         manage the optional local sidecar',
+        '  login | logout                              run Meta-Proxy Cognitum OAuth login/logout',
+      ],
+    };
+  }
+  if (subcommand === 'install') {
+    const versionIndex = args.indexOf('--version');
+    const version = versionIndex >= 0 ? args[versionIndex + 1] : undefined;
+    if (versionIndex >= 0 && !version) return { code: 2, lines: ['--version requires a value, for example 0.3.0.'] };
+    if (!args.includes('--yes')) {
+      return { code: 2, lines: ['Refusing to download a binary without explicit consent. Re-run: metaharness proxy install --yes'] };
+    }
+    const result = await installMetaProxy({ version });
+    return { code: result.ok ? 0 : 1, lines: [result.message] };
+  }
+  if (subcommand === 'status') {
+    const status = metaProxyStatus();
+    return {
+      code: status.installed ? 0 : 1,
+      lines: [
+        'Meta-Proxy',
+        `  installed: ${status.installed ? 'yes' : 'no'}`,
+        `  binary: ${status.binaryPath}`,
+        `  version: ${status.version ?? 'unknown'}`,
+        `  managed process: ${status.running ? `running (pid ${status.pid})` : 'not running'}`,
+      ],
+    };
+  }
+  if (subcommand === 'path') {
+    const status = metaProxyStatus();
+    return { code: status.installed ? 0 : 1, lines: status.installed ? [status.binaryPath] : ['Meta-Proxy is not installed. Run `metaharness proxy install --yes`.'] };
+  }
+  if (subcommand === 'start') {
+    const result = startMetaProxy();
+    return { code: result.ok ? 0 : 1, lines: [result.message] };
+  }
+  if (subcommand === 'stop') {
+    const result = stopMetaProxy();
+    return { code: result.ok ? 0 : 1, lines: [result.message] };
+  }
+  if (subcommand === 'login' || subcommand === 'logout') {
+    const status = metaProxyStatus();
+    if (!status.installed) return { code: 1, lines: ['Meta-Proxy is not installed. Run `metaharness proxy install --yes` first.'] };
+    const result = spawnSync(status.binaryPath, [subcommand, ...args.slice(1)], { stdio: 'inherit', windowsHide: true });
+    if (result.error) return { code: 1, lines: [`Could not run Meta-Proxy ${subcommand}: ${result.error.message}`] };
+    return { code: result.status ?? 1, lines: [] };
+  }
+  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | path | login | logout`] };
+}

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -8,7 +8,7 @@
  * under the user's MetaHarness state directory.
  */
 import { spawn, spawnSync } from 'node:child_process';
-import { createHash, createPublicKey, verify as verifySignature } from 'node:crypto';
+import { createHash, createHmac, createPublicKey, verify as verifySignature } from 'node:crypto';
 import {
   chmodSync,
   closeSync,
@@ -26,7 +26,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
-export const META_PROXY_VERSION = '0.3.0';
+export const META_PROXY_VERSION = '0.4.0';
 export const META_PROXY_RELEASE_BASE = 'https://github.com/cognitum-one/meta-proxy-dist/releases/download';
 
 /** The release signing key, pinned in the client rather than fetched from GitHub. */
@@ -106,6 +106,76 @@ export function metaProxyBinaryPath(
   home = homedir(),
 ): string {
   return join(metaProxyDataDir(home), 'bin', platform === 'win32' ? 'meta-proxy.exe' : 'meta-proxy');
+}
+
+/** Meta-Proxy owns this state directory; MetaHarness reads only the local bearer token. */
+export function rufloStateDir(home = homedir()): string {
+  return process.env.RUFLO_STATE_DIR?.trim() || join(home, '.ruflo');
+}
+
+export function metaProxyTokenPath(home = homedir()): string {
+  return join(rufloStateDir(home), 'proxy-token');
+}
+
+/**
+ * Resolve the endpoint that receives the local bearer token. We intentionally
+ * support only literal loopback bindings: a user-controlled config must never
+ * make `proxy run` disclose a local proxy token to a remote host.
+ */
+export function metaProxyEndpoint(home = homedir()): string {
+  let bind = '127.0.0.1:11435';
+  try {
+    const raw = readFileSync(join(rufloStateDir(home), 'proxy-config.toml'), 'utf8');
+    const match = raw.match(/^bind\s*=\s*"([^"]+)"\s*$/m);
+    if (match?.[1]) bind = match[1];
+  } catch { /* Meta-Proxy uses the documented default when the config is absent. */ }
+
+  const match = bind.match(/^(127\.0\.0\.1|\[::1\]):([1-9]\d{0,4})$/);
+  const port = match ? Number.parseInt(match[2]!, 10) : 0;
+  if (!match || port > 65_535) {
+    throw new Error(`Refusing to route a client through non-loopback Meta-Proxy bind "${bind}".`);
+  }
+  return `http://${bind}`;
+}
+
+/** Environment passed only to the launched client; no token is persisted in a project file. */
+export function metaProxyClientEnvironment(home = homedir()): Record<string, string> {
+  let token = '';
+  try { token = readFileSync(metaProxyTokenPath(home), 'utf8').trim(); } catch { /* reported below */ }
+  if (!token) {
+    throw new Error('Meta-Proxy token is unavailable. Start Meta-Proxy once to create its local token.');
+  }
+  return {
+    ANTHROPIC_BASE_URL: metaProxyEndpoint(home),
+    ANTHROPIC_AUTH_TOKEN: token,
+  };
+}
+
+export type WorktreePolicy = 'critical' | 'standard' | 'economy';
+
+const WORKTREE_POLICIES: ReadonlySet<string> = new Set(['critical', 'standard', 'economy']);
+
+/** A stable correlation value, never a filesystem path, prompt, or repo name. */
+export function worktreeFingerprint(cwd = process.cwd()): string {
+  return createHash('sha256').update(cwd).digest('hex').slice(0, 32);
+}
+
+/**
+ * Mint a short-lived policy capability accepted by Meta-Proxy v0.4.0+.
+ * The underlying proxy secret remains the HMAC key and is never sent upstream.
+ */
+export function createMetaProxyPolicyToken(
+  proxyToken: string,
+  policy: WorktreePolicy,
+  worktree = worktreeFingerprint(),
+  now = Date.now(),
+): string {
+  if (!WORKTREE_POLICIES.has(policy)) throw new Error(`Unknown worktree policy "${policy}".`);
+  const payload = Buffer.from(JSON.stringify({ policy, worktree, exp: Math.floor(now / 1_000) + 8 * 60 * 60 }))
+    .toString('base64url');
+  const signed = `mh1.${payload}`;
+  const signature = createHmac('sha256', proxyToken).update(signed).digest('base64url');
+  return `${signed}.${signature}`;
 }
 
 function pidPath(home = homedir()): string {
@@ -321,6 +391,75 @@ export function stopMetaProxy(home = homedir()): MetaProxyInstallResult {
   }
 }
 
+async function waitForMetaProxy(endpoint: string, token: string, timeoutMs = 5_000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 1_000);
+      const response = await fetch(`${endpoint}/status`, {
+        headers: { authorization: `Bearer ${token}` },
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (response.ok) return true;
+    } catch { /* a detached proxy can take a moment to bind its loopback port */ }
+    await new Promise<void>(resolve => setTimeout(resolve, 50));
+  }
+  return false;
+}
+
+/**
+ * Start the sidecar if necessary, wait until its authenticated health endpoint
+ * is ready, then launch an Anthropic-compatible client through it. This is the
+ * activation point for automatic Passthrough -> Cloud/Sponsored failover.
+ */
+function parseRunArgs(args: string[]): { policy: WorktreePolicy; commandArgs: string[] } | string {
+  let policy: WorktreePolicy = 'standard';
+  const remaining = [...args];
+  while (remaining[0] === '--policy') {
+    const value = remaining[1];
+    if (!value || !WORKTREE_POLICIES.has(value)) {
+      return '--policy must be one of: critical, standard, economy.';
+    }
+    policy = value as WorktreePolicy;
+    remaining.splice(0, 2);
+  }
+  return { policy, commandArgs: remaining[0] === '--' ? remaining.slice(1) : remaining };
+}
+
+export async function runThroughMetaProxy(args: string[], home = homedir()): Promise<ProxyCommandResult> {
+  const parsed = parseRunArgs(args);
+  if (typeof parsed === 'string') return { code: 2, lines: [parsed] };
+  const started = startMetaProxy(home);
+  if (!started.ok) return { code: 1, lines: [started.message] };
+
+  let clientEnv: Record<string, string>;
+  try {
+    clientEnv = metaProxyClientEnvironment(home);
+  } catch (error) {
+    return { code: 1, lines: [error instanceof Error ? error.message : String(error)] };
+  }
+  if (!await waitForMetaProxy(clientEnv.ANTHROPIC_BASE_URL!, clientEnv.ANTHROPIC_AUTH_TOKEN!)) {
+    return { code: 1, lines: ['Meta-Proxy did not become ready within 5 seconds. Run `metaharness proxy status` and inspect its log.'] };
+  }
+
+  const command = parsed.commandArgs[0] || 'claude';
+  const result = spawnSync(command, parsed.commandArgs.slice(1), {
+    stdio: 'inherit',
+    env: {
+      ...process.env,
+      ...clientEnv,
+      ANTHROPIC_AUTH_TOKEN: createMetaProxyPolicyToken(
+        clientEnv.ANTHROPIC_AUTH_TOKEN!, parsed.policy,
+      ),
+    },
+    windowsHide: true,
+  });
+  if (result.error) return { code: 1, lines: [`Could not start ${command}: ${result.error.message}`] };
+  return { code: result.status ?? 1, lines: [] };
+}
+
 export interface ProxyCommandResult { code: number; lines: string[]; }
 
 /** `metaharness proxy` command surface. OAuth remains inside the Meta-Proxy binary. */
@@ -330,20 +469,22 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     return {
       code: 0,
       lines: [
-        'Usage: metaharness proxy <install|status|start|stop|path|login|logout> [options]',
+        'Usage: metaharness proxy <install|status|start|stop|path|login|logout|run> [options]',
         '',
         'Optional signed Meta-Proxy sidecar for local Claude-compatible routing.',
         `  install [--version ${META_PROXY_VERSION}] --yes  download, verify, and install`,
         '  status                                      show installed version and managed process state',
         '  start | stop | path                         manage the optional local sidecar',
         '  login | logout                              run Meta-Proxy Cognitum OAuth login/logout',
+        '  run [--policy <critical|standard|economy>] [--] <client> [args...]',
+        '                                               launch Claude-compatible client through Meta-Proxy',
       ],
     };
   }
   if (subcommand === 'install') {
     const versionIndex = args.indexOf('--version');
     const version = versionIndex >= 0 ? args[versionIndex + 1] : undefined;
-    if (versionIndex >= 0 && !version) return { code: 2, lines: ['--version requires a value, for example 0.3.0.'] };
+    if (versionIndex >= 0 && !version) return { code: 2, lines: ['--version requires a value, for example 0.4.0.'] };
     if (!args.includes('--yes')) {
       return { code: 2, lines: ['Refusing to download a binary without explicit consent. Re-run: metaharness proxy install --yes'] };
     }
@@ -375,6 +516,9 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     const result = stopMetaProxy();
     return { code: result.ok ? 0 : 1, lines: [result.message] };
   }
+  if (subcommand === 'run') {
+    return runThroughMetaProxy(args.slice(1));
+  }
   if (subcommand === 'login' || subcommand === 'logout') {
     const status = metaProxyStatus();
     if (!status.installed) return { code: 1, lines: ['Meta-Proxy is not installed. Run `metaharness proxy install --yes` first.'] };
@@ -382,5 +526,5 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     if (result.error) return { code: 1, lines: [`Could not run Meta-Proxy ${subcommand}: ${result.error.message}`] };
     return { code: result.status ?? 1, lines: [] };
   }
-  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | path | login | logout`] };
+  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | path | login | logout | run`] };
 }


### PR DESCRIPTION
## Summary
- retain optional signed Meta-Proxy installation and lifecycle
- add metaharness proxy run -- [client] to start, authenticate, health-check, and launch Claude-compatible clients through local Meta-Proxy
- add --policy critical|standard|economy, sent as a short-lived HMAC-signed worktree capability
- no global client config, project-file token, or routing banner

## Validation
- npm run build --workspace metaharness
- npm test --workspace metaharness (396 passing)
- CLI help and npm pack --dry-run confirm metaharness@0.4.0 package contents

Depends on cognitum-one/meta-proxy automatic failover + ADR-322 release.