### PR TITLE
fix(ci): make publish.yml idempotent — skip already-published versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,45 +175,17 @@ jobs:
         run: |
           echo "TODO: publish per-platform native packages from dist-native/ (lands in a follow-up iteration)"
 
-      - name: Publish @metaharness/kernel (umbrella)
+      - name: Publish workspace packages (idempotent — skips already-published versions)
+        # One script instead of five sequential `npm publish` steps. The old
+        # sequence had no skip-if-published logic, so a tag re-run 403'd on
+        # the first package whose version was already live (usually
+        # @metaharness/kernel) and never reached the later packages — the
+        # reason all 7 tag/dispatch runs failed and releases went manual.
+        # publish-workspace.mjs checks the registry per package and only
+        # publishes versions that aren't there yet.
         env:
           NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.npm_token }}
-        working-directory: packages/kernel-js
-        run: npm publish --provenance --access public
-
-      - name: Publish @metaharness/sdk
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.npm_token }}
-        working-directory: packages/sdk
-        run: npm publish --provenance --access public
-
-      - name: Publish host adapters (6 packages)
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.npm_token }}
-        run: |
-          set -euo pipefail
-          for host in host-claude-code host-codex host-pi-dev host-hermes host-openclaw host-rvm; do
-            echo "::group::publish @metaharness/$host"
-            (cd packages/$host && npm publish --provenance --access public)
-            echo "::endgroup::"
-          done
-
-      - name: Publish vertical packs (2 packages)
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.npm_token }}
-        run: |
-          set -euo pipefail
-          for v in vertical-base vertical-trading; do
-            echo "::group::publish @metaharness/$v"
-            (cd packages/$v && npm publish --provenance --access public)
-            echo "::endgroup::"
-          done
-
-      - name: Publish create-agent-harness
-        env:
-          NODE_AUTH_TOKEN: ${{ steps.secrets.outputs.npm_token }}
-        working-directory: packages/create-agent-harness
-        run: npm publish --provenance --access public
+        run: node scripts/publish-workspace.mjs
 
       # ─────────────────────────────────────────────────────────────────
       # MARKETPLACE: pin the claude-marketplace registry entry to IPFS

--- a/__tests__/publish-workspace.test.ts
+++ b/__tests__/publish-workspace.test.ts
@@ -1,0 +1,57 @@
+// Unit coverage for the idempotent publish decision + release set.
+// The script's I/O (npm view / npm publish) needs a live registry, but the
+// skip-or-publish decision and the curated release order are pure — and
+// the decision is exactly what was missing when publish.yml 403'd on
+// already-published versions (7/7 failed runs before this fix).
+import { describe, it, expect } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+// @ts-expect-error — .mjs script, no types; runtime import is fine under vitest.
+import { needsPublish, RELEASE_ORDER } from '../scripts/publish-workspace.mjs';
+
+describe('needsPublish', () => {
+  it('skips when the version is already on the registry (exit 0 + version echoed)', () => {
+    expect(needsPublish({ exitCode: 0, stdout: '0.4.2\n' })).toBe(false);
+  });
+
+  it('publishes when npm view 404s (package or version missing, npm >= 10)', () => {
+    expect(needsPublish({ exitCode: 1, stdout: '' })).toBe(true);
+  });
+
+  it('publishes when npm view exits 0 with empty output (older npm, version missing)', () => {
+    expect(needsPublish({ exitCode: 0, stdout: '' })).toBe(true);
+    expect(needsPublish({ exitCode: 0, stdout: '  \n' })).toBe(true);
+  });
+
+  it('attempts publish on unknown outcomes rather than silently skipping', () => {
+    // Network/auth failures must not masquerade as "already published".
+    expect(needsPublish({ exitCode: 7, stdout: '' })).toBe(true);
+  });
+});
+
+describe('RELEASE_ORDER', () => {
+  it('matches the package set publish.yml shipped as individual steps', () => {
+    expect(RELEASE_ORDER).toEqual([
+      'kernel-js',
+      'sdk',
+      'host-claude-code',
+      'host-codex',
+      'host-pi-dev',
+      'host-hermes',
+      'host-openclaw',
+      'host-rvm',
+      'vertical-base',
+      'vertical-trading',
+      'create-agent-harness',
+    ]);
+  });
+
+  it('every entry exists in packages/ with a package.json', () => {
+    for (const dir of RELEASE_ORDER) {
+      expect(
+        existsSync(join(__dirname, '..', 'packages', dir, 'package.json')),
+        `packages/${dir}/package.json`,
+      ).toBe(true);
+    }
+  });
+});

