### PR TITLE
fix(minimal-template): document --version in the minimal template's CLAUDE.md

### DIFF
--- a/packages/create-agent-harness/templates/minimal/CLAUDE.md.tmpl
+++ b/packages/create-agent-harness/templates/minimal/CLAUDE.md.tmpl
@@ -16,6 +16,7 @@ After `{{name}} init`, the following are available:
 |---|---|
 | `{{name}} init` | Scaffold the harness into the current project |
 | `{{name}} doctor` | Health check the install |
+| `{{name}} --version` | Print the kernel version |
 
 Run `{{name}} --help` for the full list. Memory ranking and routing are kernel
 primitives used programmatically (see [@metaharness/kernel](https://www.npmjs.com/package/@metaharness/kernel)),


### PR DESCRIPTION
Supersedes #52. That PR's underlying issue (#48 — phantom `memory search`/`route` docs) was already fixed on `main` a different way while #52 sat stale, so #52 now conflicts and its own CI fails against a `scripts/gcp-cluster.mjs` path-lint rule that's unrelated to its actual change and was already fixed on `main` after #52's branch was cut.

Diffing #52's proposed commands table against what's on `main` today, #52 was still marginally more accurate — it documented `--version` as a row, which `main`'s current wording omits (only mentions `--help` in prose). Verified against the real implementation (`packages/create-agent-harness/templates/minimal/bin/cli.js.tmpl`'s `run()` switch): `init`, `doctor`, `--version`/`-v`, `--help`/`-h` are exactly the four commands. This PR adds the missing `--version` row so the table is complete.

## Test plan
- [x] `packages/create-agent-harness` full test suite: 396/396 pass, no snapshot changes.

Co-Authored-By: RuFlo <ruv@ruv.net>