### PR TITLE
release: metaharness 0.4.4 — pin meta-proxy 0.7.2

### DIFF
--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -26,7 +26,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
-export const META_PROXY_VERSION = '0.7.1';
+export const META_PROXY_VERSION = '0.7.2';
 export const META_PROXY_RELEASE_BASE = 'https://github.com/cognitum-one/meta-proxy-dist/releases/download';
 
 /** The release signing key, pinned in the client rather than fetched from GitHub. */


### PR DESCRIPTION
Hop 3a of the meta-proxy **v0.7.2** release chain — the hop that actually reaches users, since this is the package `npx metaharness` installs.

`META_PROXY_VERSION` `0.7.1` → `0.7.2`, and `metaharness` `0.4.3` → `0.4.4` so the pin ships. A pin bump without a version bump is inert.

## Upstream is live and verified before this pin moves

Checked unauthenticated against the public mirror, the way a user's install does:

```
200  meta-proxy-0.7.2-aarch64-apple-darwin.tar.gz
200  meta-proxy-0.7.2-x86_64-apple-darwin.tar.gz
200  meta-proxy-0.7.2-aarch64-unknown-linux-gnu.tar.gz
200  meta-proxy-0.7.2-x86_64-unknown-linux-gnu.tar.gz
200  meta-proxy-0.7.2-x86_64-pc-windows-msvc.zip

SHA256SUMS.sig  → verifies against the pinned public key
downloaded .tar.gz sha256 → matches the signed SHA256SUMS
```

Every asset name `META_PROXY_VERSION` produces exists, and the integrity chain `proxy install` relies on holds end to end.

## What 0.7.2 fixes

[cognitum-one/meta-proxy#74](https://github.com/cognitum-one/meta-proxy/issues/74):

- **`--help` panicked.** It matched no dispatch arm, fell through to the server path, and panicked binding 11435 when the managed sidecar already held it — reading to the user as though the proxy had crashed. It now prints usage and exits 0 before any config read, network call or socket bind.
- **A taken port** exits 1 with `error: port <N> is already in use — meta-proxy may already be running (try: metaharness proxy status)` instead of a `RUST_BACKTRACE` hint.
- **An unrecognised argument** exits 2 with usage rather than silently starting a server.
- **`--verbose` / `-v`** raises logging to debug — upstream URL, relayed headers, and the auth scheme by name, never its secret.
- **One log line per request** on every completion route, at the default level, including requests rejected before a handler runs. Previously `meta-proxy.log` held only process-start lines, so "why did this 402?" had to be reconstructed by hand with curl.

The stricter argument handling does not affect this package: `installMetaProxy` never executes the binary except for the side-effect-free `--version` probe, which is unchanged.

## One thing to know before merging

`npm ci` fails on this repo at `main` with a pre-existing lockfile desync — `@metaharness/kernel-darwin-arm64`, `-darwin-x64`, `-linux-arm64-gnu`, `-linux-x64-gnu` are missing from `package-lock.json`. I confirmed it reproduces on an unmodified checkout, so it is **not** caused by this change, and I deliberately did not fix it here: regenerating a lockfile that pulls native artifacts does not belong in a pin bump. Worth its own issue.

That does mean I could not run the repo's own suite locally. The change is two literals; the contract they encode is verified above against the live mirror.