--- a/scripts/publish-workspace.mjs
+++ b/scripts/publish-workspace.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+//
+// scripts/publish-workspace.mjs — idempotent workspace publish.
+//
+// Publishes the curated release set in dependency order, SKIPPING any
+// package whose current package.json version is already on the registry.
+// This is what lets a `v*.*.*` tag re-run publish.yml safely: before this
+// script, `npm publish` 403'd on the first already-published package
+// (@metaharness/kernel came before create-agent-harness in the step
+// sequence, with no continue-on-error), so a tag could never deliver a
+// bump of a later package. See PR #152's release notes for the full
+// post-mortem.
+//
+// Run as: node scripts/publish-workspace.mjs [--dry-run]
+// Used as: publish.yml's single publish step (NODE_AUTH_TOKEN in env).
+
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+const ROOT = process.cwd();
+const DRY = process.argv.includes('--dry-run');
+
+// The same set + order publish.yml shipped as individual steps. Packages
+// not listed here (evals-*, flywheel, darwin-mode, redblue, weight-eft, …)
+// have their own release cadence and are deliberately NOT published from
+// the tag workflow — widen this list consciously, not by directory glob.
+export const RELEASE_ORDER = [
+  'kernel-js',
+  'sdk',
+  'host-claude-code',
+  'host-codex',
+  'host-pi-dev',
+  'host-hermes',
+  'host-openclaw',
+  'host-rvm',
+  'vertical-base',
+  'vertical-trading',
+  'create-agent-harness',
+];
+
+function log(tag, msg) { process.stderr.write(`[publish-workspace] ${tag}: ${msg}\n`); }
+
+/**
+ * Pure helper (exported for unit tests): decide whether name@version needs
+ * publishing given the outcome of `npm view name@version version`.
+ *
+ * npm's behavior differs by registry state:
+ *   - version published            → exit 0, stdout is the version
+ *   - package exists, version not  → exit 0 with EMPTY stdout (npm ≤9)
+ *                                    or exit 1 E404 (npm ≥10)
+ *   - package never published      → exit 1 E404
+ * Anything else (network, auth) is "unknown" — we attempt the publish and
+ * let `npm publish` produce the real error rather than guessing.
+ */
+export function needsPublish({ exitCode, stdout }) {
+  const out = (stdout ?? '').trim();
+  if (exitCode === 0 && out.length > 0) return false; // already on registry
+  return true;
+}
+
+async function viewVersion(name, version) {
+  const args = ['view', `${name}@${version}`, 'version'];
+  const [bin, finalArgs] = process.platform === 'win32'
+    ? ['cmd.exe', ['/d', '/s', '/c', 'npm', ...args]]
+    : ['npm', args];
+  try {
+    const { stdout } = await execFile(bin, finalArgs);
+    return { exitCode: 0, stdout };
+  } catch (err) {
+    return { exitCode: err.code ?? 1, stdout: err.stdout ?? '' };
+  }
+}
+
+async function publishOne(dir) {
+  const args = ['publish', '--provenance', '--access', 'public'];
+  if (DRY) args.push('--dry-run');
+  const [bin, finalArgs] = process.platform === 'win32'
+    ? ['cmd.exe', ['/d', '/s', '/c', 'npm', ...args]]
+    : ['npm', args];
+  await execFile(bin, finalArgs, { cwd: dir });
+}
+
+async function main() {
+  const published = [];
+  const skipped = [];
+  const failed = [];
+
+  for (const dirName of RELEASE_ORDER) {
+    const dir = join(ROOT, 'packages', dirName);
+    const pkgPath = join(dir, 'package.json');
+    if (!existsSync(pkgPath)) {
+      log('FAIL', `packages/${dirName} missing package.json — release set is stale`);
+      failed.push(dirName);
+      continue;
+    }
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+    if (pkg.private === true) {
+      log('SKIP', `${pkg.name} is private`);
+      skipped.push(pkg.name);
+      continue;
+    }
+    const spec = `${pkg.name}@${pkg.version}`;
+    const view = await viewVersion(pkg.name, pkg.version);
+    if (!needsPublish(view)) {
+      log('SKIP', `${spec} already on registry`);
+      skipped.push(spec);
+      continue;
+    }
+    log('PUBLISH', `${spec}${DRY ? ' (dry-run)' : ''}`);
+    try {
+      await publishOne(dir);
+      published.push(spec);
+    } catch (err) {
+      // A concurrent publish of the same version loses the race with E403;
+      // that means the version IS on the registry, which is the goal state.
+      const msg = String(err.stderr ?? err.message ?? err);
+      if (msg.includes('E403') && msg.includes('previously published')) {
+        log('SKIP', `${spec} raced to already-published (E403) — treating as done`);
+        skipped.push(spec);
+      } else {
+        log('FAIL', `${spec}: ${msg.split('\n').slice(0, 5).join(' | ')}`);
+        failed.push(spec);
+      }
+    }
+  }
+
+  log('SUMMARY', `published=${published.length} skipped=${skipped.length} failed=${failed.length}`);
+  for (const p of published) log('SUMMARY', `  published ${p}`);
+  for (const f of failed) log('SUMMARY', `  FAILED ${f}`);
+  if (failed.length > 0) process.exit(1);
+  if (published.length === 0) log('SUMMARY', 'nothing to publish — every version already live (idempotent no-op)');
+}
+
+// Only run when executed directly (not when imported by tests).
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => { log('FAIL', String(err)); process.exit(1); });
+}


