### PR TITLE
feat(flywheel): anytime-valid sequential evidence for promotion gates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5129,7 +5129,7 @@
     },
     "packages/flywheel": {
       "name": "@metaharness/flywheel",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4.0",

--- a/packages/flywheel/__tests__/sequential.test.ts
+++ b/packages/flywheel/__tests__/sequential.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import { meetsPromotionRule } from '../src/gate.js';
+import {
+  sequentialEvidence,
+  withSequentialEvidence,
+  type PairedOutcome,
+} from '../src/sequential.js';
+import type { PromotionEvidence, Score } from '../src/types.js';
+
+const pair = (itemId: string, candidateWon: boolean, baselineWon: boolean): PairedOutcome => ({
+  itemId,
+  candidateWon,
+  baselineWon,
+});
+
+/** n discordant pairs, all favoring the candidate. */
+const candidateWins = (n: number): PairedOutcome[] =>
+  Array.from({ length: n }, (_, i) => pair(`w${i}`, true, false));
+
+const score = (over: Partial<Score> = {}): Score => ({
+  primary: 0.5,
+  noopRate: 0.5,
+  costPerWin: 10,
+  regressed: false,
+  ...over,
+});
+
+describe('sequentialEvidence', () => {
+  it('starts at 1 with no outcomes and is not significant', () => {
+    const v = sequentialEvidence([]);
+    expect(v.eValue).toBe(1);
+    expect(v.significant).toBe(false);
+    expect(v.threshold).toBe(20);
+  });
+
+  it('ignores concordant pairs entirely', () => {
+    // Both arms winning (or both losing) says nothing about which is better.
+    const v = sequentialEvidence([
+      pair('a', true, true),
+      pair('b', false, false),
+      pair('c', true, true),
+    ]);
+    expect(v.eValue).toBe(1);
+    expect(v.informativePairs).toBe(0);
+    expect(v.totalPairs).toBe(3);
+  });
+
+  it('accumulates evidence only from discordant pairs', () => {
+    const v = sequentialEvidence([
+      pair('a', true, true), // concordant
+      pair('b', true, false), // favors candidate
+      pair('c', true, false), // favors candidate
+    ]);
+    expect(v.informativePairs).toBe(2);
+    expect(v.eValue).toBeCloseTo(1.5 * 1.5, 10);
+  });
+
+  it('reaches significance after enough consistent wins', () => {
+    // 1.5^n >= 20  =>  n >= 7.39, so 8 is the first significant count.
+    expect(sequentialEvidence(candidateWins(7)).significant).toBe(false);
+    expect(sequentialEvidence(candidateWins(8)).significant).toBe(true);
+  });
+
+  it('is driven back down by losses', () => {
+    const v = sequentialEvidence([...candidateWins(8), pair('l1', false, true)]);
+    expect(v.eValue).toBeCloseTo(1.5 ** 8 * 0.5, 10);
+    expect(v.significant).toBe(false);
+  });
+
+  it('a coin-flip split does not reach significance', () => {
+    // The property that matters: noise must not promote. Under the null,
+    // P(ever crossing 1/alpha) <= alpha by Ville's inequality.
+    const alternating = Array.from({ length: 200 }, (_, i) =>
+      pair(`x${i}`, i % 2 === 0, i % 2 !== 0),
+    );
+    expect(sequentialEvidence(alternating).significant).toBe(false);
+  });
+
+  it('never crosses the threshold under a null sequence, however long', () => {
+    // Peeking is free: this is checked at EVERY prefix, not just the end.
+    const alternating = Array.from({ length: 500 }, (_, i) =>
+      pair(`x${i}`, i % 2 === 0, i % 2 !== 0),
+    );
+    for (let n = 0; n <= alternating.length; n++) {
+      expect(sequentialEvidence(alternating.slice(0, n)).significant).toBe(false);
+    }
+  });
+
+  it('honours a stricter alpha', () => {
+    const eight = candidateWins(8);
+    expect(sequentialEvidence(eight, { alpha: 0.05 }).significant).toBe(true);
+    expect(sequentialEvidence(eight, { alpha: 0.001 }).significant).toBe(false);
+  });
+
+  it('rejects out-of-range parameters instead of silently clamping', () => {
+    expect(() => sequentialEvidence([], { alpha: 0 })).toThrow(RangeError);
+    expect(() => sequentialEvidence([], { alpha: 1 })).toThrow(RangeError);
+    expect(() => sequentialEvidence([], { lambda: 0 })).toThrow(RangeError);
+    expect(() => sequentialEvidence([], { lambda: 1 })).toThrow(RangeError);
+  });
+});
+
+describe('withSequentialEvidence', () => {
+  const passingEvidence = (outcomes?: PairedOutcome[]): PromotionEvidence =>
+    ({
+      baseline: score(),
+      candidate: score({ primary: 0.9, noopRate: 0.1, costPerWin: 5 }),
+      ...(outcomes ? { pairedOutcomes: outcomes } : {}),
+    }) as PromotionEvidence;
+
+  it('degrades to the base rule when no paired outcomes are supplied', () => {
+    // A caller that has not wired per-item outcomes yet must get the old
+    // behaviour, not a permanently closed gate.
+    const rule = withSequentialEvidence(meetsPromotionRule);
+    expect(rule(passingEvidence()).promote).toBe(true);
+  });
+
+  it('blocks a candidate that clears the frozen gate on thin evidence', () => {
+    const rule = withSequentialEvidence(meetsPromotionRule);
+    const decision = rule(passingEvidence(candidateWins(3)));
+    expect(meetsPromotionRule(passingEvidence(candidateWins(3))).promote).toBe(true);
+    expect(decision.promote).toBe(false);
+    expect(decision.reasons.some((r) => r.startsWith('insufficient_sequential_evidence'))).toBe(
+      true,
+    );
+  });
+
+  it('promotes when both the frozen gate and the evidence agree', () => {
+    const rule = withSequentialEvidence(meetsPromotionRule);
+    expect(rule(passingEvidence(candidateWins(8))).promote).toBe(true);
+  });
+
+  it('never promotes something the base rule rejected, however strong the evidence', () => {
+    // Composition must be conjunctive: evidence cannot buy its way past a
+    // safety regression or a cost blowout.
+    const rule = withSequentialEvidence(meetsPromotionRule);
+    const regressed = {
+      baseline: score(),
+      candidate: score({ primary: 0.9, noopRate: 0.1, regressed: true }),
+      pairedOutcomes: candidateWins(50),
+    } as PromotionEvidence;
+    const decision = rule(regressed);
+    expect(decision.promote).toBe(false);
+    expect(decision.reasons).toContain('safety_regressed');
+  });
+
+  it('preserves the base rule reasons alongside its own', () => {
+    const rule = withSequentialEvidence(meetsPromotionRule);
+    const noopNotImproved = {
+      baseline: score(),
+      candidate: score({ primary: 0.9, noopRate: 0.5 }),
+      pairedOutcomes: candidateWins(2),
+    } as PromotionEvidence;
+    const decision = rule(noopNotImproved);
+    expect(decision.reasons).toContain('noop_rate_not_improved');
+    expect(decision.reasons.some((r) => r.startsWith('insufficient_sequential_evidence'))).toBe(
+      true,
+    );
+  });
+});

--- a/packages/flywheel/package.json
+++ b/packages/flywheel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/flywheel",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A verifiable self-improvement loop for agent harnesses. Freeze the model. Evolve the harness. Promote only what proves lift.",
   "type": "module",
   "main": "./dist/cjs/index.js",

--- a/packages/flywheel/src/index.ts
+++ b/packages/flywheel/src/index.ts
@@ -8,6 +8,8 @@ export { runFlywheelGenerations } from './run.js';
 export type { FlywheelConfig, FlywheelResult } from './run.js';
 
 export { meetsPromotionRule, gateFingerprint } from './gate.js';
+export { sequentialEvidence, withSequentialEvidence } from './sequential.js';
+export type { PairedOutcome, SequentialConfig, SequentialVerdict } from './sequential.js';
 export { makeSigner, verifyReceipt, canon } from './receipts.js';
 export { InMemoryLineageStore, computeLiftCurve, liftPoint } from './lineage.js';
 export { verifyReplayBundle } from './replay.js';

--- a/packages/flywheel/src/sequential.ts
+++ b/packages/flywheel/src/sequential.ts
@@ -1,0 +1,145 @@
+// @metaharness/flywheel — anytime-valid sequential testing for promotion gates.
+//
+// WHY THIS EXISTS
+//
+// `meetsPromotionRule` is a single-shot conjunctive comparison, and it is the
+// right shape: frozen, fingerprintable, every clause load-bearing. But a
+// flywheel run evaluates MANY generations against the SAME holdout, and that is
+// uncontrolled multiple testing. Published measurements of greedy
+// "accept-if-the-score-improved" acceptance put the false-commit rate at
+// 30-42%, and found 13-21 spurious modifications made even when NO true gains
+// existed — degrading one agent by 4.9 points while every individual decision
+// looked locally justified.
+//
+// The conjunctive gate plus a frozen anchor already mitigates this with
+// multiple hurdles, which is real. It is not, however, anytime-valid: nothing
+// in it accounts for how many times you have looked.
+//
+// This module adds that missing property WITHOUT touching the default gate,
+// whose stability is itself the product. It composes: wrap any PromotionRule,
+// and a candidate must clear both the frozen clauses AND accumulated evidence.
+//
+// METHOD
+//
+// Testing-by-betting / e-processes. An e-value is a non-negative random
+// variable with expectation <= 1 under the null hypothesis ("this candidate is
+// no better than baseline"). By Ville's inequality, P(sup_t E_t >= 1/alpha)
+// <= alpha, so you may stop and reject at ANY time — no pre-registered sample
+// size, no alpha spending schedule, and no penalty for peeking. That is exactly
+// the property a flywheel needs, because it peeks by construction.
+//
+// The bet here is deliberately simple and assumption-light: per paired item,
+// a candidate win against a baseline loss multiplies the e-value up, the
+// reverse multiplies it down, and ties leave it unchanged.
+
+import type { PromotionDecision, PromotionEvidence, PromotionRule } from './types.js';
+
+/** Per-item paired outcome: did candidate and baseline each succeed? */
+export interface PairedOutcome {
+  /** Suite item id. Pairing is by item — comparing unpaired sets is a different, weaker test. */
+  itemId: string;
+  candidateWon: boolean;
+  baselineWon: boolean;
+}
+
+export interface SequentialConfig {
+  /**
+   * Type-I error bound. Reject the null only when the e-value reaches 1/alpha.
+   * Default 0.05 => threshold 20.
+   */
+  alpha?: number;
+  /**
+   * Betting fraction in (0, 1). Higher detects large effects sooner but is
+   * slower on small ones. 0.5 is the Kelly-ish default and needs no tuning.
+   */
+  lambda?: number;
+}
+
+export interface SequentialVerdict {
+  /** True when accumulated evidence crosses 1/alpha. */
+  significant: boolean;
+  /** The e-value. Interpretable directly: 20 means "20:1 against the null". */
+  eValue: number;
+  threshold: number;
+  /** Items where the two arms disagreed — the only ones carrying information. */
+  informativePairs: number;
+  totalPairs: number;
+}
+
+const DEFAULT_ALPHA = 0.05;
+const DEFAULT_LAMBDA = 0.5;
+
+/**
+ * Accumulate paired outcomes into an anytime-valid e-value.
+ *
+ * Only discordant pairs move the e-value: if both arms win or both lose, that
+ * item tells you nothing about which is better (this is the McNemar insight,
+ * carried over to the sequential setting).
+ */
+export function sequentialEvidence(
+  outcomes: PairedOutcome[],
+  config: SequentialConfig = {},
+): SequentialVerdict {
+  const alpha = config.alpha ?? DEFAULT_ALPHA;
+  const lambda = config.lambda ?? DEFAULT_LAMBDA;
+
+  if (!(alpha > 0 && alpha < 1)) throw new RangeError('alpha must be in (0, 1)');
+  if (!(lambda > 0 && lambda < 1)) throw new RangeError('lambda must be in (0, 1)');
+
+  const threshold = 1 / alpha;
+  let eValue = 1;
+  let informativePairs = 0;
+
+  for (const o of outcomes) {
+    if (o.candidateWon === o.baselineWon) continue; // concordant: no information
+    informativePairs++;
+    // Under the null, a discordant pair favors either arm with probability 1/2,
+    // so E[multiplier] = 1 and the process is a non-negative martingale.
+    eValue *= o.candidateWon ? 1 + lambda : 1 - lambda;
+  }
+
+  return {
+    significant: eValue >= threshold,
+    eValue,
+    threshold,
+    informativePairs,
+    totalPairs: outcomes.length,
+  };
+}
+
+/**
+ * Compose a frozen gate with a sequential-evidence requirement.
+ *
+ * The returned rule is still a plain `PromotionRule`, so it fingerprints and
+ * freezes exactly like the default one. A candidate must satisfy BOTH: every
+ * clause of `baseRule`, and evidence strong enough to survive having been
+ * looked at repeatedly.
+ *
+ * Paired outcomes are read from `evidence.pairedOutcomes` when present. When
+ * absent the rule degrades to `baseRule` alone rather than silently blocking
+ * every promotion — a caller that has not wired up per-item outcomes yet should
+ * get the old behavior, not a permanently closed gate.
+ */
+export function withSequentialEvidence(
+  baseRule: PromotionRule,
+  config: SequentialConfig = {},
+): PromotionRule {
+  return function sequentialPromotionRule(evidence: PromotionEvidence): PromotionDecision {
+    const base = baseRule(evidence);
+    const outcomes = (evidence as PromotionEvidence & { pairedOutcomes?: PairedOutcome[] })
+      .pairedOutcomes;
+
+    if (!outcomes) return base;
+
+    const verdict = sequentialEvidence(outcomes, config);
+    if (verdict.significant) return base;
+
+    return {
+      promote: false,
+      reasons: [
+        ...base.reasons,
+        `insufficient_sequential_evidence(e=${verdict.eValue.toFixed(2)}<${verdict.threshold})`,
+      ],
+    };
+  };
+}


### PR DESCRIPTION
## What

Adds `withSequentialEvidence` — an optional wrapper that composes any `PromotionRule` with an anytime-valid sequential test. **The default gate is unchanged.**

## Why

`meetsPromotionRule` is a single-shot conjunctive comparison, and that shape is right: frozen, fingerprintable, every clause load-bearing. But a flywheel run evaluates *many* generations against the *same* holdout, and that is uncontrolled multiple testing.

Published measurements of greedy accept-if-improved acceptance put the false-commit rate at **30–42%**, and found **13–21 spurious modifications** made even when *no true gains existed* — degrading one agent by 4.9 points, while every individual decision looked locally justified.

The conjunctive gate plus a frozen anchor already mitigates this with multiple hurdles. That's real. It is not, however, anytime-valid: nothing in it accounts for how many times you've looked.

## Method

Testing-by-betting. An e-value has expectation ≤ 1 under the null, so by Ville's inequality you may stop and reject at **any** time — no pre-registered sample size, no alpha-spending schedule, no penalty for peeking. That's exactly what a flywheel needs, because it peeks by construction.

Only discordant pairs move the e-value: an item both arms win tells you nothing about which is better.

## Design notes

- **Composes, doesn't replace.** Returns a plain `PromotionRule`, so it fingerprints and freezes identically. Conjunctive — evidence cannot buy a candidate past a safety regression or a cost blowout.
- **Degrades safely.** With no `pairedOutcomes` supplied it falls through to the base rule, so a caller who hasn't wired per-item outcomes yet gets today's behavior rather than a permanently closed gate.
- **Parameters are validated**, not silently clamped.

## Tests

Includes the property that matters most, stated as a test rather than a comment: a null (coin-flip) sequence is checked at **every prefix up to n=500** and never crosses the threshold.

⚠️ **Not executed here.** `vitest` isn't installed in my environment, so I could not run the suite. I verified the e-value arithmetic independently against the same fixtures: 7 wins → 17.09 (below threshold 20), 8 wins → 25.63 (above), one loss pulling 25.63 back to 12.81, and the null sequence never significant at any prefix. `tsc` reports no errors in the new file — the `@types/node` errors present are pre-existing and hit `cli.ts`/`gate.ts` equally. **Please run CI before trusting the suite.**

## Context

Came out of adopting the flywheel as rvAgent's promotion engine (RuVector ADR-278). Rather than only consume the package, this is the one gap I found worth contributing back.

---
_Generated by [Claude Code](https://claude.ai/code/session_019mt39sZNUecTJBBBqPRH9F)_