### PR TITLE
fix(agntcy): schema_version mismatch was the real root cause, not a validator bug

### DIFF
--- a/docs/adrs/ADR-240-agntcy-identity-oasf-observability.md
+++ b/docs/adrs/ADR-240-agntcy-identity-oasf-observability.md
@@ -205,6 +205,39 @@ then rejects with `Invalid URL`. Both this and the TLS-mode wiring are
 covered by new tests exercising the SDK's real `createTLSTransport`
 validation path, not mocks.
 
+## Update (2026-07-31, part 3) — resolved: it was our bug, not upstream's
+
+The "materially deeper" `agntcy/dir#1943` finding above (only `id=60101`
+accepted, everything else rejected) had a root cause, and it wasn't the
+live server's validator — it was this file. Upstream maintainer
+**@akijakya** identified it directly: the pushed record declared
+`schema_version: '0.8.0'` while every id/name being tested came from OASF
+**1.1.0**'s taxonomy. The Directory server validates a skill against the
+taxonomy for the record's *own declared* `schema_version` — so every
+1.1.0-derived id was checked against the 0.8.0 taxonomy and correctly
+rejected. `id=60101` only ever "worked" by coincidence: 0.8.0 happens to
+have an unrelated skill ("indexing") at that same numeric slot.
+
+Fixed: `schema_version` is now `'1.1.0'`, matching the taxonomy this file
+actually generates from. Re-tested live — **all 9 previously-"broken" ids
+now push successfully**, and sending `id` together with the taxonomy's own
+dotted `name` (the self-documenting form, not id-only) works too. Removed
+the `SEND_REAL_TAXONOMY_IDS` workaround flag entirely — `KNOWN_AGENT_SKILLS`
+now sends real `{id, name}` pairs on the wire unconditionally, verified
+end-to-end with real internal capabilities (`orchestrator`, `maintainer`)
+that previously required the confirmed-good fallback.
+
+Closed [agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943) with
+the resolution and a thank-you to @akijakya for the fast, precise diagnosis.
+
+**agntcy/slim#1916 also resolved**, on the SLIM maintainers' side: they've
+moved off `uniffi-bindgen-react-native` onto `@ubjs/core`/`@ubjs/node`
+(compiled output) in the `alpha` dist-tag. Verified live in the companion
+ruflo ADR-380 package — a real server bring-up + client connect + graceful
+shutdown against `@agntcy/slim-bindings@2.0.0-alpha.5` succeeds under plain
+Node with zero errors. See that ADR's own update section for the pinned
+version and test changes.
+
 ## References
 
 - Cisco AGNTCY overview — https://outshift.cisco.com/the-internet-of-agents/agntcy

--- a/packages/agntcy/README.md
+++ b/packages/agntcy/README.md
@@ -92,18 +92,18 @@ above), the implementation stays a **clearly-logged, clearly-erroring stub
 gated behind a feature flag or config check** — never a call that silently
 succeeds or returns fabricated data.
 
-### Known upstream gap, filed
+### Resolved — it was a stale `schema_version`, not an upstream bug
 
-`oasf/publish.ts` sends a skill's numeric taxonomy `id` **without** a `name`
-field, on purpose — this was discovered empirically against a live server.
-Supplying `name` (in *any* format tried: the taxonomy's own dotted path,
-dot-separated, bare leaf name, human caption) makes the server run a second,
-stricter class-name lookup that rejects every value, including the taxonomy's
-own real names pulled directly from
-[agntcy/oasf](https://github.com/agntcy/oasf)'s schema files. `id`-only push
-requests succeed. This looks like a real bug or version-skew in the live
-server's validator, not a mapping error on this repo's side — see "Upstream
-reports" below.
+**A previous version of this section reported a live-server validator bug.**
+That was wrong: upstream maintainer @akijakya (agntcy/dir) identified the
+real cause in minutes. `oasf/publish.ts` declared `schema_version: '0.8.0'`
+on every pushed record while `taxonomy.generated.json`'s ids/names come from
+OASF **1.1.0**'s taxonomy — the server validates a skill against the
+taxonomy for the record's own declared version, so every 1.1.0-derived
+id/name was checked against the 0.8.0 taxonomy and correctly rejected. Fixed
+by declaring `schema_version: '1.1.0'`. `oasf/publish.ts` now sends real
+`{id, name}` pairs together (self-documenting, confirmed live), not an
+id-only workaround. See "Upstream reports" below for the full history.
 
 Upstream references (schemas are Apache-2.0 with existing Python/Go bindings):
 
@@ -151,33 +151,24 @@ exercise that path). `identity/sign.ts`'s witness-signing hook remains a
 documented TODO pending a JS/wasm binding for the real Rust signer (AGNTCY
 Identity itself has no such binding to call either — see "Status").
 
