### PR TITLE
release: version bumps for #150/#141/#85/#161 content changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4992,10 +4992,10 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
-        "@metaharness/darwin": "^0.2.2",
+        "@metaharness/darwin": "^0.8.0",
         "@metaharness/flywheel": "^0.1.1",
         "@metaharness/redblue": "^0.1.1",
         "@metaharness/weight-eft": "^0.1.0",
@@ -5027,21 +5027,9 @@
         }
       }
     },
-    "packages/create-agent-harness/node_modules/@metaharness/darwin": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.2.8.tgz",
-      "integrity": "sha512-B8tF7IrrSxwKS6fEPEL6N2Juth9WWn+hppLUtUYPTJ2vcHzzZPIg2cS5T9qTyNNuANlTSWnQHnvzlfvYdGNfeQ==",
-      "license": "MIT",
-      "bin": {
-        "metaharness-darwin": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
     "packages/darwin-mode": {
       "name": "@metaharness/darwin",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "bin": {
         "metaharness-darwin": "dist/cli.js"
@@ -5138,7 +5126,7 @@
     },
     "packages/harness": {
       "name": "@metaharness/harness",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4.0",
@@ -5372,7 +5360,7 @@
     },
     "packages/router": {
       "name": "@metaharness/router",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "devDependencies": {
         "@ruvector/tiny-dancer": "^0.1.21",
@@ -5453,7 +5441,7 @@
     },
     "packages/workspace-lens": {
       "name": "@metaharness/workspace-lens",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4.0",

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/darwin-mode/package.json
+++ b/packages/darwin-mode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/darwin",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Freeze the model, evolve the harness. Two measured applications: (1) SWE-bench code-repair \u2014 conformant GLM->Opus empty-patch cascade resolves 51.3% Lite (n=300) and 55.6% Verified (278/500, Wilson 95% CI [51.2, 59.9], official swebench gold eval, no gold tests in-loop, ~$0.15/instance est.); the same cheap->frontier cascade generalizes across both splits at ~56x cheaper than frontier-only; (2) Darwin Shield (v0.3.0) \u2014 a defensive zero-day discovery harness (Semgrep + fuzz oracles, safety-gated, deterministic replay). The harness, not the model, is the lever. Dependency-free (Node built-ins).",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/harness/package.json
+++ b/packages/harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/harness",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Algorithmic Agent Harness (ADR-047) — a deterministic control plane that wraps any model/tool/skill as a replaceable worker: utility-scored decisions, four-gate safety, hash-chained receipts, circuit-breaker recovery, adversarial verification, and a bandit agent pool. The model proposes, the harness decides, the algorithms verify.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/router",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Cost-optimal model router for AI agent harnesses — route each query to the cheapest model that's good enough (k-NN over labelled embeddings). The productized DRACO Phase-2 finding.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/workspace-lens/package.json
+++ b/packages/workspace-lens/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/workspace-lens",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Jacobian-Lens interpretability primitive for open-weight LLMs (Anthropic 2026-07-06, 'Verbalizable Representations Form a Global Workspace'). Reads the model's functional workspace at inference time — lens_l(h)=unembed(J_l·h) — into workspace tokens, layer-trajectory, drift/entropy scores, vectorized safety flags, and a signable interpretability receipt. Runtime-only (fitting is external); model-agnostic; dependency-free.",
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/healthcheck.mjs
+++ b/scripts/healthcheck.mjs
@@ -79,6 +79,11 @@ const CHECKS = {
       // published library on its own semver (published 0.1.1 with the umbrella-CLI
       // wiring, like weight-eft/redblue).
       '@metaharness/flywheel',
+      // @metaharness/harness (the hash-chained receipt audit log, ADR-047/011) is a
+      // standalone published library on its own semver, like workspace-lens/router —
+      // its ReceiptLog export/import/merge surface (0.2.0) ships independently of the
+      // umbrella-CLI's lockstep version.
+      '@metaharness/harness',
       // @metaharness/evals-hle (HLE benchmark adapter for the flywheel, ADR-233) is a
       // standalone published adapter on its own semver — not core, not umbrella-bundled.
       '@metaharness/evals-hle',


### PR DESCRIPTION
None of #150, #141, #85, #161 bumped the version of the package(s) they changed, so none of those fixes/features are reachable via \`npm install\` yet. This is a pure version-bump PR, no functional changes.

| Package | Bump | Reason |
|---|---|---|
| \`metaharness\` | 0.4.2 -> 0.4.3 (patch) | darwin pin bump (#150) + \`--version\` doc row (#161) |
| \`@metaharness/darwin\` | 0.8.0 -> 0.8.1 (patch) | O(n) clade aggregation + dist/src drift fix (#141), internal only |
| \`@metaharness/router\` | 0.3.2 -> 0.3.3 (patch) | k-NN norm caching + mismatched-length regression fix (#141), internal only |
| \`@metaharness/workspace-lens\` | 0.1.1 -> 0.1.2 (patch) | concept-vector norm caching (#141), internal only |
| \`@metaharness/harness\` | 0.1.0 -> 0.2.0 (minor) | \`ReceiptLog\` gains public export/import/merge/etc. (#85) — new API surface |

## Test plan
- [x] Full workspace build (\`node scripts/build-ordered.mjs\`) clean.
- [x] Full workspace \`npm run test\`: 0 failures.
- [x] \`packages/darwin-mode/dist/\` re-verified byte-identical to a fresh \`tsc\` build after the bump.

Co-Authored-By: RuFlo <ruv@ruv.net>