### PR TITLE
feat(proxy): opt-in start-at-login for the Meta-Proxy sidecar

### DIFF
--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -1,0 +1,199 @@
+// Coverage for the supervised sidecar lifecycle (cognitum-one/meta-proxy#82).
+//
+// The OS commands go through an injected runner and every unit-file renderer is
+// pure, so the full macOS/Linux/Windows matrix is asserted on one machine
+// without touching launchctl, systemctl or schtasks.
+
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  disableCommands,
+  disableMetaProxyService,
+  enableCommands,
+  enableMetaProxyService,
+  metaProxyServiceState,
+  renderLaunchAgent,
+  renderScheduledTask,
+  renderSystemdUnit,
+  serviceUnitPath,
+  SERVICE_LABEL,
+  type CommandOutcome,
+  type ServiceCommand,
+} from '../src/meta-proxy-service.js';
+import { metaProxyBinaryPath } from '../src/meta-proxy.js';
+
+let home: string;
+
+/** Records what would have been run, and lets a test force a failure. */
+function recorder(ok = true) {
+  const calls: ServiceCommand[] = [];
+  const run = (invocation: ServiceCommand): CommandOutcome => {
+    calls.push(invocation);
+    return ok ? { ok: true, output: '' } : { ok: false, output: 'boom' };
+  };
+  return { calls, run };
+}
+
+/** Puts a fake installed daemon where `metaProxyBinaryPath` expects one. */
+function installFakeDaemon(platform: NodeJS.Platform): string {
+  const binary = metaProxyBinaryPath(platform, home);
+  mkdirSync(dirname(binary), { recursive: true });
+  writeFileSync(binary, '#!/bin/sh\nexit 0\n');
+  return binary;
+}
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), 'mh-service-'));
+});
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe('unit rendering', () => {
+  it('keeps a deliberate stop stopped on macOS', () => {
+    const plist = renderLaunchAgent('/bin/meta-proxy', '/tmp/p.log');
+    expect(plist).toContain('<key>RunAtLoad</key>');
+    // KeepAlive:true would fight `proxy stop` forever; SuccessfulExit:false
+    // restarts a crash but respects a clean exit.
+    expect(plist).toContain('<key>SuccessfulExit</key>');
+    expect(plist).toContain('<false/>');
+    expect(plist).toContain(SERVICE_LABEL);
+  });
+
+  it('escapes a home directory that contains XML metacharacters', () => {
+    const plist = renderLaunchAgent('/Users/a&b/meta-proxy', '/tmp/p.log');
+    expect(plist).toContain('/Users/a&amp;b/meta-proxy');
+    expect(plist).not.toContain('/Users/a&b/');
+    const task = renderScheduledTask('C:\\Users\\a&b\\meta-proxy.exe');
+    expect(task).toContain('a&amp;b');
+  });
+
+  it('installs the Linux unit into the user session, not system-wide', () => {
+    const unit = renderSystemdUnit('/bin/meta-proxy');
+    // default.target is start-at-login. Booting a machine nobody logged into
+    // must not run a user's proxy.
+    expect(unit).toContain('WantedBy=default.target');
+    expect(unit).toContain('Restart=on-failure');
+    expect(unit).toContain('ExecStart=/bin/meta-proxy');
+    expect(unit).not.toContain('multi-user.target');
+  });
+
+  it('restarts on failure on Windows and does not time out', () => {
+    const task = renderScheduledTask('C:\\meta-proxy.exe');
+    expect(task).toContain('<LogonTrigger>');
+    expect(task).toContain('<RestartOnFailure>');
+    // A long-lived daemon must not be killed by the default 72h limit.
+    expect(task).toContain('<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>');
+  });
+});
+
+describe('command construction', () => {
+  it('uses the user scope on every platform', () => {
+    expect(enableCommands('linux', '/u').every((c) => c.args.includes('--user'))).toBe(true);
+    expect(enableCommands('darwin', '/u')[0]!.args[1]).toMatch(/^gui\//);
+    expect(disableCommands('linux', '/u').every((c) => c.args.includes('--user'))).toBe(true);
+  });
+
+  it('has no commands for an unsupported platform', () => {
+    expect(enableCommands('freebsd' as NodeJS.Platform, '/u')).toEqual([]);
+    expect(serviceUnitPath('freebsd' as NodeJS.Platform, home)).toBeNull();
+  });
+});
+
+describe('enable', () => {
+  it('refuses when the daemon is not installed', () => {
+    const { calls, run } = recorder();
+    const result = enableMetaProxyService({ home, platform: 'darwin', run });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('proxy install --yes');
+    // Nothing ran and nothing was written.
+    expect(calls).toEqual([]);
+    expect(existsSync(serviceUnitPath('darwin', home)!)).toBe(false);
+  });
+
+  it('writes the definition and loads it', () => {
+    const binary = installFakeDaemon('darwin');
+    const { calls, run } = recorder();
+    const result = enableMetaProxyService({ home, platform: 'darwin', run });
+
+    expect(result.ok).toBe(true);
+    const unitPath = serviceUnitPath('darwin', home)!;
+    expect(existsSync(unitPath)).toBe(true);
+    expect(calls[0]!.command).toBe('launchctl');
+    expect(calls[0]!.args[0]).toBe('bootstrap');
+    // The definition points at the managed binary, not a PATH lookup.
+    expect(result.unitPath).toBe(unitPath);
+    expect(binary.length).toBeGreaterThan(0);
+  });
+
+  /// A unit file present but never loaded makes `proxy status` claim
+  /// start-at-login is on when it is not.
+  it('leaves nothing behind when the service manager rejects it', () => {
+    installFakeDaemon('linux');
+    const { run } = recorder(false);
+    const result = enableMetaProxyService({ home, platform: 'linux', run });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('boom');
+    expect(existsSync(serviceUnitPath('linux', home)!)).toBe(false);
+  });
+
+  it('says so rather than pretending on an unsupported platform', () => {
+    const result = enableMetaProxyService({ home, platform: 'freebsd' as NodeJS.Platform });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('not supported');
+  });
+});
+
+describe('disable', () => {
+  it('removes the definition and leaves the daemon binary alone', () => {
+    const binary = installFakeDaemon('darwin');
+    const { run } = recorder();
+    enableMetaProxyService({ home, platform: 'darwin', run });
+
+    const result = disableMetaProxyService({ home, platform: 'darwin', run });
+    expect(result.ok).toBe(true);
+    expect(existsSync(serviceUnitPath('darwin', home)!)).toBe(false);
+    // Disabling supervision is not uninstalling the proxy.
+    expect(existsSync(binary)).toBe(true);
+  });
+
+  it('is a no-op when start-at-login was never enabled', () => {
+    const { calls, run } = recorder();
+    const result = disableMetaProxyService({ home, platform: 'linux', run });
+    expect(result.ok).toBe(true);
+    expect(result.message).toContain('not set to start at login');
+    expect(calls).toEqual([]);
+  });
+
+  /// A stale definition left behind is the state that lies to `proxy status`,
+  /// so removal must not be conditional on the service manager cooperating.
+  it('still removes the definition when the service manager complains', () => {
+    installFakeDaemon('linux');
+    const ok = recorder();
+    enableMetaProxyService({ home, platform: 'linux', run: ok.run });
+
+    const failing = recorder(false);
+    const result = disableMetaProxyService({ home, platform: 'linux', run: failing.run });
+    expect(result.ok).toBe(true);
+    expect(existsSync(serviceUnitPath('linux', home)!)).toBe(false);
+    expect(result.message).toContain('boom');
+  });
+});
+
+describe('state reporting', () => {
+  it('distinguishes enabled from disabled from unsupported', () => {
+    expect(metaProxyServiceState('darwin', home).installed).toBe(false);
+
+    installFakeDaemon('darwin');
+    enableMetaProxyService({ home, platform: 'darwin', run: recorder().run });
+    expect(metaProxyServiceState('darwin', home).installed).toBe(true);
+
+    const unsupported = metaProxyServiceState('freebsd' as NodeJS.Platform, home);
+    expect(unsupported.supported).toBe(false);
+    expect(unsupported.unitPath).toBeNull();
+  });
+});

--- a/packages/create-agent-harness/src/index.ts
+++ b/packages/create-agent-harness/src/index.ts
@@ -718,7 +718,7 @@ export async function main(argv: string[]): Promise<number> {
     console.log('       npx metaharness analyze <repo>           (recommend a harness plan, no-exec)');
     console.log('       npx metaharness genome <repo>            (7-section repo readiness)');
     console.log('       npx metaharness learn --host <h> --model <m> --slice <manifest>   (ADR-235 GEPA learning run — $0 dry-run by default, --run to spend; needs a repo checkout)');
-    console.log('       npx metaharness proxy <install|status|start|stop|path|login|logout>  (optional signed Cognitum Meta-Proxy sidecar)');
+    console.log('       npx metaharness proxy <install|status|start|stop|enable|disable|path|login|logout>  (optional signed Cognitum Meta-Proxy sidecar)');
     console.log('       npx metaharness --from-existing [./path]');
     console.log('       npx metaharness --wizard          (iter 100 — interactive picker)');
     console.log('       npx metaharness --list            (browse all templates)');

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -1,0 +1,336 @@
+// Supervised lifecycle for the Meta-Proxy sidecar (cognitum-one/meta-proxy#82).
+//
+// `metaharness proxy start` launches the sidecar for the life of that invocation
+// only. Nothing starts it at login and nothing restarts it if it exits, so after
+// a reboot `proxy status` reports "not running" and every tool pointed at
+// 127.0.0.1:11435 — the VS Code console, the configured terminal, any
+// Anthropic-compatible client — fails until someone remembers a CLI command.
+// The failure lands on whatever the user was doing at the time, not at a moment
+// when they are thinking about proxy lifecycle.
+//
+// ## Opt-in, always
+//
+// Installing something that survives reboots is not done silently. There is no
+// implicit enable inside `proxy install`; the user runs `proxy enable` and the
+// command says exactly which file it wrote and how to undo it.
+//
+// ## Shape
+//
+// Every unit-file renderer is a pure string function, and the OS commands go
+// through an injected runner, so the whole matrix is testable on one machine
+// without touching launchctl/systemctl/schtasks. That mirrors `installFromSource`
+// in meta-proxy.ts, which already takes an injected `run`.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { metaProxyBinaryPath, metaProxyDataDir } from './meta-proxy.js';
+
+/** Reverse-DNS label, shared by the launchd job and the scheduled task. */
+export const SERVICE_LABEL = 'one.cognitum.meta-proxy';
+
+export interface ServiceCommand {
+  command: string;
+  args: string[];
+}
+
+export interface CommandOutcome {
+  ok: boolean;
+  output: string;
+}
+
+export type CommandRunner = (invocation: ServiceCommand) => CommandOutcome;
+
+export interface ServiceResult {
+  ok: boolean;
+  message: string;
+  /** The unit/plist/task definition written, when one was. */
+  unitPath?: string;
+}
+
+export interface ServiceState {
+  supported: boolean;
+  /** A definition exists on disk (macOS/Linux) or the task is registered (Windows). */
+  installed: boolean;
+  unitPath: string | null;
+}
+
+function defaultRunner(invocation: ServiceCommand): CommandOutcome {
+  const result = spawnSync(invocation.command, invocation.args, {
+    encoding: 'utf8',
+    timeout: 15_000,
+    windowsHide: true,
+  });
+  const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+  if (result.error) return { ok: false, output: result.error.message };
+  return { ok: result.status === 0, output };
+}
+
+// --- unit file locations ----------------------------------------------------
+
+export function launchAgentPath(home = homedir()): string {
+  return join(home, 'Library', 'LaunchAgents', `${SERVICE_LABEL}.plist`);
+}
+
+export function systemdUnitPath(home = homedir()): string {
+  return join(home, '.config', 'systemd', 'user', 'meta-proxy.service');
+}
+
+/** The XML definition handed to `schtasks /create /xml`. */
+export function scheduledTaskPath(home = homedir()): string {
+  return join(metaProxyDataDir(home), 'meta-proxy-task.xml');
+}
+
+export function serviceUnitPath(platform: NodeJS.Platform, home = homedir()): string | null {
+  if (platform === 'darwin') return launchAgentPath(home);
+  if (platform === 'linux') return systemdUnitPath(home);
+  if (platform === 'win32') return scheduledTaskPath(home);
+  return null;
+}
+
+// --- pure renderers ---------------------------------------------------------
+
+/** Minimal XML escaping — a home directory can legitimately contain `&`. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * launchd job. `RunAtLoad` covers start-at-login and `KeepAlive.SuccessfulExit
+ * = false` covers restart-after-crash while still letting a deliberate
+ * `proxy stop` (SIGTERM, exit 0) stay stopped — a plain `KeepAlive: true` would
+ * fight the user's own stop command forever.
+ */
+export function renderLaunchAgent(binaryPath: string, logPath: string): string {
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${SERVICE_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${escapeXml(binaryPath)}</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>${escapeXml(logPath)}</string>
+  <key>StandardErrorPath</key>
+  <string>${escapeXml(logPath)}</string>
+  <key>ProcessType</key>
+  <string>Background</string>
+</dict>
+</plist>
+`;
+}
+
+/**
+ * systemd **user** unit. `default.target` is the user-session target, so this is
+ * start-at-login rather than start-at-boot; booting a machine nobody has logged
+ * into should not run a user's proxy. `Restart=on-failure` matches the launchd
+ * choice: a clean stop stays stopped.
+ */
+export function renderSystemdUnit(binaryPath: string): string {
+  return `[Unit]
+Description=Cognitum Meta-Proxy sidecar
+Documentation=https://github.com/cognitum-one/meta-proxy
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=${binaryPath}
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+/** Task Scheduler definition — Windows has no launchd/systemd equivalent. */
+export function renderScheduledTask(binaryPath: string): string {
+  return `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>Cognitum Meta-Proxy sidecar</Description>
+  </RegistrationInfo>
+  <Triggers>
+    <LogonTrigger>
+      <Enabled>true</Enabled>
+    </LogonTrigger>
+  </Triggers>
+  <Settings>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <RestartOnFailure>
+      <Interval>PT1M</Interval>
+      <Count>3</Count>
+    </RestartOnFailure>
+    <ExecutionTimeLimit>PT0S</ExecutionTimeLimit>
+    <Hidden>true</Hidden>
+  </Settings>
+  <Actions Context="Author">
+    <Exec>
+      <Command>${escapeXml(binaryPath)}</Command>
+    </Exec>
+  </Actions>
+</Task>
+`;
+}
+
+// --- the OS commands, as data so they can be asserted -----------------------
+
+export function enableCommands(platform: NodeJS.Platform, unitPath: string): ServiceCommand[] {
+  if (platform === 'darwin') {
+    // `bootstrap` is the modern replacement for `load -w`; `kickstart` starts it
+    // now so the user does not have to log out and back in to get a daemon.
+    return [
+      { command: 'launchctl', args: ['bootstrap', `gui/${process.getuid?.() ?? 0}`, unitPath] },
+      { command: 'launchctl', args: ['kickstart', `gui/${process.getuid?.() ?? 0}/${SERVICE_LABEL}`] },
+    ];
+  }
+  if (platform === 'linux') {
+    return [
+      { command: 'systemctl', args: ['--user', 'daemon-reload'] },
+      { command: 'systemctl', args: ['--user', 'enable', '--now', 'meta-proxy.service'] },
+    ];
+  }
+  if (platform === 'win32') {
+    return [
+      { command: 'schtasks', args: ['/create', '/tn', SERVICE_LABEL, '/xml', unitPath, '/f'] },
+      { command: 'schtasks', args: ['/run', '/tn', SERVICE_LABEL] },
+    ];
+  }
+  return [];
+}
+
+export function disableCommands(platform: NodeJS.Platform, unitPath: string): ServiceCommand[] {
+  if (platform === 'darwin') {
+    return [{ command: 'launchctl', args: ['bootout', `gui/${process.getuid?.() ?? 0}`, unitPath] }];
+  }
+  if (platform === 'linux') {
+    return [
+      { command: 'systemctl', args: ['--user', 'disable', '--now', 'meta-proxy.service'] },
+      { command: 'systemctl', args: ['--user', 'daemon-reload'] },
+    ];
+  }
+  if (platform === 'win32') {
+    return [{ command: 'schtasks', args: ['/delete', '/tn', SERVICE_LABEL, '/f'] }];
+  }
+  return [];
+}
+
+// --- public API -------------------------------------------------------------
+
+export function metaProxyServiceState(
+  platform: NodeJS.Platform = process.platform,
+  home = homedir(),
+): ServiceState {
+  const unitPath = serviceUnitPath(platform, home);
+  if (!unitPath) return { supported: false, installed: false, unitPath: null };
+  return { supported: true, installed: existsSync(unitPath), unitPath };
+}
+
+export interface ServiceOptions {
+  home?: string;
+  platform?: NodeJS.Platform;
+  run?: CommandRunner;
+}
+
+export function enableMetaProxyService(options: ServiceOptions = {}): ServiceResult {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const run = options.run ?? defaultRunner;
+
+  const unitPath = serviceUnitPath(platform, home);
+  if (!unitPath) {
+    return { ok: false, message: `Start-at-login is not supported on ${platform}.` };
+  }
+
+  const binaryPath = metaProxyBinaryPath(platform, home);
+  if (!existsSync(binaryPath)) {
+    return {
+      ok: false,
+      message: 'Meta-Proxy is not installed. Run `metaharness proxy install --yes` first.',
+    };
+  }
+
+  const logPath = join(metaProxyDataDir(home), 'meta-proxy.log');
+  const definition =
+    platform === 'darwin'
+      ? renderLaunchAgent(binaryPath, logPath)
+      : platform === 'linux'
+        ? renderSystemdUnit(binaryPath)
+        : renderScheduledTask(binaryPath);
+
+  mkdirSync(dirname(unitPath), { recursive: true, mode: 0o700 });
+  writeFileSync(unitPath, definition, { encoding: 'utf8', mode: 0o600 });
+
+  for (const invocation of enableCommands(platform, unitPath)) {
+    const outcome = run(invocation);
+    if (!outcome.ok) {
+      // Leave nothing half-installed: a unit file present but never loaded
+      // would make `proxy status` claim start-at-login is on when it is not.
+      rmSync(unitPath, { force: true });
+      return {
+        ok: false,
+        message: `Could not enable start-at-login (${invocation.command} ${invocation.args.join(' ')}): ${outcome.output || 'command failed'}`,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    message: `Meta-Proxy will start at login. Definition: ${unitPath}\nDisable with: metaharness proxy disable`,
+    unitPath,
+  };
+}
+
+export function disableMetaProxyService(options: ServiceOptions = {}): ServiceResult {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const run = options.run ?? defaultRunner;
+
+  const unitPath = serviceUnitPath(platform, home);
+  if (!unitPath) {
+    return { ok: true, message: `Start-at-login is not supported on ${platform}; nothing to disable.` };
+  }
+  if (!existsSync(unitPath)) {
+    return { ok: true, message: 'Meta-Proxy is not set to start at login.' };
+  }
+
+  // Best-effort: the unit file is removed even if the OS command complains,
+  // because a stale definition left behind is the state that lies to
+  // `proxy status`. The daemon binary is untouched — disabling supervision is
+  // not uninstalling the proxy.
+  const failures: string[] = [];
+  for (const invocation of disableCommands(platform, unitPath)) {
+    const outcome = run(invocation);
+    if (!outcome.ok) failures.push(outcome.output || `${invocation.command} failed`);
+  }
+  rmSync(unitPath, { force: true });
+
+  if (failures.length > 0) {
+    return {
+      ok: true,
+      message: `Removed ${unitPath}, but the service manager reported: ${failures.join('; ')}. The Meta-Proxy binary is untouched.`,
+    };
+  }
+  return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
+}

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -469,12 +469,13 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     return {
       code: 0,
       lines: [
-        'Usage: metaharness proxy <install|status|start|stop|path|login|logout|run> [options]',
+        'Usage: metaharness proxy <install|status|start|stop|enable|disable|path|login|logout|run> [options]',
         '',
         'Optional signed Meta-Proxy sidecar for local Claude-compatible routing.',
         `  install [--version ${META_PROXY_VERSION}] --yes  download, verify, and install`,
         '  status                                      show installed version and managed process state',
         '  start | stop | path                         manage the optional local sidecar',
+        '  enable | disable                            start the sidecar at login (opt-in), or stop doing so',
         '  login | logout                              run Meta-Proxy Cognitum OAuth login/logout',
         '  run [--policy <critical|standard|economy>] [--] <client> [args...]',
         '                                               launch Claude-compatible client through Meta-Proxy',
@@ -493,6 +494,15 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
   }
   if (subcommand === 'status') {
     const status = metaProxyStatus();
+    // #82 — installed / running / start-at-login are three different states, and
+    // conflating them is why "it worked yesterday" reports were unanswerable.
+    const { metaProxyServiceState } = await import('./meta-proxy-service.js');
+    const service = metaProxyServiceState();
+    const startAtLogin = !service.supported
+      ? 'not supported on this platform'
+      : service.installed
+        ? `enabled (${service.unitPath})`
+        : 'disabled — enable with `metaharness proxy enable`';
     return {
       code: status.installed ? 0 : 1,
       lines: [
@@ -501,6 +511,7 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
         `  binary: ${status.binaryPath}`,
         `  version: ${status.version ?? 'unknown'}`,
         `  managed process: ${status.running ? `running (pid ${status.pid})` : 'not running'}`,
+        `  start at login: ${startAtLogin}`,
       ],
     };
   }
@@ -516,6 +527,16 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     const result = stopMetaProxy();
     return { code: result.ok ? 0 : 1, lines: [result.message] };
   }
+  if (subcommand === 'enable') {
+    const { enableMetaProxyService } = await import('./meta-proxy-service.js');
+    const result = enableMetaProxyService();
+    return { code: result.ok ? 0 : 1, lines: result.message.split('\n') };
+  }
+  if (subcommand === 'disable') {
+    const { disableMetaProxyService } = await import('./meta-proxy-service.js');
+    const result = disableMetaProxyService();
+    return { code: result.ok ? 0 : 1, lines: result.message.split('\n') };
+  }
   if (subcommand === 'run') {
     return runThroughMetaProxy(args.slice(1));
   }
@@ -526,5 +547,5 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     if (result.error) return { code: 1, lines: [`Could not run Meta-Proxy ${subcommand}: ${result.error.message}`] };
     return { code: result.status ?? 1, lines: [] };
   }
-  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | path | login | logout | run`] };
+  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | enable | disable | path | login | logout | run`] };
 }


### PR DESCRIPTION
Addresses [cognitum-one/meta-proxy#82](https://github.com/cognitum-one/meta-proxy/issues/82). Built here rather than in `cognitum-one/metaharness` because this is the package `npx metaharness` installs — supervision has to reach the users who never open VS Code.

## The problem

`proxy start` launches the sidecar for the life of that invocation only. Nothing starts it at login and nothing restarts it if it exits. After a reboot `proxy status` reports `managed process: not running`, and everything pointed at `127.0.0.1:11435` fails — the VS Code console, the configured terminal, any Anthropic-compatible client, Claude Code through the proxy — until someone remembers a CLI command.

The cost is asymmetric: the daemon is cheap to keep resident and expensive to notice missing, because the failure surfaces as unrelated tools misbehaving.

## What this adds

`metaharness proxy enable` / `disable`, and a third line in `proxy status`:

```
Meta-Proxy
  installed: yes
  binary: ~/.metaharness/meta-proxy/bin/meta-proxy
  version: 0.7.2
  managed process: running (pid 4821)
  start at login: enabled (~/Library/LaunchAgents/one.cognitum.meta-proxy.plist)
```

Installed, running, and start-at-login are three different states. Conflating them is what made "it worked yesterday" reports unanswerable.

**Opt-in is explicit.** Installing something that survives reboots is not done silently, so there is no implicit enable inside `proxy install`. The user runs `proxy enable`, and it names the file it wrote and how to undo it.

## Per platform, and why

| | mechanism | restart-on-crash |
|---|---|---|
| macOS | LaunchAgent, `launchctl bootstrap` + `kickstart` | `KeepAlive.SuccessfulExit=false` |
| Linux | systemd **user** unit, `systemctl --user enable --now` | `Restart=on-failure` |
| Windows | Task Scheduler logon trigger, `schtasks` | `RestartOnFailure` |

- **`KeepAlive.SuccessfulExit=false`, not `KeepAlive: true`.** The latter would fight the user's own `proxy stop` forever. A crash restarts; a deliberate stop stays stopped.
- **`WantedBy=default.target`, not `multi-user.target`.** This is start-at-*login*. Booting a machine nobody has logged into must not run a user's proxy.
- **`ExecutionTimeLimit PT0S`** on Windows, or Task Scheduler kills a long-lived daemon at the default 72 hours.

## Failure behaviour, deliberately asymmetric

- **`enable` cleans up after itself.** If the load command fails, the definition is removed — a unit file present but never loaded makes `proxy status` claim start-at-login is on when it is not.
- **`disable` removes the definition unconditionally**, even when the service manager complains, because a stale definition left behind is exactly the state that lies to `proxy status`. It leaves the daemon binary alone; disabling supervision is not uninstalling the proxy, which is the point of having both.

## Testing shape

Every unit renderer is a pure string function and the OS commands go through an injected runner, so the whole macOS/Linux/Windows matrix is asserted on one machine without touching `launchctl`, `systemctl` or `schtasks`. That mirrors `installFromSource`, which already takes an injected `run`.

Verified end to end against **real files on disk** for all three platforms — definition written, correct commands constructed, `disable` removing the definition while the daemon binary survives:

```
darwin  ~/Library/LaunchAgents/one.cognitum.meta-proxy.plist
        launchctl bootstrap gui/501 … | launchctl kickstart gui/501/one.cognitum.meta-proxy
linux   ~/.config/systemd/user/meta-proxy.service
        systemctl --user daemon-reload | systemctl --user enable --now meta-proxy.service
win32   ~/.metaharness/meta-proxy/meta-proxy-task.xml
        schtasks /create /tn one.cognitum.meta-proxy /xml … /f | schtasks /run /tn …
after disable: unit exists=false   daemon binary intact=true   (all three)
```

## Verification

```
vitest packages/create-agent-harness/__tests__/meta-proxy-service.test.ts   14 passed
vitest packages/create-agent-harness/__tests__/                            369 passed
```

Baseline on `main` is **355 passed, 2 failed across 5 files**; with this branch it is **369 passed, 2 failed across the same 5 files** — the +14 are exactly the new tests, and the pre-existing failures are untouched.

Two pre-existing conditions worth naming, neither introduced here: `npm ci` fails on `main` with a lockfile desync (`@metaharness/kernel-*` optional deps missing), so I used `npm install --ignore-scripts`; and `tsc --noEmit` reports `Cannot find module '@metaharness/*'` for unbuilt sibling workspace packages, in files this PR does not touch.

## Not in scope

The issue asks that **uninstalling the daemon remove the service**. There is no `proxy uninstall` command in this CLI today, so there is nothing to hook — `disable` is the removal path. Worth its own issue if an uninstall command is added.