### PR TITLE
release: metaharness 0.4.2 (delivers the meta-proxy 0.7.1 pin to npm)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4344,7 +4344,7 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.4.0",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "@metaharness/darwin": "^0.2.2",

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -84,7 +84,7 @@ of normal harness scaffolding. Install it only when you want a locally bound,
 Claude-compatible routing endpoint with Meta-Proxy's own Cognitum OAuth flow:
 
 ```bash
-npx metaharness proxy install --yes   # signed v0.4.1 download; checksum + Ed25519 verified
+npx metaharness proxy install --yes   # signed v0.7.1 download; checksum + Ed25519 verified
 npx metaharness proxy run -- claude   # starts the sidecar and routes this Claude session through it
 npx metaharness proxy run --policy critical -- claude -p "review this migration"
 ```

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {


### PR DESCRIPTION
Prepares the npm release that actually delivers #149. Refs #149.

**`npx metaharness` installs the published package, which is still `0.4.1`.** The pin bump merged in #151 reaches nobody until a new version ships — so this is the last step between the fix and users.

## Why patch, not minor

The entire delta from published `0.4.1` to `main`, over this package:

```
modified  +1/-1  packages/create-agent-harness/src/meta-proxy.ts   (META_PROXY_VERSION 0.4.1 → 0.7.1)
added    +50/-0  .github/workflows/proxy-pin-drift.yml
```

The workflow isn't in the package's `files` whitelist (`dist/** templates/** genomes/** README.md LICENSE`), so it doesn't ship. One line of shipped code, no API change, no new surface. From a user's side it's purely *"`proxy install` now delivers a daemon that starts."* Consistent with this package's npm history, which is patch-heavy (`0.2.2 … 0.2.8, 0.3.0 … 0.3.2, 0.4.0, 0.4.1`).

## Two stale references found while auditing

Auditing for copies of the version turned up two things beyond the bump:

**`README.md` documented the wrong daemon version.** It described `proxy install` as a *"signed v0.4.1 download"*. That number is the **meta-proxy** version, not the CLI's — #151 moved it to `0.7.1` and left the doc behind. This README **ships in the tarball**, so it was about to tell users the wrong version, and the one it named is the release that cannot start on Debian 12 / Ubuntu 22.04 / RHEL 9 (cognitum-one/meta-proxy#65). Now `0.7.1`.

**`package-lock.json` was already stale** — it recorded the package at `0.4.0` while `package.json` said `0.4.1`, so the previous release never synced it. Corrected to `0.4.2` by a **targeted single-field edit** rather than `npm install --package-lock-only`: on this repo that also rewrites unrelated entries. (`npm ci` here already fails with `Missing: @metaharness/kernel-* from lock file`; that pre-existing drift is deliberately left alone — it's not this PR's to fix.)

## Verification

```
$ npm pack --dry-run
npm notice name:     metaharness
npm notice version:  0.4.2
npm notice filename: metaharness-0.4.2.tgz
```

- `package.json` and the lockfile entry now agree (`0.4.2` / `0.4.2`)
- `package-lock.json` still parses
- diff is exactly **three lines across three files** — no incidental churn
- source constant confirmed at `META_PROXY_VERSION = '0.7.1'`, which is what `tsc` will compile into the shipped `dist/`

## ⚠ Publishing is manual — a tag will not do it

Not tagged and not published here, deliberately. Worth knowing before anyone reaches for a tag:

- **All seven `publish.yml` runs have failed.** Last attempt `2026-06-18`; npm has shipped `0.2.2` → `0.4.1` since, so every recent release went out **outside** that workflow.
- **A `v*.*.*` tag today would fail before reaching this package.** `publish.yml` runs `npm publish` across ~12 workspace packages with no `continue-on-error`, and `npm publish` 403s on an already-published version:

  | package | on npm | on main |
  |---|---|---|
  | `@metaharness/kernel` | 0.1.2 | **0.1.2** |
  | `@metaharness/sdk` | 0.1.0 | **0.1.0** |

  Those run *before* `create-agent-harness`, which is **last** in the sequence.

So the path to shipping is: merge this, then publish `metaharness@0.4.2` the same way `0.4.1` went out. Repairing `publish.yml` is worth doing but shouldn't gate the fix.

## After it's published

`npx metaharness proxy install --yes` will deliver meta-proxy `0.7.1`, which I verified end-to-end in `node:22-bookworm` on arm64 — the same Debian 12 / glibc 2.36 as the devcontainer where this was reported:

```
Installed verified Meta-Proxy v0.7.1 at /root/.metaharness/meta-proxy/bin/meta-proxy.
$ meta-proxy --version    → meta-proxy 0.7.1
$ meta-proxy auth-status  → connected: false / credential source: none / data plane: passthrough:anthropic
```

Against the current published `0.4.1` the same command yields ``version `GLIBC_2.39' not found``.

🤖 Generated with Ruflo & AQE