### PR DESCRIPTION
Repairs the structural half of why all 7 `publish.yml` runs failed (context: #152's release notes — every recent release has shipped manually, including `metaharness@0.4.2` today).

## The two failure causes

**1. Structural — fixed here.** The five sequential `npm publish` steps had no skip-if-published logic. `npm publish` returns E403 for an already-published version, and `@metaharness/kernel` (published, 0.1.2) sits **first** in the sequence — so any tag or dispatch on a tree where even one earlier package was already live crashed before reaching the package that actually had a new version. That made the workflow unusable for exactly its main job: shipping a bump of one package (like `create-agent-harness`, which is last).

Replaced the five steps with one call to **`scripts/publish-workspace.mjs`**: same curated package set and order (deliberately NOT a directory glob — evals-*, flywheel, darwin, etc. have their own release cadence), but it checks the registry per package (`npm view name@version`) and only publishes versions that aren't there. It also treats a publish that races to E403 "previously published" as success, and fails loud on anything else.

**2. Credential — not fixable in-repo.** Gate 1 (`validate-gcp-secrets.mjs`) fails with `npm whoami → E401`: the `NPM_TOKEN` in GCP Secret Manager (`ruv-dev`, versions from 2026-05-14) is dead. The gate is working as designed — it needs a one-time secret rotation (new npm granular token with read/write on the `@metaharness` packages + `metaharness`, package 2FA settings set to allow token/automation publishes, then `gcloud secrets versions add NPM_TOKEN --project=ruv-dev --data-file=-`). Until then the workflow will still stop at Gate 1 — correctly, and before any registry I/O.

## Verification

- New unit tests (`__tests__/publish-workspace.test.ts`, repo style — pure decision helper + release-set pinning): 6/6 pass.
- `node scripts/publish-workspace.mjs --dry-run` against the **live registry** on this tree: `published=0 skipped=11 failed=0`, exit 0 — the exact state that previously guaranteed a crash is now a green no-op.
- Workflow YAML parses; no other steps touched (gates, native/wasm builds, marketplace pin all unchanged).

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)