### PR TITLE
fix(proxy): bump pinned Meta-Proxy version to 0.4.1

### DIFF
--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -84,7 +84,7 @@ of normal harness scaffolding. Install it only when you want a locally bound,
 Claude-compatible routing endpoint with Meta-Proxy's own Cognitum OAuth flow:
 
 ```bash
-npx metaharness proxy install --yes   # signed v0.4.0 download; checksum + Ed25519 verified
+npx metaharness proxy install --yes   # signed v0.4.1 download; checksum + Ed25519 verified
 npx metaharness proxy run -- claude   # starts the sidecar and routes this Claude session through it
 npx metaharness proxy run --policy critical -- claude -p "review this migration"
 ```

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -26,7 +26,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
-export const META_PROXY_VERSION = '0.4.0';
+export const META_PROXY_VERSION = '0.4.1';
 export const META_PROXY_RELEASE_BASE = 'https://github.com/cognitum-one/meta-proxy-dist/releases/download';
 
 /** The release signing key, pinned in the client rather than fetched from GitHub. */


### PR DESCRIPTION
## Summary
- Meta-Proxy v0.4.1 ([cognitum-one/meta-proxy#28](https://github.com/cognitum-one/meta-proxy/pull/28)) fixes a real bug: `meta-proxy login`/`logout` only ever wrote `~/.ruflo/proxy-config.toml` on disk. An already-running daemon (config loaded once at boot into memory) never observed that change until restarted — a `logout` could even be silently undone the next time the daemon's cached OAuth token needed a refresh. v0.4.1 adds an internal reload endpoint that `login`/`logout` now call, so it takes effect immediately without a restart.
- The default `META_PROXY_VERSION` pin here was still `0.4.0` (the pre-fix release), so every user running `npx metaharness proxy install`/`proxy run` without an explicit `--version` override was getting the buggy binary.
- Bumps `META_PROXY_VERSION` to `0.4.1` (already signed and published to `meta-proxy-dist`), and bumps this package's own version in lockstep — matching the existing `0.3.2 → 0.4.0` precedent from the last proxy-version bump.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run __tests__/meta-proxy.test.ts` — 6/6 pass
- [x] `npx vitest run` (full suite) — 394/396 pass; the 2 failures (`__tests__/bin-exit-code.test.ts`) are pre-existing on unmodified `origin/main` (verified by stashing this change and re-running), unrelated to this bump
- [x] `npm run build`, then real e2e: fresh isolated `HOME`, `node dist/bin.js proxy install --yes` with **no** `--version` override — installed, checksum + Ed25519 signature verified against the real public release channel, confirmed the installed binary contains the fix (`reload-config` symbol present)

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)