-## Upstream reports
+## Upstream reports — filed, and resolved
 
-- **[agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943)** — the live
-  Directory server's schema validator rejects any `skills[].name` value
-  (including the taxonomy's own real dotted paths from
-  [agntcy/oasf](https://github.com/agntcy/oasf)) and only accepts a bare
-  numeric `id`. Filed with a minimal, reproducible example. Investigated
-  `agntcy/oasf-sdk` first hoping to fix it directly — that package turned out
-  to be an HTTP client against a remote, hosted validation service, not
-  something with local source to patch, so this is a report rather than a PR.
-  **Update:** the `id`-only path is *also* broken beyond a small, seemingly
-  arbitrary subset — see below.
-- **Follow-up finding on the same issue (id-only validation is inconsistent
-  too):** built the full real skill taxonomy from a fresh
-  `agntcy/oasf` checkout (`scripts/generate-oasf-taxonomy.mjs` →
-  `src/oasf/taxonomy.generated.json`, 364 leaves) and live-tested a spread of
-  correctly-derived composite ids against the real Directory server.
-  Reproducibly (verified across a container restart, ruling out local
-  caching), only `id=60101` is accepted — every other structurally-correct
-  id tried (including well-known subcategories like `software_testing`
-  and `application_security`) is rejected with `no class is defined for
-  <id>`. This repo's `src/oasf/publish.ts` now works around it: the actual
-  wire payload always sends the one confirmed-good id, while every
-  capability's real, correctly-derived taxonomy id is still recorded in
-  `annotations` (`skill.taxonomyId.*`) so nothing is lost — flip
-  `SEND_REAL_TAXONOMY_IDS` in that file once upstream's validator accepts
-  the full schema tree.
+- **[agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943)** (closed) —
+  originally filed believing the live Directory server's validator rejected
+  `skills[].name`/numeric `id` values inconsistently. Maintainer @akijakya
+  found the real cause fast: our pushed records declared
+  `schema_version: '0.8.0'` while the ids/names we tested came from OASF
+  1.1.0's taxonomy — the server validates against the taxonomy for a
+  record's own declared version, so every mismatch was a genuine, correct
+  rejection, not a validator bug. Fixed (`schema_version: '1.1.0'`),
+  re-verified live (all 9 previously-failing ids now push, `id`+`name`
+  together also works), and closed with thanks.
+- **[agntcy/slim#1916](https://github.com/agntcy/slim/issues/1916)** (open,
+  fix confirmed) — companion ruflo ADR-380's SLIM transport issue. The SLIM
+  maintainers moved off `uniffi-bindgen-react-native` onto `@ubjs/core`/
+  `@ubjs/node` in the `alpha` dist-tag; verified live that
+  `@agntcy/slim-bindings@2.0.0-alpha.5` loads and connects cleanly under
+  plain Node. Left open until the fix is promoted to `latest`.
 
 ## License
 

--- a/packages/agntcy/src/oasf/publish.ts
+++ b/packages/agntcy/src/oasf/publish.ts
@@ -38,16 +38,20 @@
 // leaf defaults to 1" theory before this was traced through the real
 // `agntcy/oasf` tree.
 //
-// IMPORTANT (found empirically against a live server, see this file's test
-// suite): send `{ id }` ONLY — no `name` field. The server resolves the
-// class name from the numeric id internally; supplying ANY `name` value
-// (even the taxonomy's own dotted path, e.g.
-// "software_engineering/code_generation/code_generation") makes it run a
-// separate, stricter lookup that currently rejects every value tried,
-// including the taxonomy's own real names — this looks like a real,
-// reportable bug/version-skew in the live server's validator, not a mapping
-// error on this repo's side. Filed upstream: see README.md "Upstream
-// reports" (agntcy/dir#1943).
+// RESOLVED (agntcy/dir#1943 — root cause found by upstream maintainer
+// @akijakya, 2026-07-31): every earlier "name is broken" / "id is broken"
+// finding in this file's history was actually the SAME self-inflicted bug —
+// the pushed record's `schema_version` field was hardcoded to `'0.8.0'`
+// while `taxonomy.generated.json`'s ids/names come from OASF **1.1.0**'s
+// `schema/skills/**` tree. The live server validates a skill's `id`/`name`
+// against the taxonomy for the record's OWN declared `schema_version`, so
+// every 1.1.0-derived id/name was being checked against the 0.8.0 taxonomy
+// and correctly rejected — id=60101 only "worked" by coincidence (0.8.0
+// happens to have an unrelated skill, "indexing", at that same numeric
+// slot). Fixed below by declaring `schema_version: '1.1.0'` to match the
+// taxonomy this file actually uses. Verified live: all 9 previously-"broken"
+// ids now push successfully, and sending BOTH `id` and the taxonomy's own
+// dotted `name` together (self-documenting, not id-only) also now works.
 
 import { Client, Config } from 'agntcy-dir';
 import { create } from '@bufbuild/protobuf';
@@ -123,6 +127,13 @@ function leafId(path: string): number {
   return leaf.id;
 }
 
+/** `{ id, name }` pair for a taxonomy path — sending both together is the
+ * self-documenting form confirmed to work live (see the RESOLVED note
+ * above); `name` is exactly the leaf's own dotted path, nothing derived. */
+function skillOf(path: string): { id: number; name: string } {
+  return { id: leafId(path), name: path };
+}
+
 // This repo's REAL internal capability vocabulary — not a guess. These are
 // exactly the ids `harness-genome`'s `buildGenomeReport()` emits into
 // `plan.agents` (23 possible values, archetype-dependent), `plan.skills` (4
@@ -135,78 +146,57 @@ function leafId(path: string): number {
 // so this table must be kept in sync by hand against that real vocabulary,
 // not derived automatically). Three internal names have no confidently
 // fitting real leaf and are intentionally left unmapped — `worker`, `scout`,
-// `escalator` — for these, `projectAnnotations` simply has no
-// `skill.taxonomyId.*` entry to record (still lists the capability itself
-// under `capability.*`, per this file's "never silently drop" rule).
-export const KNOWN_AGENT_SKILLS: Record<string, { id: number }> = {
+// `escalator` — they fall through to FALLBACK_SKILL in projectSkills below
+// (still listed under `capability.*` in annotations, per this file's "never
+// silently drop" rule).
+export const KNOWN_AGENT_SKILLS: Record<string, { id: number; name: string }> = {
   // agent_topology (4/4 mapped)
-  maintainer: { id: leafId('software_engineering/code_quality/code_migration') },
-  tester: { id: leafId('software_engineering/software_testing/unit_integration_testing') },
-  security: { id: leafId('cybersecurity/application_security/secure_coding') },
-  release: { id: leafId('devops_cloud_infra/deployment_release/release_management') },
+  maintainer: skillOf('software_engineering/code_quality/code_migration'),
+  tester: skillOf('software_engineering/software_testing/unit_integration_testing'),
+  security: skillOf('cybersecurity/application_security/secure_coding'),
+  release: skillOf('devops_cloud_infra/deployment_release/release_management'),
   // agents (20/23 mapped — worker, scout, escalator deliberately absent)
-  orchestrator: { id: leafId('ai_ml_engineering/agent_orchestration/agentic_workflow_orchestration') },
-  planner: { id: leafId('ai_ml_engineering/agent_orchestration/multi_agent_planning') },
-  critic: { id: leafId('ai_ml_engineering/model_evaluation/llm_judge_evaluation') },
-  reviewer: { id: leafId('software_engineering/code_quality/code_review') },
-  'test-writer': { id: leafId('software_engineering/software_testing/test_case_generation') },
-  architect: { id: leafId('software_engineering/software_architecture/system_design') },
-  implementer: { id: leafId('software_engineering/api_development/api_implementation') },
-  'data-curator': { id: leafId('ai_ml_engineering/training_data_engineering/data_curation') },
-  trainer: { id: leafId('ai_ml_engineering/model_training/deep_learning_training') },
-  evaluator: { id: leafId('ai_ml_engineering/model_evaluation/quality_evaluation') },
-  deployer: { id: leafId('devops_cloud_infra/deployment_release/deployment_orchestration') },
-  synthesizer: { id: leafId('research_knowledge_productivity/web_search/information_synthesis') },
-  'fact-checker': { id: leafId('research_knowledge_productivity/web_search/fact_verification') },
-  citer: { id: leafId('research_knowledge_productivity/research/citation_management') },
-  responder: { id: leafId('devops_cloud_infra/site_reliability_engineering/incident_response') },
-  'runbook-runner': { id: leafId('devops_cloud_infra/site_reliability_engineering/incident_response') },
-  postmortem: { id: leafId('devops_cloud_infra/site_reliability_engineering/postmortem_authoring') },
-  analyst: { id: leafId('data_engineering_analytics/data_analytics/exploratory_data_analysis') },
-  strategist: { id: leafId('business_professional/business_strategy/strategic_advisory') },
-  'ops-coordinator': { id: leafId('devops_cloud_infra/deployment_release/deployment_orchestration') },
+  orchestrator: skillOf('ai_ml_engineering/agent_orchestration/agentic_workflow_orchestration'),
+  planner: skillOf('ai_ml_engineering/agent_orchestration/multi_agent_planning'),
+  critic: skillOf('ai_ml_engineering/model_evaluation/llm_judge_evaluation'),
+  reviewer: skillOf('software_engineering/code_quality/code_review'),
+  'test-writer': skillOf('software_engineering/software_testing/test_case_generation'),
+  architect: skillOf('software_engineering/software_architecture/system_design'),
+  implementer: skillOf('software_engineering/api_development/api_implementation'),
+  'data-curator': skillOf('ai_ml_engineering/training_data_engineering/data_curation'),
+  trainer: skillOf('ai_ml_engineering/model_training/deep_learning_training'),
+  evaluator: skillOf('ai_ml_engineering/model_evaluation/quality_evaluation'),
+  deployer: skillOf('devops_cloud_infra/deployment_release/deployment_orchestration'),
+  synthesizer: skillOf('research_knowledge_productivity/web_search/information_synthesis'),
+  'fact-checker': skillOf('research_knowledge_productivity/web_search/fact_verification'),
+  citer: skillOf('research_knowledge_productivity/research/citation_management'),
+  responder: skillOf('devops_cloud_infra/site_reliability_engineering/incident_response'),
+  'runbook-runner': skillOf('devops_cloud_infra/site_reliability_engineering/incident_response'),
+  postmortem: skillOf('devops_cloud_infra/site_reliability_engineering/postmortem_authoring'),
+  analyst: skillOf('data_engineering_analytics/data_analytics/exploratory_data_analysis'),
+  strategist: skillOf('business_professional/business_strategy/strategic_advisory'),
+  'ops-coordinator': skillOf('devops_cloud_infra/deployment_release/deployment_orchestration'),
   // skills (4/4 mapped)
-  'run-swarm': { id: leafId('ai_ml_engineering/agent_orchestration/multi_agent_coordination') },
-  'memory-inspect': { id: leafId('ai_ml_engineering/agent_development/agent_memory') },
-  'plan-change': { id: leafId('ai_ml_engineering/agent_orchestration/multi_agent_planning') },
-  'eval-report': { id: leafId('ai_ml_engineering/model_evaluation/benchmark_execution') },
+  'run-swarm': skillOf('ai_ml_engineering/agent_orchestration/multi_agent_coordination'),
+  'memory-inspect': skillOf('ai_ml_engineering/agent_development/agent_memory'),
+  'plan-change': skillOf('ai_ml_engineering/agent_orchestration/multi_agent_planning'),
+  'eval-report': skillOf('ai_ml_engineering/model_evaluation/benchmark_execution'),
 };
-// EMPIRICALLY CONFIRMED against the real live Directory server, reproducibly
-// (verified across a container restart, ruling out local caching): the
-// remote schema.oasf.outshift.com validator the server delegates to
-// currently recognizes id=60101 and rejects EVERY OTHER numerically-correct
-// composite id tried from the CURRENT public agntcy/oasf schema tree —
-// including ids for well-known subcategories (software_testing=60501,
-// application_security=100101) that an earlier version of this file believed
-// confirmed. This is a deeper instance of the same upstream inconsistency
-// already reported in agntcy/dir#1943 (originally filed for the `name`
-// field failing on every value tried) — this shows the numeric `id`-only
-// path is ALSO broken beyond a small, seemingly-arbitrary subset. Filed as
-// an update to that issue with a minimal repro.
-//
-// Consequence for this function: sending KNOWN_AGENT_SKILLS' real ids
-// directly on the wire would make live pushes FAIL for every record whose
-// capabilities don't happen to map to the one confirmed-good id — a real
-// regression versus the old 5-entry table, which accidentally always fell
-// back to 60101 for almost everything. So `projectSkills` sends ONLY
-// `CONFIRMED_LIVE_SKILL` in the actual wire payload (matches today's proven
-// behavior exactly) while `projectAnnotations` still records each
-// capability's REAL, correctly-derived taxonomy id — nothing is silently
-// dropped, and flipping `SEND_REAL_TAXONOMY_IDS` to `true` is the entire
-// fix once upstream's validator accepts the full schema tree (tracked by
-// the linked issue).
-const SEND_REAL_TAXONOMY_IDS = false;
-const CONFIRMED_LIVE_SKILL = { id: leafId('software_engineering/code_generation/text_to_code') }; // = 60101, the one id currently accepted live
+const FALLBACK_SKILL = skillOf('software_engineering/code_generation/text_to_code');
 
-function projectSkills(record: OasfRecord): Array<{ id: number }> {
+function projectSkills(record: OasfRecord): Array<{ id: number; name: string }> {
   // The real Directory server requires a non-empty skills array (validated
-  // live — see this file's test suite).
-  if (!SEND_REAL_TAXONOMY_IDS) return [CONFIRMED_LIVE_SKILL];
-  if (record.capabilities.length === 0) return [CONFIRMED_LIVE_SKILL];
+  // live — see this file's test suite). Map every capability with a known
+  // real taxonomy entry, sending both `id` and the taxonomy's own dotted
+  // `name` together (self-documenting; confirmed live to work once
+  // schema_version matches — see the RESOLVED note above). Anything
+  // unrecognized gets the closest honest category-level fallback rather
+  // than being silently dropped, since the array cannot be empty.
+  if (record.capabilities.length === 0) return [FALLBACK_SKILL];
   const seen = new Set<number>();
-  const skills: Array<{ id: number }> = [];
+  const skills: Array<{ id: number; name: string }> = [];
   for (const cap of record.capabilities) {
-    const mapped = KNOWN_AGENT_SKILLS[cap.id] ?? CONFIRMED_LIVE_SKILL;
+    const mapped = KNOWN_AGENT_SKILLS[cap.id] ?? FALLBACK_SKILL;
     if (!seen.has(mapped.id)) {
       seen.add(mapped.id);
       skills.push(mapped);
@@ -217,14 +207,7 @@ function projectSkills(record: OasfRecord): Array<{ id: number }> {
 
 function projectAnnotations(record: OasfRecord): Record<string, string> {
   const annotations: Record<string, string> = {};
-  for (const cap of record.capabilities) {
-    annotations[`capability.${cap.kind}.${cap.id}`] = 'true';
-    // Real, correctly-derived taxonomy id for this capability, recorded even
-    // though (per the note above) it may not be what actually went into
-    // `skills[]` above — never silently dropped.
-    const realTaxonomyId = KNOWN_AGENT_SKILLS[cap.id]?.id;
-    if (realTaxonomyId !== undefined) annotations[`skill.taxonomyId.${cap.id}`] = String(realTaxonomyId);
-  }
+  for (const cap of record.capabilities) annotations[`capability.${cap.kind}.${cap.id}`] = 'true';
   for (const proto of record.supportedProtocols) annotations[`host.${proto.host}`] = 'true';
   annotations['model.recommendedMode'] = record.modelRequirements.recommendedMode;
   annotations['model.estCostPerRunUsd'] = String(record.modelRequirements.estCostPerRunUsd);
@@ -320,7 +303,13 @@ export async function publishToDirectory(record: OasfRecord, target: PublishTarg
     data: {
       name: target.name,
       version: target.version,
-      schema_version: '0.8.0',
+      // Must match the OASF version taxonomy.generated.json was derived
+      // from (1.1.0) — see the RESOLVED note at the top of this file. A
+      // stale schema_version here is what caused every earlier "id/name is
+      // broken" finding: the server validates skills against the taxonomy
+      // for the record's OWN declared version, not whatever version the
+      // caller had in mind.
+      schema_version: '1.1.0',
       description: 'MetaHarness-generated harness (ADR-240 §2.2 projection)',
       authors: ['metaharness'],
       created_at: record.generatedAt,
@@ -361,5 +350,5 @@ export async function publishToDirectory(record: OasfRecord, target: PublishTarg
  * throws at import time on a miss; this re-check exists so a test failure
  * names the exact file, not a module-load crash). */
 export function __allMappedIdsExistInTaxonomy(): boolean {
-  return Object.values(KNOWN_AGENT_SKILLS).every((v) => TAXONOMY_IDS.has(v.id)) && TAXONOMY_IDS.has(CONFIRMED_LIVE_SKILL.id);
+  return Object.values(KNOWN_AGENT_SKILLS).every((v) => TAXONOMY_IDS.has(v.id)) && TAXONOMY_IDS.has(FALLBACK_SKILL.id);
 }


### PR DESCRIPTION
## Summary

Upstream maintainer @akijakya ([agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943)) found the real root cause of the "id-only Directory validation" issue in minutes: it was our bug, not a validator inconsistency.

`oasf/publish.ts` declared `schema_version: '0.8.0'` on every pushed record while `taxonomy.generated.json`'s ids/names come from OASF **1.1.0**'s taxonomy. The Directory server validates a skill against the taxonomy for the record's *own declared* version — so every 1.1.0-derived id/name was checked against the 0.8.0 taxonomy and correctly rejected. `id=60101` only "worked" by coincidence (0.8.0 has an unrelated skill, "indexing", at that same numeric slot).

**Fixed:** `schema_version` is now `'1.1.0'`. Re-verified live — all 9 previously-"broken" ids now push successfully, and sending `id`+`name` together (self-documenting, not id-only) also works. Removed the `SEND_REAL_TAXONOMY_IDS` workaround flag entirely — `KNOWN_AGENT_SKILLS` now sends real `{id, name}` pairs unconditionally.

Closed [agntcy/dir#1943](https://github.com/agntcy/dir/issues/1943) with the resolution and thanks. Corrected the README/ADR-240 sections that had (incorrectly) framed this as a deeper upstream inconsistency.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 83/83 vitest tests pass
- [x] Live-verified: pushed a record with real internal capabilities (`orchestrator`, `maintainer`) that previously required the fallback workaround — now succeeds via the real, correctly-mapped taxonomy id+name, not a fallback
- [x] Live spot-check: all 9 previously-rejected ids (60501, 60701, 100101, 70906, 90502, 60704, 70904, 71003, plus 60101) now push successfully with the corrected schema_version

🤖 Generated with [Claude Code](https://claude.com/claude-code)