### PR TITLE
chore(proxy): pin META_PROXY_VERSION 0.7.3, release metaharness 0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5013,7 +5013,7 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@metaharness/darwin": "^0.8.0",

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM, Prime Agent.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -26,7 +26,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
-export const META_PROXY_VERSION = '0.7.2';
+export const META_PROXY_VERSION = '0.7.3';
 export const META_PROXY_RELEASE_BASE = 'https://github.com/cognitum-one/meta-proxy-dist/releases/download';
 
 /** The release signing key, pinned in the client rather than fetched from GitHub. */


### PR DESCRIPTION
Ready for publish — **this PR does not publish anything**; it stages the tree so `metaharness` can go to npm when you're back at a keyboard.

## What this unblocks

`cognitum-one/meta-proxy` **v0.7.3** is released and mirrored to `meta-proxy-dist`. `metaharness proxy install` downloads the *pinned* version, so until this lands `npx metaharness` keeps installing **0.7.1** and none of these reach a user:

| Fix | What a user gets |
|---|---|
| #75 | Local plane translates Anthropic Messages → OpenAI, so Claude Code can drive a local model |
| #73 | Out-of-credits `402` carries account, tier, cap and reset date instead of a bare refusal |
| #85 | `--help` / `--version` honoured from any argv position |
| #79 | VS Code console prefers the managed daemon over the legacy metaharness path |
| #81 | VS Code console offers a way out when the daemon is not running |

## Why 0.4.5 and not 0.4.4

Tag `v0.4.4` exists in this repo but was **never published** — npm latest is `0.4.3`, because `publish.yml` has not succeeded in any of its 8 runs since 2026-06-14 (`google-github-actions/auth` → `unauthorized_client: The given credential is rejected by the attribute condition`, WIF provider in `ruv-dev`, rejecting both tag refs and `main`). That tag also points at a tree pinning meta-proxy 0.7.2. Publishing a *different* tree under `v0.4.4` would make the tag lie about what shipped, so this takes a fresh 0.4.5.

Happy to redo it as 0.4.4 if you'd rather — say the word and I'll rebase.

## Also fixes pre-existing drift

`package-lock.json` recorded the workspace at `0.4.3`; it was never updated when `package.json` moved to `0.4.4`. Corrected to `0.4.5` **surgically** — running `npm install --package-lock-only` additionally filled in unrelated optional-dependency entries for `kernel-js`, which don't belong in a release change. The lockfile diff here is one line.

## Verified against the real artifact, not just the constant

```
npm run build            (workspace root, then this package)   clean
npm test                 36 files, 410 tests                   pass

HOME=<temp> node dist/bin.js proxy install --yes
  → Installed verified Meta-Proxy v0.7.3
HOME=<temp> node dist/bin.js proxy status
  → installed: yes   version: 0.7.3

# the binary carries the FIX, not just the number (#85):
meta-proxy --port 9999 --help   → prints usage, exit 0
```

"Installed verified" is the meaningful part: the installer fetched from `meta-proxy-dist` and passed **both** the SHA-256 check and the Ed25519 signature check against the public key pinned in this repo. I also verified that independently and unauthenticated from the public download URL — signature `VALID`, tarball sha256 matches `SHA256SUMS`, extracted binary reports `meta-proxy 0.7.3`.

The install ran under a temporary `HOME` so it could not disturb a running daemon. For contrast, the daemon actually installed from npm today still reports `meta-proxy 0.7.1` — that gap is exactly what publishing this closes.

## What's left for you

1. Merge this.
2. Tag `v0.4.5`.
3. `npm publish` by hand — `publish.yml` will fail again at GCP auth, and only `ruvnet` has npm write on `metaharness` (`npm access list collaborators metaharness` → `ruvnet: read-write` only).

If you'd rather fix the automation than keep publishing by hand, the block is the WIF attribute condition on `projects/875130704813/.../workloadIdentityPools/github-pool/providers/github` for `metaharness-publish@ruv-dev.iam.gserviceaccount.com` — it rejects this repo's tag refs *and* `main`, which is why the workflow has never once succeeded.