### PR TITLE
fix(create-agent-harness): bump @metaharness/darwin pin ^0.2.2 → ^0.8.0 (#142)

### DIFF
--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -98,7 +98,7 @@
   "dependencies": {
     "kolorist": "^1.8.0",
     "prompts": "^2.4.2",
-    "@metaharness/darwin": "^0.2.2",
+    "@metaharness/darwin": "^0.8.0",
     "@metaharness/weight-eft": "^0.1.0",
     "@metaharness/redblue": "^0.1.1",
     "@metaharness/flywheel": "^0.1.1"

--- a/packages/create-agent-harness/src/index.ts
+++ b/packages/create-agent-harness/src/index.ts
@@ -231,7 +231,7 @@ export interface ScaffoldOptions {
 }
 
 /** ADR-147: the darwin version a scaffolded harness depends on. */
-const DARWIN_VERSION = '^0.2.2';
+const DARWIN_VERSION = '^0.8.0';
 
 /** ADR-147: the real `evolve` skill emitted into every darwin-integrated harness. */
 function darwinEvolveSkill(name: string): string {


### PR DESCRIPTION
Closes #142.

`^0.2.2` is minor-locked to 0.2.x (`>=0.2.2 <0.3.0`), so the scaffolder's own darwin **and every harness it mints** resolve to 0.2.8 and can never reach 0.3.0–0.8.0. Current `latest` is **0.8.0** — the generated `npm run evolve` silently misses the whole 0.3→0.8 evolution engine.

Bumps both `^0.2.2` pins to `^0.8.0`:
- `packages/create-agent-harness/src/index.ts:234` — `DARWIN_VERSION` (stamped into every generated harness, ADR-147)
- `packages/create-agent-harness/package.json:101` — the scaffolder's own dependency

Verified: `^0.8.0` admits `@metaharness/darwin@0.8.0` (npm latest). Matches ruflo's independent `~0.8.0` pin.

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)