### PR TITLE
fix(proxy): harden managed service lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,27 @@ jobs:
         shell: bash
         run: node examples/vertical-tour/vertical-tour.mjs
 
+  # Real user LaunchAgent contract. This must stay a required, non-skipped job:
+  # unit render tests cannot prove launchd restart and bootout behavior.
+  meta-proxy-launchagent:
+    name: Meta-Proxy / native macOS lifecycle
+    runs-on: macos-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+      - name: Install exact dependencies
+        run: npm ci
+      - name: Build MetaHarness CLI
+        run: npm run -w packages/create-agent-harness build
+      - name: Exercise real isolated LaunchAgent lifecycle
+        working-directory: packages/create-agent-harness
+        env:
+          RUN_REAL_LAUNCHD_ACCEPTANCE: '1'
+        run: npx vitest run __tests__/meta-proxy-launchagent.real.test.ts
+
   # ─────────────────────────────────────────────────────────────────────
   # Per-platform npm pack + install smoke for every published package
   # ─────────────────────────────────────────────────────────────────────
@@ -247,7 +268,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   ci-pass:
     name: CI passed
-    needs: [rust, wasm, node, pack-install, bench]
+    needs: [rust, wasm, node, meta-proxy-launchagent, pack-install, bench]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All cross-platform gates green."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,27 @@ jobs:
           RUN_REAL_LAUNCHD_ACCEPTANCE: '1'
         run: npx vitest run __tests__/meta-proxy-launchagent.real.test.ts
 
+  # Real per-user Task Scheduler contract. Unique task names and a temporary
+  # fixture keep this isolated from any runner/user Meta-Proxy installation.
+  meta-proxy-scheduled-task:
+    name: Meta-Proxy / native Windows lifecycle
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+      - name: Install exact dependencies
+        run: npm ci
+      - name: Build MetaHarness CLI
+        run: npm run build
+      - name: Exercise real isolated Scheduled Task lifecycle
+        working-directory: packages/create-agent-harness
+        env:
+          RUN_REAL_SCHEDULED_TASK_ACCEPTANCE: '1'
+        run: npx vitest run __tests__/meta-proxy-scheduled-task.real.test.ts
+
   # ─────────────────────────────────────────────────────────────────────
   # Per-platform npm pack + install smoke for every published package
   # ─────────────────────────────────────────────────────────────────────
@@ -270,7 +291,7 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   ci-pass:
     name: CI passed
-    needs: [rust, wasm, node, meta-proxy-launchagent, pack-install, bench]
+    needs: [rust, wasm, node, meta-proxy-launchagent, meta-proxy-scheduled-task, pack-install, bench]
     runs-on: ubuntu-latest
     steps:
       - run: echo "All cross-platform gates green."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,9 @@ jobs:
       - name: Install exact dependencies
         run: npm ci
       - name: Build MetaHarness CLI
-        run: npm run -w packages/create-agent-harness build
+        # The CLI imports internal workspaces; the ordered root build produces
+        # their declarations before compiling create-agent-harness.
+        run: npm run build
       - name: Exercise real isolated LaunchAgent lifecycle
         working-directory: packages/create-agent-harness
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5373,6 +5373,21 @@
         }
       }
     },
+    "packages/kernel-js/node_modules/@metaharness/kernel-darwin-arm64": {
+      "optional": true
+    },
+    "packages/kernel-js/node_modules/@metaharness/kernel-darwin-x64": {
+      "optional": true
+    },
+    "packages/kernel-js/node_modules/@metaharness/kernel-linux-arm64-gnu": {
+      "optional": true
+    },
+    "packages/kernel-js/node_modules/@metaharness/kernel-linux-x64-gnu": {
+      "optional": true
+    },
+    "packages/kernel-js/node_modules/@metaharness/kernel-win32-x64-msvc": {
+      "optional": true
+    },
     "packages/oo-agents": {
       "name": "@metaharness/oo-agents",
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5009,7 +5009,7 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "@metaharness/darwin": "^0.8.0",

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -113,7 +113,8 @@ require a stable stopped state. A failed enable restores a pre-existing absent
 or disabled task exactly; it deletes the task/XML only when both were created by
 that attempt. A registered task without its owned XML is never overwritten, and
 an owned disabled task removed by an ambiguous create is recreated from that XML
-and returned to disabled. On Linux, ambiguous `disable --now` and later `daemon-reload`
+and returned to disabled after an authoritative re-read, even if the compensating
+create response is also lost. On Linux, ambiguous `disable --now` and later `daemon-reload`
 failures re-read manager state and restore the prior login and running state,
 or fail closed with the owned definition preserved when restoration cannot be
 proved.

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -109,7 +109,12 @@ run `proxy logout` first when credential removal is required.
 On Windows this is a least-privilege per-user Scheduled Task. Status comes from
 locale-neutral ScheduledTasks API enum state and reports registration, task
 enablement, and running state separately. Disable and ambiguous-start cleanup
-require a stable stopped state before deleting either the task or its XML.
+require a stable stopped state. A failed enable restores a pre-existing absent
+or disabled task exactly; it deletes the task/XML only when both were created by
+that attempt. On Linux, ambiguous `disable --now` and later `daemon-reload`
+failures re-read manager state and restore the prior login and running state,
+or fail closed with the owned definition preserved when restoration cannot be
+proved.
 
 ### Per-worktree routing policy
 

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -111,7 +111,9 @@ locale-neutral ScheduledTasks API enum state and reports registration, task
 enablement, and running state separately. Disable and ambiguous-start cleanup
 require a stable stopped state. A failed enable restores a pre-existing absent
 or disabled task exactly; it deletes the task/XML only when both were created by
-that attempt. On Linux, ambiguous `disable --now` and later `daemon-reload`
+that attempt. A registered task without its owned XML is never overwritten, and
+an owned disabled task removed by an ambiguous create is recreated from that XML
+and returned to disabled. On Linux, ambiguous `disable --now` and later `daemon-reload`
 failures re-read manager state and restore the prior login and running state,
 or fail closed with the owned definition preserved when restoration cannot be
 proved.

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -85,7 +85,7 @@ of normal harness scaffolding. Install it only when you want a locally bound,
 Claude-compatible routing endpoint with Meta-Proxy's own Cognitum OAuth flow:
 
 ```bash
-npx metaharness proxy install --yes   # signed v0.7.1 download; checksum + Ed25519 verified
+npx metaharness proxy install --yes   # pinned signed download; checksum + Ed25519 verified
 npx metaharness proxy run -- claude   # starts the sidecar and routes this Claude session through it
 npx metaharness proxy run --policy critical -- claude -p "review this migration"
 ```
@@ -99,7 +99,12 @@ select consented Cloud or Sponsored capacity per request. Cognitum login is
 needed only for Cloud routing, not for installation or normal Passthrough.
 
 Use `npx metaharness proxy login` to authorize Cognitum Cloud routing, and
-`npx metaharness proxy status` to inspect the managed sidecar.
+`npx metaharness proxy status` to inspect the managed sidecar. Use `proxy enable`
+to configure login start, `proxy stop` for a stop that survives crash-restart
+policy in the current session, `proxy start` to resume it, `proxy logs` for the
+managed log, `proxy disable` to remove login start, and `proxy uninstall --yes`
+to remove the managed runtime. Uninstall intentionally preserves credentials;
+run `proxy logout` first when credential removal is required.
 
 ### Per-worktree routing policy
 

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -106,6 +106,11 @@ managed log, `proxy disable` to remove login start, and `proxy uninstall --yes`
 to remove the managed runtime. Uninstall intentionally preserves credentials;
 run `proxy logout` first when credential removal is required.
 
+On Windows this is a least-privilege per-user Scheduled Task. Status comes from
+locale-neutral ScheduledTasks API enum state and reports registration, task
+enablement, and running state separately. Disable and ambiguous-start cleanup
+require a stable stopped state before deleting either the task or its XML.
+
 ### Per-worktree routing policy
 
 `proxy run` attaches a short-lived, HMAC-signed local capability to the

--- a/packages/create-agent-harness/README.md
+++ b/packages/create-agent-harness/README.md
@@ -111,7 +111,8 @@ locale-neutral ScheduledTasks API enum state and reports registration, task
 enablement, and running state separately. Disable and ambiguous-start cleanup
 require a stable stopped state. A failed enable restores a pre-existing absent
 or disabled task exactly; it deletes the task/XML only when both were created by
-that attempt. A registered task without its owned XML is never overwritten, and
+that attempt. A registered task without its owned XML is never overwritten or
+deleted by label alone, and
 an owned disabled task removed by an ambiguous create is recreated from that XML
 and returned to disabled after an authoritative re-read, even if the compensating
 create response is also lost. On Linux, ambiguous `disable --now` and later `daemon-reload`

--- a/packages/create-agent-harness/__tests__/meta-proxy-launchagent.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-launchagent.real.test.ts
@@ -9,6 +9,8 @@ import {
   enableMetaProxyService,
   metaProxyServiceState,
   serviceUnitPath,
+  startMetaProxyService,
+  stopMetaProxyService,
 } from '../src/meta-proxy-service.js';
 import { metaProxyBinaryPath } from '../src/meta-proxy.js';
 
@@ -57,17 +59,24 @@ it.runIf(real)('proves isolated LaunchAgent login start, crash restart, clean st
     );
     expect(restartedPid).not.toBe(firstPid);
 
-    expect(launchctl('kill', 'SIGTERM', target).status).toBe(0);
+    const stopped = stopMetaProxyService({ home, platform: 'darwin', label });
+    expect(stopped.ok, stopped.message).toBe(true);
     expect(await eventually(() => pidFor(target), (pid) => pid === null, 20_000)).toBeNull();
     await new Promise((resolve) => setTimeout(resolve, 11_000));
     expect(pidFor(target)).toBeNull();
+
+    const started = startMetaProxyService({ home, platform: 'darwin', label });
+    expect(started.ok, started.message).toBe(true);
+    expect(await eventually(() => pidFor(target), (pid) => pid !== null)).not.toBeNull();
 
     const disabled = disableMetaProxyService({ home, platform: 'darwin', label });
     expect(disabled.ok, disabled.message).toBe(true);
     expect(existsSync(serviceUnitPath('darwin', home, label)!)).toBe(false);
     expect(metaProxyServiceState('darwin', home, undefined, label).managerState).toBe('disabled');
   } finally {
-    launchctl('bootout', target);
+    const cleanup = launchctl('bootout', target);
+    const alreadyGone = /could not find service|no such process/i.test(`${cleanup.stdout}${cleanup.stderr}`);
+    expect(cleanup.status === 0 || alreadyGone, `${cleanup.stdout}${cleanup.stderr}`).toBe(true);
     rmSync(home, { recursive: true, force: true });
   }
 }, 60_000);

--- a/packages/create-agent-harness/__tests__/meta-proxy-launchagent.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-launchagent.real.test.ts
@@ -72,7 +72,11 @@ it.runIf(real)('proves isolated LaunchAgent login start, crash restart, clean st
     const disabled = disableMetaProxyService({ home, platform: 'darwin', label });
     expect(disabled.ok, disabled.message).toBe(true);
     expect(existsSync(serviceUnitPath('darwin', home, label)!)).toBe(false);
-    expect(metaProxyServiceState('darwin', home, undefined, label).managerState).toBe('disabled');
+    const unloaded = await eventually(
+      () => metaProxyServiceState('darwin', home, undefined, label).managerState,
+      (state) => state === 'disabled',
+    );
+    expect(unloaded).toBe('disabled');
   } finally {
     const cleanup = launchctl('bootout', target);
     const alreadyGone = /could not find service|no such process/i.test(`${cleanup.stdout}${cleanup.stderr}`);

--- a/packages/create-agent-harness/__tests__/meta-proxy-launchagent.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-launchagent.real.test.ts
@@ -1,0 +1,73 @@
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { expect, it } from 'vitest';
+
+import {
+  disableMetaProxyService,
+  enableMetaProxyService,
+  metaProxyServiceState,
+  serviceUnitPath,
+} from '../src/meta-proxy-service.js';
+import { metaProxyBinaryPath } from '../src/meta-proxy.js';
+
+const real = process.platform === 'darwin' && process.env.RUN_REAL_LAUNCHD_ACCEPTANCE === '1';
+
+function launchctl(...args: string[]) {
+  return spawnSync('launchctl', args, { encoding: 'utf8', timeout: 15_000 });
+}
+
+function pidFor(target: string): number | null {
+  const result = launchctl('print', target);
+  const match = result.stdout.match(/\bpid = (\d+)/);
+  return match ? Number.parseInt(match[1]!, 10) : null;
+}
+
+async function eventually<T>(read: () => T, accept: (value: T) => boolean, timeoutMs = 15_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let value = read();
+  while (!accept(value) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    value = read();
+  }
+  return value;
+}
+
+it.runIf(real)('proves isolated LaunchAgent login start, crash restart, clean stop, and disable', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'mh-launchagent-real-'));
+  const label = `one.cognitum.meta-proxy.qe.${process.pid}.${Date.now()}`;
+  const target = `gui/${process.getuid?.() ?? 0}/${label}`;
+  const binary = metaProxyBinaryPath('darwin', home);
+  try {
+    mkdirSync(dirname(binary), { recursive: true });
+    writeFileSync(binary, '#!/bin/sh\ntrap "exit 0" TERM INT\nwhile true; do sleep 1; done\n');
+    chmodSync(binary, 0o700);
+
+    const enabled = enableMetaProxyService({ home, platform: 'darwin', label });
+    expect(enabled.ok, enabled.message).toBe(true);
+    const firstPid = await eventually(() => pidFor(target), (pid) => pid !== null);
+    expect(firstPid).not.toBeNull();
+    expect(metaProxyServiceState('darwin', home, undefined, label).managerState).toBe('enabled');
+
+    expect(launchctl('kill', 'SIGKILL', target).status).toBe(0);
+    const restartedPid = await eventually(
+      () => pidFor(target),
+      (pid) => pid !== null && pid !== firstPid,
+    );
+    expect(restartedPid).not.toBe(firstPid);
+
+    expect(launchctl('kill', 'SIGTERM', target).status).toBe(0);
+    expect(await eventually(() => pidFor(target), (pid) => pid === null, 20_000)).toBeNull();
+    await new Promise((resolve) => setTimeout(resolve, 11_000));
+    expect(pidFor(target)).toBeNull();
+
+    const disabled = disableMetaProxyService({ home, platform: 'darwin', label });
+    expect(disabled.ok, disabled.message).toBe(true);
+    expect(existsSync(serviceUnitPath('darwin', home, label)!)).toBe(false);
+    expect(metaProxyServiceState('darwin', home, undefined, label).managerState).toBe('disabled');
+  } finally {
+    launchctl('bootout', target);
+    rmSync(home, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
@@ -83,6 +83,29 @@ it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and de
     );
     expect(schtasks('/change', '/tn', label, '/disable').status).toBe(0);
     expect(metaProxyServiceState('win32', home, undefined, label)).toMatchObject({ loaded: true, enabledAtLogin: false, running: false });
+
+    // `/create /f` can partially replace or remove an existing task before its
+    // caller loses the response. Delete it after the real first create and
+    // require the owned XML to recreate the exact prior disabled registration.
+    let firstCreate = true;
+    const ambiguousCreate = (invocation: ServiceCommand): CommandOutcome => {
+      const result = spawnSync(invocation.command, invocation.args, { encoding: 'utf8', timeout: 15_000, windowsHide: true });
+      const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+      if (invocation.args[0] === '/create' && firstCreate) {
+        firstCreate = false;
+        schtasks('/delete', '/tn', label, '/f');
+        return { ok: false, output: 'simulated create removed task before lost response' };
+      }
+      return result.error
+        ? { ok: false, output: result.error.message, error: result.error.message }
+        : { ok: result.status === 0, output };
+    };
+    const restoredAfterCreate = enableMetaProxyService({ home, platform: 'win32', label, run: ambiguousCreate });
+    expect(restoredAfterCreate.ok).toBe(false);
+    expect(restoredAfterCreate.message).toContain('simulated create removed task');
+    expect(metaProxyServiceState('win32', home, undefined, label)).toMatchObject({ loaded: true, enabledAtLogin: false, running: false });
+    expect(existsSync(serviceUnitPath('win32', home, label)!)).toBe(true);
+
     const restoredDisabled = enableMetaProxyService({ home, platform: 'win32', label, run: ambiguousRun });
     expect(restoredDisabled.ok).toBe(false);
     expect(restoredDisabled.message).toContain('simulated lost /run response');

--- a/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
@@ -1,0 +1,63 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { expect, it } from 'vitest';
+
+import {
+  disableMetaProxyService,
+  enableMetaProxyService,
+  metaProxyServiceState,
+  serviceUnitPath,
+} from '../src/meta-proxy-service.js';
+import { metaProxyBinaryPath } from '../src/meta-proxy.js';
+
+const real = process.platform === 'win32' && process.env.RUN_REAL_SCHEDULED_TASK_ACCEPTANCE === '1';
+
+function schtasks(...args: string[]) {
+  return spawnSync('schtasks', args, { encoding: 'utf8', timeout: 15_000 });
+}
+
+async function eventually<T>(read: () => T, accept: (value: T) => boolean, timeoutMs = 15_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  let value = read();
+  while (!accept(value) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    value = read();
+  }
+  return value;
+}
+
+it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and deletes cleanly', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'mh-scheduled-task-real-'));
+  const label = `CognitumMetaProxyQE-${process.pid}-${Date.now()}`;
+  const binary = metaProxyBinaryPath('win32', home);
+  const source = join(home, 'fixture.cs');
+  try {
+    mkdirSync(dirname(binary), { recursive: true });
+    writeFileSync(source, 'using System.Threading; public class Program { public static void Main(string[] args) { while (true) Thread.Sleep(1000); } }');
+    const compile = spawnSync(
+      'powershell.exe',
+      ['-NoProfile', '-NonInteractive', '-Command', 'Add-Type -TypeDefinition (Get-Content -Raw -LiteralPath $env:FIXTURE_SOURCE) -OutputAssembly $env:FIXTURE_BINARY -OutputType ConsoleApplication'],
+      { encoding: 'utf8', timeout: 30_000, env: { ...process.env, FIXTURE_SOURCE: source, FIXTURE_BINARY: binary } },
+    );
+    expect(compile.status, `${compile.stdout}${compile.stderr}`).toBe(0);
+
+    const enabled = enableMetaProxyService({ home, platform: 'win32', label });
+    expect(enabled.ok, enabled.message).toBe(true);
+    const running = await eventually(
+      () => metaProxyServiceState('win32', home, undefined, label),
+      (state) => state.running === true,
+    );
+    expect(running).toMatchObject({ managerState: 'enabled', running: true, definitionPresent: true });
+
+    const disabled = disableMetaProxyService({ home, platform: 'win32', label });
+    expect(disabled.ok, disabled.message).toBe(true);
+    expect(existsSync(serviceUnitPath('win32', home, label)!)).toBe(false);
+    expect(metaProxyServiceState('win32', home, undefined, label).managerState).toBe('disabled');
+  } finally {
+    schtasks('/end', '/tn', label);
+    schtasks('/delete', '/tn', label, '/f');
+    rmSync(home, { recursive: true, force: true });
+  }
+}, 60_000);

--- a/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
@@ -55,9 +55,22 @@ it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and de
     expect(disabled.ok, disabled.message).toBe(true);
     expect(existsSync(serviceUnitPath('win32', home, label)!)).toBe(false);
     expect(metaProxyServiceState('win32', home, undefined, label).managerState).toBe('disabled');
+    const binaryReleased = await eventually(
+      () => {
+        try {
+          rmSync(binary);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      (released) => released,
+      5_000,
+    );
+    expect(binaryReleased).toBe(true);
   } finally {
     schtasks('/end', '/tn', label);
     schtasks('/delete', '/tn', label, '/f');
-    rmSync(home, { recursive: true, force: true });
+    rmSync(home, { recursive: true, force: true, maxRetries: 50, retryDelay: 100 });
   }
 }, 60_000);

--- a/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
@@ -9,6 +9,8 @@ import {
   enableMetaProxyService,
   metaProxyServiceState,
   serviceUnitPath,
+  type CommandOutcome,
+  type ServiceCommand,
 } from '../src/meta-proxy-service.js';
 import { metaProxyBinaryPath } from '../src/meta-proxy.js';
 
@@ -55,6 +57,25 @@ it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and de
     expect(disabled.ok, disabled.message).toBe(true);
     expect(existsSync(serviceUnitPath('win32', home, label)!)).toBe(false);
     expect(metaProxyServiceState('win32', home, undefined, label).managerState).toBe('disabled');
+
+    // A successful /run whose response is lost is indistinguishable from a
+    // failed start to the caller. Exercise the real manager, then lie only
+    // about that response and require compensation to stop + delete safely.
+    const ambiguousRun = (invocation: ServiceCommand): CommandOutcome => {
+      const result = spawnSync(invocation.command, invocation.args, { encoding: 'utf8', timeout: 15_000, windowsHide: true });
+      const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
+      if (invocation.args[0] === '/run' && result.status === 0) {
+        return { ok: false, output: 'simulated lost /run response' };
+      }
+      return result.error
+        ? { ok: false, output: result.error.message, error: result.error.message }
+        : { ok: result.status === 0, output };
+    };
+    const ambiguous = enableMetaProxyService({ home, platform: 'win32', label, run: ambiguousRun });
+    expect(ambiguous.ok).toBe(false);
+    expect(ambiguous.message).toContain('simulated lost /run response');
+    expect(metaProxyServiceState('win32', home, undefined, label).managerState).toBe('disabled');
+    expect(existsSync(serviceUnitPath('win32', home, label)!)).toBe(false);
     const binaryReleased = await eventually(
       () => {
         try {

--- a/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
@@ -60,7 +60,7 @@ it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and de
 
     // A successful /run whose response is lost is indistinguishable from a
     // failed start to the caller. Exercise the real manager, then lie only
-    // about that response and require compensation to stop + delete safely.
+    // about that response and require exact compensation.
     const ambiguousRun = (invocation: ServiceCommand): CommandOutcome => {
       const result = spawnSync(invocation.command, invocation.args, { encoding: 'utf8', timeout: 15_000, windowsHide: true });
       const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
@@ -71,6 +71,28 @@ it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and de
         ? { ok: false, output: result.error.message, error: result.error.message }
         : { ok: result.status === 0, output };
     };
+
+    // First prove a task which existed in the disabled state is restored to
+    // that same state rather than deleted or left running.
+    const preexisting = enableMetaProxyService({ home, platform: 'win32', label });
+    expect(preexisting.ok, preexisting.message).toBe(true);
+    expect(schtasks('/end', '/tn', label).status).toBe(0);
+    await eventually(
+      () => metaProxyServiceState('win32', home, undefined, label),
+      (state) => state.running === false,
+    );
+    expect(schtasks('/change', '/tn', label, '/disable').status).toBe(0);
+    expect(metaProxyServiceState('win32', home, undefined, label)).toMatchObject({ loaded: true, enabledAtLogin: false, running: false });
+    const restoredDisabled = enableMetaProxyService({ home, platform: 'win32', label, run: ambiguousRun });
+    expect(restoredDisabled.ok).toBe(false);
+    expect(restoredDisabled.message).toContain('simulated lost /run response');
+    expect(metaProxyServiceState('win32', home, undefined, label)).toMatchObject({ loaded: true, enabledAtLogin: false, running: false });
+    expect(existsSync(serviceUnitPath('win32', home, label)!)).toBe(true);
+    const cleanupRestored = disableMetaProxyService({ home, platform: 'win32', label });
+    expect(cleanupRestored.ok, cleanupRestored.message).toBe(true);
+
+    // Then prove a task newly created by the ambiguous request is stopped and
+    // removed, and that no process retains the daemon executable afterward.
     const ambiguous = enableMetaProxyService({ home, platform: 'win32', label, run: ambiguousRun });
     expect(ambiguous.ok).toBe(false);
     expect(ambiguous.message).toContain('simulated lost /run response');

--- a/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-scheduled-task.real.test.ts
@@ -87,14 +87,19 @@ it.runIf(real)('proves an isolated Scheduled Task starts, reports, stops, and de
     // `/create /f` can partially replace or remove an existing task before its
     // caller loses the response. Delete it after the real first create and
     // require the owned XML to recreate the exact prior disabled registration.
-    let firstCreate = true;
+    let createAttempts = 0;
     const ambiguousCreate = (invocation: ServiceCommand): CommandOutcome => {
       const result = spawnSync(invocation.command, invocation.args, { encoding: 'utf8', timeout: 15_000, windowsHide: true });
       const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
-      if (invocation.args[0] === '/create' && firstCreate) {
-        firstCreate = false;
-        schtasks('/delete', '/tn', label, '/f');
-        return { ok: false, output: 'simulated create removed task before lost response' };
+      if (invocation.args[0] === '/create') {
+        createAttempts += 1;
+        if (createAttempts === 1) {
+          schtasks('/delete', '/tn', label, '/f');
+          return { ok: false, output: 'simulated create removed task before lost response' };
+        }
+        if (createAttempts === 2 && result.status === 0) {
+          return { ok: false, output: 'simulated lost compensating create response' };
+        }
       }
       return result.error
         ? { ok: false, output: result.error.message, error: result.error.message }

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -141,6 +141,28 @@ describe('enable', () => {
     expect(existsSync(serviceUnitPath('linux', home)!)).toBe(false);
   });
 
+  it('compensates a registration when starting the registered job fails', () => {
+    installFakeDaemon('darwin');
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      const action = invocation.args[0];
+      if (action === 'kickstart') return { ok: false, output: 'kickstart failed' };
+      return { ok: true, output: '' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'darwin', run });
+
+    expect(result.ok).toBe(false);
+    expect(calls.map((call) => call.args[0])).toEqual([
+      'bootstrap',
+      'kickstart',
+      'print',
+      'bootout',
+    ]);
+    expect(existsSync(serviceUnitPath('darwin', home)!)).toBe(false);
+  });
+
   it('says so rather than pretending on an unsupported platform', () => {
     const result = enableMetaProxyService({ home, platform: 'freebsd' as NodeJS.Platform });
     expect(result.ok).toBe(false);
@@ -162,25 +184,35 @@ describe('disable', () => {
   });
 
   it('is a no-op when start-at-login was never enabled', () => {
-    const { calls, run } = recorder();
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      return { ok: false, output: 'disabled' };
+    };
     const result = disableMetaProxyService({ home, platform: 'linux', run });
     expect(result.ok).toBe(true);
     expect(result.message).toContain('not set to start at login');
-    expect(calls).toEqual([]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.args).toContain('is-enabled');
   });
 
-  /// A stale definition left behind is the state that lies to `proxy status`,
-  /// so removal must not be conditional on the service manager cooperating.
-  it('still removes the definition when the service manager complains', () => {
+  it('reports failure and preserves the definition when unregistering fails', () => {
     installFakeDaemon('linux');
-    const ok = recorder();
-    enableMetaProxyService({ home, platform: 'linux', run: ok.run });
+    const unit = serviceUnitPath('linux', home)!;
+    mkdirSync(dirname(unit), { recursive: true });
+    writeFileSync(unit, 'owned unit');
 
-    const failing = recorder(false);
-    const result = disableMetaProxyService({ home, platform: 'linux', run: failing.run });
-    expect(result.ok).toBe(true);
-    expect(existsSync(serviceUnitPath('linux', home)!)).toBe(false);
-    expect(result.message).toContain('boom');
+    const result = disableMetaProxyService({
+      home,
+      platform: 'linux',
+      run: (invocation) =>
+        invocation.args.includes('is-enabled')
+          ? { ok: true, output: 'enabled' }
+          : { ok: false, output: 'disable failed' },
+    });
+    expect(result.ok).toBe(false);
+    expect(existsSync(unit)).toBe(true);
+    expect(result.message).toContain('disable failed');
   });
 });
 
@@ -189,11 +221,38 @@ describe('state reporting', () => {
     expect(metaProxyServiceState('darwin', home).installed).toBe(false);
 
     installFakeDaemon('darwin');
-    enableMetaProxyService({ home, platform: 'darwin', run: recorder().run });
-    expect(metaProxyServiceState('darwin', home).installed).toBe(true);
+    const enabled = recorder().run;
+    enableMetaProxyService({ home, platform: 'darwin', run: enabled });
+    expect(metaProxyServiceState('darwin', home, enabled).installed).toBe(true);
 
     const unsupported = metaProxyServiceState('freebsd' as NodeJS.Platform, home);
     expect(unsupported.supported).toBe(false);
     expect(unsupported.unitPath).toBeNull();
+  });
+
+  it('trusts the service manager over a stale definition file', () => {
+    const unit = serviceUnitPath('darwin', home)!;
+    mkdirSync(dirname(unit), { recursive: true });
+    writeFileSync(unit, 'stale definition');
+
+    const state = metaProxyServiceState('darwin', home, () => ({
+      ok: false,
+      output: 'Could not find service',
+    }));
+
+    expect(state.managerState).toBe('disabled');
+    expect(state.installed).toBe(false);
+    expect(state.definitionPresent).toBe(true);
+  });
+
+  it('reports an externally registered service even when its definition is missing', () => {
+    const state = metaProxyServiceState('darwin', home, () => ({
+      ok: true,
+      output: 'service = one.cognitum.meta-proxy',
+    }));
+
+    expect(state.managerState).toBe('enabled');
+    expect(state.installed).toBe(true);
+    expect(state.definitionPresent).toBe(false);
   });
 });

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -481,6 +481,22 @@ describe('disable', () => {
     expect(calls[0]?.args).toContain('show');
   });
 
+  it('refuses to delete a registered Windows task without its owned XML', () => {
+    installFakeDaemon('win32');
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (isWindowsQuery(invocation)) return windowsState(3);
+      return { ok: false, output: 'unexpected mutation' };
+    };
+
+    const result = disableMetaProxyService({ home, platform: 'win32', run });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/registered.*owned definition/i);
+    expect(calls.some((call) => call.args[0] === '/end' || call.args[0] === '/delete')).toBe(false);
+  });
+
   it('reports failure and preserves the definition when unregistering fails', () => {
     installFakeDaemon('linux');
     const unit = serviceUnitPath('linux', home)!;

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -344,6 +344,61 @@ describe('enable', () => {
     expect(existsSync(binary)).toBe(false);
   });
 
+  it('preserves a pre-existing definition while removing a newly-created Windows task after an ambiguous run', () => {
+    const binary = installFakeDaemon('win32');
+    const unitPath = serviceUnitPath('win32', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    const definition = renderScheduledTask(binary);
+    writeFileSync(unitPath, definition, 'utf16le');
+    let registered = false;
+    let running = false;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (isWindowsQuery(invocation)) return registered ? windowsState(running ? 4 : 3) : { ok: true, output: 'TaskState=Missing' };
+      if (invocation.args[0] === '/create') { registered = true; return { ok: true, output: '' }; }
+      if (invocation.args[0] === '/run') { running = true; return { ok: false, output: 'simulated lost run response' }; }
+      if (invocation.args[0] === '/end') { running = false; return { ok: true, output: '' }; }
+      if (invocation.args[0] === '/delete') { registered = false; return { ok: true, output: '' }; }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
+
+    expect(result.ok).toBe(false);
+    expect(registered).toBe(false);
+    expect(readFileSync(unitPath, 'utf16le')).toBe(definition);
+    expect(calls.some((call) => call.args[0] === '/end')).toBe(true);
+  });
+
+  it('restores a pre-existing disabled Windows task after an ambiguous run', () => {
+    const binary = installFakeDaemon('win32');
+    const unitPath = serviceUnitPath('win32', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    const definition = renderScheduledTask(binary);
+    writeFileSync(unitPath, definition, 'utf16le');
+    let taskState: 1 | 3 | 4 = 1;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (isWindowsQuery(invocation)) return windowsState(taskState);
+      if (invocation.args[0] === '/create') { taskState = 3; return { ok: true, output: '' }; }
+      if (invocation.args[0] === '/run') { taskState = 4; return { ok: false, output: 'simulated lost run response' }; }
+      if (invocation.args[0] === '/end') { taskState = 3; return { ok: true, output: '' }; }
+      if (invocation.args[0] === '/change' && invocation.args.includes('/disable')) { taskState = 1; return { ok: true, output: '' }; }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
+
+    expect(result.ok).toBe(false);
+    expect(metaProxyServiceState('win32', home, run)).toMatchObject({ loaded: true, enabledAtLogin: false, running: false });
+    expect(readFileSync(unitPath, 'utf16le')).toBe(definition);
+    expect(calls.some((call) => call.args[0] === '/end')).toBe(true);
+    expect(calls.some((call) => call.args[0] === '/change' && call.args.includes('/disable'))).toBe(true);
+    expect(calls.some((call) => call.args[0] === '/delete')).toBe(false);
+  });
+
   it('says so rather than pretending on an unsupported platform', () => {
     const result = enableMetaProxyService({ home, platform: 'freebsd' as NodeJS.Platform });
     expect(result.ok).toBe(false);
@@ -424,6 +479,40 @@ describe('disable', () => {
     expect(readFileSync(unitPath, 'utf8')).toBe(definition);
     expect(metaProxyServiceState('linux', home, run)).toMatchObject({ enabledAtLogin: true, running: true, pid: 456 });
     expect(reloads).toBe(2);
+    expect(calls.some((call) => call.args.includes('enable'))).toBe(true);
+    expect(calls.some((call) => call.args.includes('start'))).toBe(true);
+  });
+
+  it('restores Linux login enablement and running state after an ambiguous disable failure', () => {
+    const binary = installFakeDaemon('linux');
+    const unitPath = serviceUnitPath('linux', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    const definition = renderSystemdUnit(binary);
+    writeFileSync(unitPath, definition);
+    let enabledAtLogin = true;
+    let active = true;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) {
+        return { ok: true, output: `LoadState=loaded\nUnitFileState=${enabledAtLogin ? 'enabled' : 'disabled'}\nActiveState=${active ? 'active' : 'inactive'}\nMainPID=${active ? '772' : '0'}` };
+      }
+      if (invocation.args.includes('disable') && invocation.args.includes('--now')) {
+        enabledAtLogin = false;
+        active = false;
+        return { ok: false, output: 'simulated lost disable response' };
+      }
+      if (invocation.args.includes('enable')) { enabledAtLogin = true; return { ok: true, output: '' }; }
+      if (invocation.args.includes('start')) { active = true; return { ok: true, output: '' }; }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = disableMetaProxyService({ home, platform: 'linux', run });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('simulated lost disable response');
+    expect(readFileSync(unitPath, 'utf8')).toBe(definition);
+    expect(metaProxyServiceState('linux', home, run)).toMatchObject({ enabledAtLogin: true, running: true, pid: 772 });
     expect(calls.some((call) => call.args.includes('enable'))).toBe(true);
     expect(calls.some((call) => call.args.includes('start'))).toBe(true);
   });

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -89,7 +89,10 @@ describe('unit rendering', () => {
 
   it('restarts on failure on Windows and does not time out', () => {
     const task = renderScheduledTask('C:\\meta-proxy.exe');
+    expect(task).toContain('encoding="UTF-8"');
     expect(task).toContain('<LogonTrigger>');
+    expect(task).toContain('<LogonType>InteractiveToken</LogonType>');
+    expect(task).toContain('<RunLevel>LeastPrivilege</RunLevel>');
     expect(task).toContain('<RestartOnFailure>');
     // A long-lived daemon must not be killed by the default 72h limit.
     expect(task).toContain('<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>');
@@ -102,6 +105,14 @@ describe('command construction', () => {
     expect(enableCommands('linux', '/u').every((c) => c.args.includes('--user'))).toBe(true);
     expect(enableCommands('darwin', '/u')[0]!.args[1]).toMatch(/^gui\//);
     expect(disableCommands('linux', '/u').every((c) => c.args.includes('--user'))).toBe(true);
+  });
+
+  it('isolates Windows commands and definitions by the requested task label', () => {
+    const label = 'CognitumMetaProxyQE-123';
+    const unitPath = serviceUnitPath('win32', home, label)!;
+    expect(unitPath).toContain(label);
+    expect(enableCommands('win32', unitPath, label).every((command) => command.args.includes(label))).toBe(true);
+    expect(disableCommands('win32', unitPath, label)[0]!.args).toContain(label);
   });
 
   it('has no commands for an unsupported platform', () => {
@@ -196,6 +207,44 @@ describe('enable', () => {
     expect(result.ok).toBe(false);
     expect(readFileSync(unitPath, 'utf8')).toBe(definition);
     expect(calls.some((call) => call.args.includes('disable'))).toBe(false);
+  });
+
+  it('restores disabled-but-active Linux state after a partial enable failure', () => {
+    const binary = installFakeDaemon('linux');
+    const unitPath = serviceUnitPath('linux', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, renderSystemdUnit(binary));
+    let enabledAtLogin = false;
+    let active = true;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) {
+        return {
+          ok: true,
+          output: `LoadState=loaded\nUnitFileState=${enabledAtLogin ? 'enabled' : 'disabled'}\nActiveState=${active ? 'active' : 'inactive'}\nMainPID=${active ? '718' : '0'}`,
+        };
+      }
+      if (invocation.args.includes('daemon-reload')) return { ok: true, output: '' };
+      if (invocation.args.includes('enable')) {
+        enabledAtLogin = true;
+        return { ok: false, output: 'enable reported failure after changing state' };
+      }
+      if (invocation.args.includes('disable')) {
+        enabledAtLogin = false;
+        if (invocation.args.includes('--now')) active = false;
+        return { ok: true, output: '' };
+      }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'linux', run });
+    const after = metaProxyServiceState('linux', home, run);
+
+    expect(result.ok).toBe(false);
+    expect(after).toMatchObject({ loaded: true, enabledAtLogin: false, running: true, pid: 718 });
+    const compensation = calls.find((call) => call.args.includes('disable'));
+    expect(compensation?.args).toEqual(['--user', 'disable', 'meta-proxy.service']);
   });
 
   /// A rejected first-time enable must not leave a new definition behind.
@@ -336,7 +385,7 @@ describe('disable', () => {
       return { ok: false, output: 'unexpected command' };
     };
 
-    const result = disableMetaProxyService({ home, platform: 'win32', run });
+    const result = disableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
 
     expect(result.ok).toBe(false);
     expect(calls.map((call) => call.args[0])).toEqual(['/query', '/end', '/query', '/delete']);
@@ -356,11 +405,45 @@ describe('disable', () => {
       return { ok: false, output: 'unexpected command' };
     };
 
-    const result = disableMetaProxyService({ home, platform: 'win32', run });
+    const result = disableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
 
     expect(result.ok).toBe(false);
     expect(calls.some((call) => call.args[0] === '/delete')).toBe(false);
     expect(existsSync(unitPath)).toBe(true);
+  });
+
+  it('bounded-polls a Windows task whose stopped state is asynchronous', () => {
+    installFakeDaemon('win32');
+    const unitPath = serviceUnitPath('win32', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, '<Task>owned definition</Task>');
+    let ended = false;
+    let postEndQueries = 0;
+    const waits: number[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      if (invocation.args[0] === '/query') {
+        if (ended && ++postEndQueries >= 3) return { ok: true, output: 'Status: Ready' };
+        return { ok: true, output: 'Status: Running' };
+      }
+      if (invocation.args[0] === '/end') {
+        ended = true;
+        return { ok: true, output: '' };
+      }
+      if (invocation.args[0] === '/delete') return { ok: true, output: '' };
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = disableMetaProxyService({
+      home,
+      platform: 'win32',
+      run,
+      wait: (ms) => waits.push(ms),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(postEndQueries).toBe(3);
+    expect(waits).toEqual([100, 100]);
+    expect(existsSync(unitPath)).toBe(false);
   });
 });
 

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -29,6 +29,14 @@ import { metaProxyBinaryPath } from '../src/meta-proxy.js';
 
 let home: string;
 
+function isWindowsQuery(invocation: ServiceCommand): boolean {
+  return invocation.command === 'powershell.exe';
+}
+
+function windowsState(state: 1 | 3 | 4, enabled = true): CommandOutcome {
+  return { ok: true, output: `TaskState=${state}\nEnabled=${enabled ? '1' : '0'}` };
+}
+
 /** Records what would have been run, and lets a test force a failure. */
 function recorder(ok = true) {
   const calls: ServiceCommand[] = [];
@@ -36,7 +44,7 @@ function recorder(ok = true) {
     calls.push(invocation);
     if (invocation.args[0] === 'print') return { ok: false, output: 'Could not find service' };
     if (invocation.args.includes('show')) return { ok: true, output: 'LoadState=not-found' };
-    if (invocation.args[0] === '/query') return { ok: false, output: 'ERROR: The system cannot find the file specified.' };
+    if (isWindowsQuery(invocation)) return { ok: true, output: 'TaskState=Missing' };
     return ok ? { ok: true, output: '' } : { ok: false, output: 'boom' };
   };
   return { calls, run };
@@ -175,10 +183,10 @@ describe('enable', () => {
     installFakeDaemon('win32');
     let registered = false;
     const run = (invocation: ServiceCommand): CommandOutcome => {
-      if (invocation.args[0] === '/query') {
+      if (isWindowsQuery(invocation)) {
         return registered
-          ? { ok: true, output: 'Status: Ready' }
-          : { ok: false, output: 'ERROR: The system cannot find the file specified.' };
+          ? windowsState(3)
+          : { ok: true, output: 'TaskState=Missing' };
       }
       if (invocation.args[0] === '/create') registered = true;
       return { ok: true, output: '' };
@@ -310,6 +318,32 @@ describe('enable', () => {
     expect(existsSync(serviceUnitPath('darwin', home)!)).toBe(false);
   });
 
+  it('stops, proves stopped, and deletes a Windows task after an ambiguous run failure', () => {
+    const binary = installFakeDaemon('win32');
+    let registered = false;
+    let running = false;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (isWindowsQuery(invocation)) return registered ? windowsState(running ? 4 : 3) : { ok: true, output: 'TaskState=Missing' };
+      if (invocation.args[0] === '/create') { registered = true; return { ok: true, output: '' }; }
+      if (invocation.args[0] === '/run') { running = true; return { ok: false, output: 'simulated lost run response' }; }
+      if (invocation.args[0] === '/end') { running = false; return { ok: true, output: '' }; }
+      if (invocation.args[0] === '/delete') { registered = false; return { ok: true, output: '' }; }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('simulated lost run response');
+    expect(existsSync(serviceUnitPath('win32', home)!)).toBe(false);
+    expect(calls.some((call) => call.args[0] === '/end')).toBe(true);
+    expect(calls.some((call) => call.args[0] === '/delete')).toBe(true);
+    rmSync(binary);
+    expect(existsSync(binary)).toBe(false);
+  });
+
   it('says so rather than pretending on an unsupported platform', () => {
     const result = enableMetaProxyService({ home, platform: 'freebsd' as NodeJS.Platform });
     expect(result.ok).toBe(false);
@@ -362,20 +396,25 @@ describe('disable', () => {
     expect(result.message).toContain('disable failed');
   });
 
-  it('restores the Linux definition when daemon-reload fails after disable', () => {
+  it('transactionally restores Linux definition, login enablement, and running state when reload fails', () => {
     const binary = installFakeDaemon('linux');
     const unitPath = serviceUnitPath('linux', home)!;
     mkdirSync(dirname(unitPath), { recursive: true });
     const definition = renderSystemdUnit(binary);
     writeFileSync(unitPath, definition);
     const calls: ServiceCommand[] = [];
+    let enabledAtLogin = true;
+    let active = true;
+    let reloads = 0;
     const run = (invocation: ServiceCommand): CommandOutcome => {
       calls.push(invocation);
       if (invocation.args.includes('show')) {
-        return { ok: true, output: 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nMainPID=456' };
+        return { ok: true, output: `LoadState=loaded\nUnitFileState=${enabledAtLogin ? 'enabled' : 'disabled'}\nActiveState=${active ? 'active' : 'inactive'}\nMainPID=${active ? '456' : '0'}` };
       }
-      if (invocation.args.includes('disable')) return { ok: true, output: '' };
-      if (invocation.args.includes('daemon-reload')) return { ok: false, output: 'manager unavailable' };
+      if (invocation.args.includes('disable')) { enabledAtLogin = false; active = false; return { ok: true, output: '' }; }
+      if (invocation.args.includes('daemon-reload')) return ++reloads === 1 ? { ok: false, output: 'transient manager failure' } : { ok: true, output: '' };
+      if (invocation.args.includes('enable')) { enabledAtLogin = true; return { ok: true, output: '' }; }
+      if (invocation.args.includes('start')) { active = true; return { ok: true, output: '' }; }
       return { ok: false, output: 'unexpected command' };
     };
 
@@ -383,7 +422,10 @@ describe('disable', () => {
 
     expect(result.ok).toBe(false);
     expect(readFileSync(unitPath, 'utf8')).toBe(definition);
-    expect(calls.some((call) => call.args.includes('daemon-reload'))).toBe(true);
+    expect(metaProxyServiceState('linux', home, run)).toMatchObject({ enabledAtLogin: true, running: true, pid: 456 });
+    expect(reloads).toBe(2);
+    expect(calls.some((call) => call.args.includes('enable'))).toBe(true);
+    expect(calls.some((call) => call.args.includes('start'))).toBe(true);
   });
 
   it('ends and confirms a Windows task before deleting it', () => {
@@ -395,8 +437,8 @@ describe('disable', () => {
     const calls: ServiceCommand[] = [];
     const run = (invocation: ServiceCommand): CommandOutcome => {
       calls.push(invocation);
-      if (invocation.args[0] === '/query') {
-        return { ok: true, output: running ? 'Status: Running' : 'Status: Ready' };
+      if (isWindowsQuery(invocation)) {
+        return windowsState(running ? 4 : 3);
       }
       if (invocation.args[0] === '/end') {
         running = false;
@@ -409,7 +451,7 @@ describe('disable', () => {
     const result = disableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
 
     expect(result.ok).toBe(false);
-    expect(calls.map((call) => call.args[0])).toEqual(['/query', '/end', '/query', '/query', '/delete']);
+    expect(calls.map((call) => call.command === 'powershell.exe' ? 'query' : call.args[0])).toEqual(['query', '/end', 'query', 'query', '/delete']);
     expect(existsSync(unitPath)).toBe(true);
   });
 
@@ -421,7 +463,7 @@ describe('disable', () => {
     const calls: ServiceCommand[] = [];
     const run = (invocation: ServiceCommand): CommandOutcome => {
       calls.push(invocation);
-      if (invocation.args[0] === '/query') return { ok: true, output: 'Status: Running' };
+      if (isWindowsQuery(invocation)) return windowsState(4);
       if (invocation.args[0] === '/end') return { ok: true, output: '' };
       return { ok: false, output: 'unexpected command' };
     };
@@ -442,9 +484,9 @@ describe('disable', () => {
     let postEndQueries = 0;
     const waits: number[] = [];
     const run = (invocation: ServiceCommand): CommandOutcome => {
-      if (invocation.args[0] === '/query') {
-        if (ended && ++postEndQueries >= 3) return { ok: true, output: 'Status: Ready' };
-        return { ok: true, output: 'Status: Running' };
+      if (isWindowsQuery(invocation)) {
+        if (ended && ++postEndQueries >= 3) return windowsState(3);
+        return windowsState(4);
       }
       if (invocation.args[0] === '/end') {
         ended = true;
@@ -469,6 +511,16 @@ describe('disable', () => {
 });
 
 describe('state reporting', () => {
+  it('reports a registered but Task-Scheduler-disabled task without inventing login enablement', () => {
+    const state = metaProxyServiceState('win32', home, () => windowsState(1, false));
+    expect(state).toMatchObject({ managerState: 'enabled', loaded: true, enabledAtLogin: false, running: false });
+  });
+
+  it('fails closed on an unstructured Windows manager response', () => {
+    const state = metaProxyServiceState('win32', home, () => ({ ok: true, output: 'Status: Ready' }));
+    expect(state).toMatchObject({ managerState: 'unknown', loaded: null, running: null });
+  });
+
   it('distinguishes enabled from disabled from unsupported', () => {
     const missing = () => ({ ok: false, output: 'Could not find service' });
     expect(metaProxyServiceState('darwin', home, missing).installed).toBe(false);

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -4,7 +4,7 @@
 // pure, so the full macOS/Linux/Windows matrix is asserted on one machine
 // without touching launchctl, systemctl or schtasks.
 
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -18,6 +18,8 @@ import {
   renderLaunchAgent,
   renderScheduledTask,
   renderSystemdUnit,
+  startMetaProxyService,
+  stopMetaProxyService,
   serviceUnitPath,
   SERVICE_LABEL,
   type CommandOutcome,
@@ -32,6 +34,9 @@ function recorder(ok = true) {
   const calls: ServiceCommand[] = [];
   const run = (invocation: ServiceCommand): CommandOutcome => {
     calls.push(invocation);
+    if (invocation.args[0] === 'print') return { ok: false, output: 'Could not find service' };
+    if (invocation.args.includes('show')) return { ok: true, output: 'LoadState=not-found' };
+    if (invocation.args[0] === '/query') return { ok: false, output: 'ERROR: The system cannot find the file specified.' };
     return ok ? { ok: true, output: '' } : { ok: false, output: 'boom' };
   };
   return { calls, run };
@@ -61,6 +66,7 @@ describe('unit rendering', () => {
     expect(plist).toContain('<key>SuccessfulExit</key>');
     expect(plist).toContain('<false/>');
     expect(plist).toContain(SERVICE_LABEL);
+    expect(plist).toContain('<string>--supervised</string>');
   });
 
   it('escapes a home directory that contains XML metacharacters', () => {
@@ -77,7 +83,7 @@ describe('unit rendering', () => {
     // must not run a user's proxy.
     expect(unit).toContain('WantedBy=default.target');
     expect(unit).toContain('Restart=on-failure');
-    expect(unit).toContain('ExecStart=/bin/meta-proxy');
+    expect(unit).toContain('ExecStart=/bin/meta-proxy --supervised');
     expect(unit).not.toContain('multi-user.target');
   });
 
@@ -87,6 +93,7 @@ describe('unit rendering', () => {
     expect(task).toContain('<RestartOnFailure>');
     // A long-lived daemon must not be killed by the default 72h limit.
     expect(task).toContain('<ExecutionTimeLimit>PT0S</ExecutionTimeLimit>');
+    expect(task).toContain('<Arguments>--supervised</Arguments>');
   });
 });
 
@@ -123,10 +130,49 @@ describe('enable', () => {
     const unitPath = serviceUnitPath('darwin', home)!;
     expect(existsSync(unitPath)).toBe(true);
     expect(calls[0]!.command).toBe('launchctl');
-    expect(calls[0]!.args[0]).toBe('bootstrap');
+    expect(calls[0]!.args[0]).toBe('print');
+    expect(calls.some((call) => call.args[0] === 'bootstrap')).toBe(true);
     // The definition points at the managed binary, not a PATH lookup.
     expect(result.unitPath).toBe(unitPath);
     expect(binary.length).toBeGreaterThan(0);
+  });
+
+  it('is idempotent when the same LaunchAgent is already enabled', () => {
+    installFakeDaemon('darwin');
+    const calls: ServiceCommand[] = [];
+    let registered = false;
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args[0] === 'print') {
+        return registered
+          ? { ok: true, output: 'state = running\npid = 123' }
+          : { ok: false, output: 'Could not find service' };
+      }
+      if (invocation.args[0] === 'bootstrap') registered = true;
+      return { ok: true, output: '' };
+    };
+
+    expect(enableMetaProxyService({ home, platform: 'darwin', run }).ok).toBe(true);
+    calls.length = 0;
+    const again = enableMetaProxyService({ home, platform: 'darwin', run });
+
+    expect(again.ok).toBe(true);
+    expect(calls.map((call) => call.args[0])).toEqual(['print']);
+  });
+
+  it('does not overwrite a different stopped LaunchAgent definition', () => {
+    installFakeDaemon('darwin');
+    const unitPath = serviceUnitPath('darwin', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, 'foreign or tampered definition');
+    const { calls, run } = recorder();
+
+    const result = enableMetaProxyService({ home, platform: 'darwin', run });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/different.*definition/i);
+    expect(readFileSync(unitPath, 'utf8')).toBe('foreign or tampered definition');
+    expect(calls.map((call) => call.args[0])).toEqual(['print']);
   });
 
   /// A unit file present but never loaded makes `proxy status` claim
@@ -144,10 +190,18 @@ describe('enable', () => {
   it('compensates a registration when starting the registered job fails', () => {
     installFakeDaemon('darwin');
     const calls: ServiceCommand[] = [];
+    let registered = false;
     const run = (invocation: ServiceCommand): CommandOutcome => {
       calls.push(invocation);
       const action = invocation.args[0];
+      if (action === 'print') {
+        return registered
+          ? { ok: true, output: 'state = running\npid = 123' }
+          : { ok: false, output: 'Could not find service' };
+      }
+      if (action === 'bootstrap') registered = true;
       if (action === 'kickstart') return { ok: false, output: 'kickstart failed' };
+      if (action === 'bootout') registered = false;
       return { ok: true, output: '' };
     };
 
@@ -155,6 +209,7 @@ describe('enable', () => {
 
     expect(result.ok).toBe(false);
     expect(calls.map((call) => call.args[0])).toEqual([
+      'print',
       'bootstrap',
       'kickstart',
       'print',
@@ -187,13 +242,13 @@ describe('disable', () => {
     const calls: ServiceCommand[] = [];
     const run = (invocation: ServiceCommand): CommandOutcome => {
       calls.push(invocation);
-      return { ok: false, output: 'disabled' };
+      return { ok: true, output: 'LoadState=not-found' };
     };
     const result = disableMetaProxyService({ home, platform: 'linux', run });
     expect(result.ok).toBe(true);
     expect(result.message).toContain('not set to start at login');
     expect(calls).toHaveLength(1);
-    expect(calls[0]?.args).toContain('is-enabled');
+    expect(calls[0]?.args).toContain('show');
   });
 
   it('reports failure and preserves the definition when unregistering fails', () => {
@@ -206,8 +261,8 @@ describe('disable', () => {
       home,
       platform: 'linux',
       run: (invocation) =>
-        invocation.args.includes('is-enabled')
-          ? { ok: true, output: 'enabled' }
+        invocation.args.includes('show')
+          ? { ok: true, output: 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nMainPID=123' }
           : { ok: false, output: 'disable failed' },
     });
     expect(result.ok).toBe(false);
@@ -218,10 +273,20 @@ describe('disable', () => {
 
 describe('state reporting', () => {
   it('distinguishes enabled from disabled from unsupported', () => {
-    expect(metaProxyServiceState('darwin', home).installed).toBe(false);
+    const missing = () => ({ ok: false, output: 'Could not find service' });
+    expect(metaProxyServiceState('darwin', home, missing).installed).toBe(false);
 
     installFakeDaemon('darwin');
-    const enabled = recorder().run;
+    let registered = false;
+    const enabled = (invocation: ServiceCommand): CommandOutcome => {
+      if (invocation.args[0] === 'print') {
+        return registered
+          ? { ok: true, output: 'state = running\npid = 123' }
+          : { ok: false, output: 'Could not find service' };
+      }
+      if (invocation.args[0] === 'bootstrap') registered = true;
+      return { ok: true, output: '' };
+    };
     enableMetaProxyService({ home, platform: 'darwin', run: enabled });
     expect(metaProxyServiceState('darwin', home, enabled).installed).toBe(true);
 
@@ -243,6 +308,59 @@ describe('state reporting', () => {
     expect(state.managerState).toBe('disabled');
     expect(state.installed).toBe(false);
     expect(state.definitionPresent).toBe(true);
+  });
+
+  it('fails closed when a manager query is denied instead of treating it as disabled', () => {
+    const unit = serviceUnitPath('darwin', home)!;
+    mkdirSync(dirname(unit), { recursive: true });
+    writeFileSync(unit, 'owned definition');
+
+    const run = () => ({ ok: false, output: 'Operation not permitted' });
+    const state = metaProxyServiceState('darwin', home, run);
+    const disabled = disableMetaProxyService({ home, platform: 'darwin', run });
+
+    expect(state.managerState).toBe('unknown');
+    expect(disabled.ok).toBe(false);
+    expect(existsSync(unit)).toBe(true);
+  });
+
+  it('reports the supervisor pid and stops it without a MetaHarness pid file', () => {
+    const binary = installFakeDaemon('darwin');
+    const unit = serviceUnitPath('darwin', home)!;
+    mkdirSync(dirname(unit), { recursive: true });
+    writeFileSync(unit, renderLaunchAgent(binary, join(home, 'proxy.log')));
+    let running = true;
+    let registered = true;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args[0] === 'print') {
+        return registered
+          ? { ok: true, output: running ? 'state = running\npid = 4242' : 'state = exited' }
+          : { ok: false, output: 'Could not find service' };
+      }
+      if (invocation.args[0] === 'bootout') {
+        registered = false;
+        running = false;
+      }
+      if (invocation.args[0] === 'bootstrap') registered = true;
+      if (invocation.args[0] === 'kickstart') running = true;
+      return { ok: true, output: '' };
+    };
+
+    const before = metaProxyServiceState('darwin', home, run);
+    expect(before.running).toBe(true);
+    expect(before.pid).toBe(4242);
+
+    const stopped = stopMetaProxyService({ home, platform: 'darwin', run });
+    expect(stopped.ok).toBe(true);
+    expect(calls.some((call) => call.args[0] === 'bootout')).toBe(true);
+    expect(metaProxyServiceState('darwin', home, run).running).toBe(false);
+
+    const started = startMetaProxyService({ home, platform: 'darwin', run });
+    expect(started.ok).toBe(true);
+    expect(calls.some((call) => call.args[0] === 'bootstrap')).toBe(true);
+    expect(calls.some((call) => call.args[0] === 'kickstart')).toBe(true);
   });
 
   it('reports an externally registered service even when its definition is missing', () => {

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -175,8 +175,30 @@ describe('enable', () => {
     expect(calls.map((call) => call.args[0])).toEqual(['print']);
   });
 
-  /// A unit file present but never loaded makes `proxy status` claim
-  /// start-at-login is on when it is not.
+  it('preserves an active loaded Linux unit when enabling login start fails', () => {
+    const binary = installFakeDaemon('linux');
+    const unitPath = serviceUnitPath('linux', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    const definition = renderSystemdUnit(binary);
+    writeFileSync(unitPath, definition);
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) {
+        return { ok: true, output: 'LoadState=loaded\nUnitFileState=disabled\nActiveState=active\nMainPID=718' };
+      }
+      if (invocation.args.includes('daemon-reload')) return { ok: false, output: 'reload unavailable' };
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'linux', run });
+
+    expect(result.ok).toBe(false);
+    expect(readFileSync(unitPath, 'utf8')).toBe(definition);
+    expect(calls.some((call) => call.args.includes('disable'))).toBe(false);
+  });
+
+  /// A rejected first-time enable must not leave a new definition behind.
   it('leaves nothing behind when the service manager rejects it', () => {
     installFakeDaemon('linux');
     const { run } = recorder(false);
@@ -269,6 +291,77 @@ describe('disable', () => {
     expect(existsSync(unit)).toBe(true);
     expect(result.message).toContain('disable failed');
   });
+
+  it('restores the Linux definition when daemon-reload fails after disable', () => {
+    const binary = installFakeDaemon('linux');
+    const unitPath = serviceUnitPath('linux', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    const definition = renderSystemdUnit(binary);
+    writeFileSync(unitPath, definition);
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) {
+        return { ok: true, output: 'LoadState=loaded\nUnitFileState=enabled\nActiveState=active\nMainPID=456' };
+      }
+      if (invocation.args.includes('disable')) return { ok: true, output: '' };
+      if (invocation.args.includes('daemon-reload')) return { ok: false, output: 'manager unavailable' };
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = disableMetaProxyService({ home, platform: 'linux', run });
+
+    expect(result.ok).toBe(false);
+    expect(readFileSync(unitPath, 'utf8')).toBe(definition);
+    expect(calls.some((call) => call.args.includes('daemon-reload'))).toBe(true);
+  });
+
+  it('ends and confirms a Windows task before deleting it', () => {
+    installFakeDaemon('win32');
+    const unitPath = serviceUnitPath('win32', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, '<Task>owned definition</Task>');
+    let running = true;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args[0] === '/query') {
+        return { ok: true, output: running ? 'Status: Running' : 'Status: Ready' };
+      }
+      if (invocation.args[0] === '/end') {
+        running = false;
+        return { ok: true, output: '' };
+      }
+      if (invocation.args[0] === '/delete') return { ok: false, output: 'delete denied' };
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = disableMetaProxyService({ home, platform: 'win32', run });
+
+    expect(result.ok).toBe(false);
+    expect(calls.map((call) => call.args[0])).toEqual(['/query', '/end', '/query', '/delete']);
+    expect(existsSync(unitPath)).toBe(true);
+  });
+
+  it('preserves a Windows task when stop cannot be confirmed', () => {
+    installFakeDaemon('win32');
+    const unitPath = serviceUnitPath('win32', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    writeFileSync(unitPath, '<Task>owned definition</Task>');
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args[0] === '/query') return { ok: true, output: 'Status: Running' };
+      if (invocation.args[0] === '/end') return { ok: true, output: '' };
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = disableMetaProxyService({ home, platform: 'win32', run });
+
+    expect(result.ok).toBe(false);
+    expect(calls.some((call) => call.args[0] === '/delete')).toBe(false);
+    expect(existsSync(unitPath)).toBe(true);
+  });
 });
 
 describe('state reporting', () => {
@@ -295,7 +388,7 @@ describe('state reporting', () => {
     expect(unsupported.unitPath).toBeNull();
   });
 
-  it('trusts the service manager over a stale definition file', () => {
+  it('separates current manager load state from a next-login definition', () => {
     const unit = serviceUnitPath('darwin', home)!;
     mkdirSync(dirname(unit), { recursive: true });
     writeFileSync(unit, 'stale definition');
@@ -322,6 +415,34 @@ describe('state reporting', () => {
     expect(state.managerState).toBe('unknown');
     expect(disabled.ok).toBe(false);
     expect(existsSync(unit)).toBe(true);
+  });
+
+  it('reports and stops an active loaded Linux service even when login start is disabled', () => {
+    const binary = installFakeDaemon('linux');
+    const unit = serviceUnitPath('linux', home)!;
+    mkdirSync(dirname(unit), { recursive: true });
+    writeFileSync(unit, renderSystemdUnit(binary));
+    let active = true;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) {
+        return {
+          ok: true,
+          output: `LoadState=loaded\nUnitFileState=disabled\nActiveState=${active ? 'active' : 'inactive'}\nMainPID=${active ? '991' : '0'}`,
+        };
+      }
+      if (invocation.args.includes('stop')) {
+        active = false;
+        return { ok: true, output: '' };
+      }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const before = metaProxyServiceState('linux', home, run);
+    expect(before).toMatchObject({ installed: true, loaded: true, enabledAtLogin: false, running: true, pid: 991 });
+    expect(stopMetaProxyService({ home, platform: 'linux', run }).ok).toBe(true);
+    expect(calls.some((call) => call.args.includes('stop'))).toBe(true);
   });
 
   it('reports the supervisor pid and stops it without a MetaHarness pid file', () => {

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -805,3 +805,68 @@ describe('state reporting', () => {
     expect(state.definitionPresent).toBe(false);
   });
 });
+
+describe('foreign registrations are never touched (ownership guard)', () => {
+  const foreignPrint: CommandOutcome = { ok: true, output: 'state = running\npid = 55' };
+  const foreignShow: CommandOutcome = {
+    ok: true,
+    output: 'LoadState=loaded\nUnitFileState=static\nActiveState=active\nMainPID=99',
+  };
+
+  it('enable refuses a label-matching macOS job it does not own', () => {
+    installFakeDaemon('darwin');
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args[0] === 'print') return foreignPrint;
+      return { ok: true, output: '' };
+    };
+    const result = enableMetaProxyService({ home, platform: 'darwin', run });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('registered without the owned definition');
+    // Only the state read may run — no bootstrap, and above all no bootout.
+    expect(calls.map((call) => call.args[0])).toEqual(['print']);
+    expect(existsSync(serviceUnitPath('darwin', home)!)).toBe(false);
+  });
+
+  it('enable refuses a shadowing systemd unit it does not own', () => {
+    installFakeDaemon('linux');
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) return foreignShow;
+      return { ok: true, output: '' };
+    };
+    const result = enableMetaProxyService({ home, platform: 'linux', run });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('registered without the owned definition');
+    expect(calls).toHaveLength(1);
+    expect(existsSync(serviceUnitPath('linux', home)!)).toBe(false);
+  });
+
+  it('disable refuses to boot out a macOS job without the owned definition', () => {
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args[0] === 'print') return foreignPrint;
+      return { ok: true, output: '' };
+    };
+    const result = disableMetaProxyService({ home, platform: 'darwin', run });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('refusing to stop or delete it by label alone');
+    expect(calls.map((call) => call.args[0])).toEqual(['print']);
+  });
+
+  it('disable refuses to unregister a Linux unit without the owned definition', () => {
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (invocation.args.includes('show')) return foreignShow;
+      return { ok: true, output: '' };
+    };
+    const result = disableMetaProxyService({ home, platform: 'linux', run });
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('refusing to stop or delete it by label alone');
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -432,7 +432,7 @@ describe('enable', () => {
         creates += 1;
         if (creates === 1) { taskState = 'missing'; return { ok: false, output: 'simulated create removed task before lost response' }; }
         taskState = 3;
-        return { ok: true, output: '' };
+        return { ok: false, output: 'simulated lost compensating create response' };
       }
       if (invocation.args[0] === '/end') return { ok: true, output: '' };
       if (invocation.args[0] === '/change' && invocation.args.includes('/disable')) { taskState = 1; return { ok: true, output: '' }; }

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -409,7 +409,7 @@ describe('disable', () => {
     const result = disableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
 
     expect(result.ok).toBe(false);
-    expect(calls.map((call) => call.args[0])).toEqual(['/query', '/end', '/query', '/delete']);
+    expect(calls.map((call) => call.args[0])).toEqual(['/query', '/end', '/query', '/query', '/delete']);
     expect(existsSync(unitPath)).toBe(true);
   });
 
@@ -462,8 +462,8 @@ describe('disable', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(postEndQueries).toBe(3);
-    expect(waits).toEqual([100, 100]);
+    expect(postEndQueries).toBe(4);
+    expect(waits).toEqual([100, 100, 100]);
     expect(existsSync(unitPath)).toBe(false);
   });
 });

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -89,7 +89,7 @@ describe('unit rendering', () => {
 
   it('restarts on failure on Windows and does not time out', () => {
     const task = renderScheduledTask('C:\\meta-proxy.exe');
-    expect(task).toContain('encoding="UTF-8"');
+    expect(task.startsWith('\uFEFF<?xml version="1.0" encoding="UTF-16"?>')).toBe(true);
     expect(task).toContain('<LogonTrigger>');
     expect(task).toContain('<LogonType>InteractiveToken</LogonType>');
     expect(task).toContain('<RunLevel>LeastPrivilege</RunLevel>');
@@ -169,6 +169,27 @@ describe('enable', () => {
 
     expect(again.ok).toBe(true);
     expect(calls.map((call) => call.args[0])).toEqual(['print']);
+  });
+
+  it('writes canonical UTF-16LE Windows XML and can read it idempotently', () => {
+    installFakeDaemon('win32');
+    let registered = false;
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      if (invocation.args[0] === '/query') {
+        return registered
+          ? { ok: true, output: 'Status: Ready' }
+          : { ok: false, output: 'ERROR: The system cannot find the file specified.' };
+      }
+      if (invocation.args[0] === '/create') registered = true;
+      return { ok: true, output: '' };
+    };
+
+    expect(enableMetaProxyService({ home, platform: 'win32', run }).ok).toBe(true);
+    const unitPath = serviceUnitPath('win32', home)!;
+    const bytes = readFileSync(unitPath);
+    expect([...bytes.subarray(0, 2)]).toEqual([0xff, 0xfe]);
+    expect(bytes.toString('utf16le')).toBe(renderScheduledTask(metaProxyBinaryPath('win32', home)));
+    expect(enableMetaProxyService({ home, platform: 'win32', run }).ok).toBe(true);
   });
 
   it('does not overwrite a different stopped LaunchAgent definition', () => {

--- a/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-service.test.ts
@@ -399,6 +399,55 @@ describe('enable', () => {
     expect(calls.some((call) => call.args[0] === '/delete')).toBe(false);
   });
 
+  it('refuses to overwrite a registered disabled Windows task without an owned definition', () => {
+    installFakeDaemon('win32');
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (isWindowsQuery(invocation)) return windowsState(1);
+      return { ok: false, output: 'unexpected mutation' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'win32', run });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toMatch(/registered.*definition/i);
+    expect(calls.some((call) => call.args[0] === '/create')).toBe(false);
+    expect(existsSync(serviceUnitPath('win32', home)!)).toBe(false);
+  });
+
+  it('recreates an owned disabled Windows task when an ambiguous create leaves it absent', () => {
+    const binary = installFakeDaemon('win32');
+    const unitPath = serviceUnitPath('win32', home)!;
+    mkdirSync(dirname(unitPath), { recursive: true });
+    const definition = renderScheduledTask(binary);
+    writeFileSync(unitPath, definition, 'utf16le');
+    let taskState: 1 | 3 | 'missing' = 1;
+    let creates = 0;
+    const calls: ServiceCommand[] = [];
+    const run = (invocation: ServiceCommand): CommandOutcome => {
+      calls.push(invocation);
+      if (isWindowsQuery(invocation)) return taskState === 'missing' ? { ok: true, output: 'TaskState=Missing' } : windowsState(taskState);
+      if (invocation.args[0] === '/create') {
+        creates += 1;
+        if (creates === 1) { taskState = 'missing'; return { ok: false, output: 'simulated create removed task before lost response' }; }
+        taskState = 3;
+        return { ok: true, output: '' };
+      }
+      if (invocation.args[0] === '/end') return { ok: true, output: '' };
+      if (invocation.args[0] === '/change' && invocation.args.includes('/disable')) { taskState = 1; return { ok: true, output: '' }; }
+      return { ok: false, output: 'unexpected command' };
+    };
+
+    const result = enableMetaProxyService({ home, platform: 'win32', run, wait: () => {} });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('simulated create removed task');
+    expect(creates).toBe(2);
+    expect(metaProxyServiceState('win32', home, run)).toMatchObject({ loaded: true, enabledAtLogin: false, running: false });
+    expect(readFileSync(unitPath, 'utf16le')).toBe(definition);
+  });
+
   it('says so rather than pretending on an unsupported platform', () => {
     const result = enableMetaProxyService({ home, platform: 'freebsd' as NodeJS.Platform });
     expect(result.ok).toBe(false);

--- a/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
@@ -16,4 +16,16 @@ describe('Meta-Proxy native lifecycle gate', () => {
     expect(workflow).toContain('meta-proxy-launchagent.real.test.ts');
     expect(workflow).toMatch(/ci-pass:\n[\s\S]*needs:.*meta-proxy-launchagent/);
   });
+
+  it('is a durable required Windows CI job rather than unit mocks only', () => {
+    const workflow = readFileSync(
+      fileURLToPath(new URL('../../../.github/workflows/ci.yml', import.meta.url)),
+      'utf8',
+    );
+
+    expect(workflow).toMatch(/meta-proxy-scheduled-task:\n[\s\S]*runs-on: windows-latest/);
+    expect(workflow).toMatch(/RUN_REAL_SCHEDULED_TASK_ACCEPTANCE: ['"]1['"]/);
+    expect(workflow).toContain('meta-proxy-scheduled-task.real.test.ts');
+    expect(workflow).toMatch(/ci-pass:\n[\s\S]*needs:.*meta-proxy-scheduled-task/);
+  });
 });

--- a/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
@@ -9,7 +9,7 @@ describe('Meta-Proxy native lifecycle gate', () => {
     const workflow = readFileSync(
       fileURLToPath(new URL('../../../.github/workflows/ci.yml', import.meta.url)),
       'utf8',
-    );
+    ).replace(/\r\n/g, '\n');
 
     expect(workflow).toMatch(/meta-proxy-launchagent:\n[\s\S]*runs-on: macos-latest/);
     expect(workflow).toMatch(/RUN_REAL_LAUNCHD_ACCEPTANCE: ['"]1['"]/);
@@ -21,7 +21,7 @@ describe('Meta-Proxy native lifecycle gate', () => {
     const workflow = readFileSync(
       fileURLToPath(new URL('../../../.github/workflows/ci.yml', import.meta.url)),
       'utf8',
-    );
+    ).replace(/\r\n/g, '\n');
 
     expect(workflow).toMatch(/meta-proxy-scheduled-task:\n[\s\S]*runs-on: windows-latest/);
     expect(workflow).toMatch(/RUN_REAL_SCHEDULED_TASK_ACCEPTANCE: ['"]1['"]/);

--- a/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: MIT
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+describe('Meta-Proxy native lifecycle gate', () => {
+  it('is a durable required macOS CI job rather than an opt-in-only local test', () => {
+    const workflow = readFileSync(
+      fileURLToPath(new URL('../../../.github/workflows/ci.yml', import.meta.url)),
+      'utf8',
+    );
+
+    expect(workflow).toMatch(/meta-proxy-launchagent:\n[\s\S]*runs-on: macos-latest/);
+    expect(workflow).toMatch(/RUN_REAL_LAUNCHD_ACCEPTANCE: ['"]1['"]/);
+    expect(workflow).toContain('meta-proxy-launchagent.real.test.ts');
+    expect(workflow).toMatch(/ci-pass:\n[\s\S]*needs:.*meta-proxy-launchagent/);
+  });
+});

--- a/packages/create-agent-harness/__tests__/meta-proxy.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy.test.ts
@@ -167,4 +167,34 @@ describe('optional Meta-Proxy integration', () => {
       rmSync(home, { recursive: true, force: true });
     }
   });
+
+  it('reports files it could not remove instead of throwing mid-uninstall', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'proxy-uninstall-locked-'));
+    try {
+      const root = join(home, '.metaharness', 'meta-proxy');
+      const bin = join(root, 'bin', 'meta-proxy');
+      mkdirSync(join(root, 'bin'), { recursive: true });
+      writeFileSync(bin, 'binary');
+      // A non-empty directory where the log file lives makes
+      // `rmSync(path, { force: true })` throw, standing in for the Windows
+      // EBUSY on a still-locked executable.
+      mkdirSync(join(root, 'meta-proxy.log', 'held'), { recursive: true });
+
+      const result = await uninstallMetaProxy({
+        home,
+        platform: 'darwin',
+        run: () => ({ ok: false, output: 'Could not find service' }),
+        wait: async () => {},
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toContain('meta-proxy.log');
+      expect(result.message).toContain('re-run: metaharness proxy uninstall --yes');
+      // The failure is reported, not thrown, and the other owned files were
+      // still removed.
+      expect(existsSync(bin)).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/create-agent-harness/__tests__/meta-proxy.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy.test.ts
@@ -8,18 +8,24 @@ import {
   metaProxyClientEnvironment,
   metaProxyCmd,
   metaProxyEndpoint,
+  metaProxyLogLines,
   parseSha256Sums,
   resolveMetaProxyAsset,
   sha256Hex,
   verifyMetaProxyChecksum,
   verifyMetaProxyManifest,
+  uninstallMetaProxy,
   worktreeFingerprint,
 } from '../src/meta-proxy.js';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 describe('optional Meta-Proxy integration', () => {
+  it('pins the daemon release required by the signed extension', () => {
+    expect(META_PROXY_VERSION).toBe('0.7.4');
+  });
+
   it('maps each supported platform to the signed v0.3.0 asset name', () => {
     expect(resolveMetaProxyAsset('win32', 'x64')).toMatchObject({
       target: 'x86_64-pc-windows-msvc',
@@ -94,5 +100,71 @@ describe('optional Meta-Proxy integration', () => {
     expect(claim).toMatchObject({ policy: 'economy', exp: 28_800 });
     expect(claim.worktree).toMatch(/^[a-f0-9]{32}$/);
     expect(JSON.stringify(claim)).not.toContain('C:/tmp/herd/agent-a');
+  });
+
+  it('tails logs without returning the whole file', () => {
+    const home = mkdtempSync(join(tmpdir(), 'proxy-logs-'));
+    try {
+      const root = join(home, '.metaharness', 'meta-proxy');
+      mkdirSync(root, { recursive: true });
+      writeFileSync(join(root, 'meta-proxy.log'), 'one\ntwo\nthree\n');
+      expect(metaProxyLogLines(home, 2)).toEqual(['two', 'three']);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('uninstalls only owned files and preserves user routing state', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'proxy-uninstall-'));
+    try {
+      const root = join(home, '.metaharness', 'meta-proxy');
+      const bin = join(root, 'bin', 'meta-proxy');
+      const userState = join(home, '.ruflo');
+      mkdirSync(join(root, 'bin'), { recursive: true });
+      mkdirSync(userState, { recursive: true });
+      writeFileSync(bin, 'binary');
+      writeFileSync(`${bin}.version`, '0.7.3\n');
+      writeFileSync(join(root, 'meta-proxy.log'), 'log');
+      writeFileSync(join(root, 'unrelated-user-note'), 'keep');
+      writeFileSync(join(userState, 'proxy-token'), 'keep');
+      writeFileSync(join(userState, 'proxy-config.toml'), 'keep');
+
+      const result = await uninstallMetaProxy({
+        home,
+        platform: 'darwin',
+        run: () => ({ ok: false, output: 'not registered' }),
+      });
+
+      expect(result.ok).toBe(true);
+      expect(existsSync(bin)).toBe(false);
+      expect(existsSync(`${bin}.version`)).toBe(false);
+      expect(existsSync(join(root, 'meta-proxy.log'))).toBe(false);
+      expect(existsSync(join(root, 'unrelated-user-note'))).toBe(true);
+      expect(existsSync(join(userState, 'proxy-token'))).toBe(true);
+      expect(existsSync(join(userState, 'proxy-config.toml'))).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to remove the binary when service-manager state is unknown', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'proxy-uninstall-failure-'));
+    try {
+      const bin = join(home, '.metaharness', 'meta-proxy', 'bin', 'meta-proxy');
+      mkdirSync(join(home, '.metaharness', 'meta-proxy', 'bin'), { recursive: true });
+      writeFileSync(bin, 'binary');
+
+      const result = await uninstallMetaProxy({
+        home,
+        platform: 'darwin',
+        run: () => ({ ok: false, output: 'launchctl unavailable', error: 'ENOENT' }),
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.message).toMatch(/refusing to uninstall/i);
+      expect(existsSync(bin)).toBe(true);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/create-agent-harness/__tests__/meta-proxy.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy.test.ts
@@ -132,7 +132,7 @@ describe('optional Meta-Proxy integration', () => {
       const result = await uninstallMetaProxy({
         home,
         platform: 'darwin',
-        run: () => ({ ok: false, output: 'not registered' }),
+        run: () => ({ ok: false, output: 'Could not find service' }),
       });
 
       expect(result.ok).toBe(true);

--- a/packages/create-agent-harness/__tests__/secrets.test.ts
+++ b/packages/create-agent-harness/__tests__/secrets.test.ts
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 
+import { EventEmitter } from 'node:events';
 import { describe, it, expect } from 'vitest';
-import { check, fetch, secretsDispatch, type GcloudRunner } from '../src/secrets.js';
+import { check, commandOnPath, fetch, secretsDispatch, type GcloudRunner } from '../src/secrets.js';
 
 function mockRunner(table: Record<string, { code: number; stdout: string; stderr?: string }>): GcloudRunner {
   return {
@@ -22,12 +23,7 @@ describe('harness secrets check', () => {
       'secrets describe NPM_TOKEN': { code: 0, stdout: 'projects/123/secrets/NPM_TOKEN\n' },
       'iam workload-identity-pools list': { code: 0, stdout: 'GitHub Actions\n' },
     });
-    const { code, lines } = await check([], runner);
-    // gcloud-on-PATH might be false in CI without gcloud — accept either path.
-    if (lines[1]?.includes('FAIL gcloud CLI not on PATH')) {
-      expect(code).toBe(1);
-      return;
-    }
+    const { code, lines } = await check([], runner, async () => true);
     expect(code).toBe(0);
     expect(lines.some(l => l.startsWith('Result: HEALTHY'))).toBe(true);
   });
@@ -36,12 +32,7 @@ describe('harness secrets check', () => {
     const runner = mockRunner({
       'config get-value project': { code: 0, stdout: '(unset)\n' },
     });
-    const { code, lines } = await check([], runner);
-    if (lines[1]?.includes('FAIL gcloud CLI not on PATH')) {
-      // Skip — no gcloud installed in CI sandbox
-      expect(code).toBe(1);
-      return;
-    }
+    const { code, lines } = await check([], runner, async () => true);
     expect(code).toBe(1);
     expect(lines.join('\n')).toMatch(/no active gcloud project/);
   });
@@ -56,9 +47,19 @@ describe('harness secrets check', () => {
         code: 0, stdout: 'GitHub Actions\n',
       },
     });
-    const { lines } = await check(['--project=forced-proj'], runner);
-    if (lines[1]?.includes('FAIL gcloud CLI not on PATH')) return;
+    const { lines } = await check(['--project=forced-proj'], runner, async () => true);
     expect(lines.some(l => l.includes('forced-proj'))).toBe(true);
+  });
+
+  it('bounds a hung PATH lookup and terminates its child', async () => {
+    class HungChild extends EventEmitter {
+      killed = false;
+      kill() { this.killed = true; return true; }
+    }
+    const child = new HungChild();
+    const found = await commandOnPath('gcloud', 'win32', () => child, 5);
+    expect(found).toBe(false);
+    expect(child.killed).toBe(true);
   });
 });
 

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM, Prime Agent.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -59,11 +59,13 @@ export interface ServiceResult {
 
 export interface ServiceState {
   supported: boolean;
-  /** A definition exists on disk (macOS/Linux) or the task is registered (Windows). */
+  /** The service manager currently has the job/unit/task loaded. */
   installed: boolean;
   unitPath: string | null;
   managerState: 'enabled' | 'disabled' | 'unknown';
   definitionPresent: boolean;
+  /** Whether the service manager currently has the job/unit/task loaded. */
+  loaded: boolean | null;
   /** Whether the service remains configured to start on the user's next login. */
   enabledAtLogin: boolean;
   /** null means the manager answered but does not expose a portable run state. */
@@ -283,31 +285,40 @@ function knownMissingService(platform: NodeJS.Platform, output: string): boolean
   return false;
 }
 
-function parseManagerState(platform: NodeJS.Platform, outcome: CommandOutcome): Pick<ServiceState, 'managerState' | 'running' | 'pid'> {
-  if (outcome.error) return { managerState: 'unknown', running: null, pid: null };
+function parseManagerState(
+  platform: NodeJS.Platform,
+  outcome: CommandOutcome,
+  definitionPresent: boolean,
+): Pick<ServiceState, 'managerState' | 'loaded' | 'enabledAtLogin' | 'running' | 'pid'> {
+  if (outcome.error) return { managerState: 'unknown', loaded: null, enabledAtLogin: false, running: null, pid: null };
   if (!outcome.ok) {
     return knownMissingService(platform, outcome.output)
-      ? { managerState: 'disabled', running: false, pid: null }
-      : { managerState: 'unknown', running: null, pid: null };
+      ? { managerState: 'disabled', loaded: false, enabledAtLogin: platform === 'darwin' && definitionPresent, running: false, pid: null }
+      : { managerState: 'unknown', loaded: null, enabledAtLogin: false, running: null, pid: null };
   }
 
   if (platform === 'darwin') {
     const pid = outcome.output.match(/\bpid\s*=\s*(\d+)/)?.[1];
     return {
       managerState: 'enabled',
+      loaded: true,
+      enabledAtLogin: definitionPresent,
       running: /\bstate\s*=\s*running\b/.test(outcome.output) || pid !== undefined,
       pid: pid ? Number.parseInt(pid, 10) : null,
     };
   }
   if (platform === 'linux') {
     if (/^LoadState=not-found$/m.test(outcome.output)) {
-      return { managerState: 'disabled', running: false, pid: null };
+      return { managerState: 'disabled', loaded: false, enabledAtLogin: false, running: false, pid: null };
     }
     const enabled = /^UnitFileState=(?:enabled|enabled-runtime|linked|linked-runtime)$/m.test(outcome.output);
+    const loaded = /^LoadState=loaded$/m.test(outcome.output);
     const pidText = outcome.output.match(/^MainPID=(\d+)$/m)?.[1];
     const pid = pidText && pidText !== '0' ? Number.parseInt(pidText, 10) : null;
     return {
-      managerState: enabled ? 'enabled' : 'disabled',
+      managerState: loaded ? 'enabled' : 'disabled',
+      loaded,
+      enabledAtLogin: enabled,
       running: /^ActiveState=active$/m.test(outcome.output),
       pid,
     };
@@ -315,11 +326,17 @@ function parseManagerState(platform: NodeJS.Platform, outcome: CommandOutcome): 
   if (platform === 'win32') {
     return {
       managerState: 'enabled',
-      running: /^Status:\s+Running\s*$/im.test(outcome.output),
+      loaded: true,
+      enabledAtLogin: true,
+      running: /^Status:\s+Running\s*$/im.test(outcome.output)
+        ? true
+        : /^Status:\s+(?:Ready|Disabled)\s*$/im.test(outcome.output)
+          ? false
+          : null,
       pid: null,
     };
   }
-  return { managerState: 'unknown', running: null, pid: null };
+  return { managerState: 'unknown', loaded: null, enabledAtLogin: false, running: null, pid: null };
 }
 
 // --- public API -------------------------------------------------------------
@@ -331,13 +348,12 @@ export function metaProxyServiceState(
   label = SERVICE_LABEL,
 ): ServiceState {
   const unitPath = serviceUnitPath(platform, home, label);
-  if (!unitPath) return { supported: false, installed: false, unitPath: null, managerState: 'unknown', definitionPresent: false, enabledAtLogin: false, running: null, pid: null };
+  if (!unitPath) return { supported: false, installed: false, unitPath: null, managerState: 'unknown', definitionPresent: false, loaded: null, enabledAtLogin: false, running: null, pid: null };
   const definitionPresent = existsSync(unitPath);
   const command = serviceStateCommand(platform, label);
   const outcome = command ? run(command) : { ok: false, output: '', error: 'unsupported' };
-  const manager = parseManagerState(platform, outcome);
-  const enabledAtLogin = manager.managerState === 'enabled' || (platform === 'darwin' && definitionPresent);
-  return { supported: true, installed: manager.managerState === 'enabled', unitPath, definitionPresent, enabledAtLogin, ...manager };
+  const manager = parseManagerState(platform, outcome, definitionPresent);
+  return { supported: true, installed: manager.loaded === true, unitPath, definitionPresent, ...manager };
 }
 
 export interface ServiceOptions {
@@ -386,7 +402,7 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
       unitPath,
     };
   }
-  if (before.managerState === 'enabled') {
+  if (before.managerState === 'enabled' && before.enabledAtLogin) {
     if (before.definitionPresent) {
       return { ok: true, message: `Meta-Proxy is already set to start at login. Definition: ${unitPath}`, unitPath };
     }
@@ -404,6 +420,27 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
     const outcome = run(invocation);
     if (!outcome.ok) {
       const state = metaProxyServiceState(platform, home, run, label);
+      if (before.definitionPresent) {
+        // This enable started from an existing owned definition. Never erase it
+        // or stop a pre-existing active service while compensating a failed
+        // attempt to change only its login-start state.
+        if (before.loaded === false && state.managerState === 'enabled') {
+          const cleanup = disableCommands(platform, unitPath, label)[0];
+          const cleanupOutcome = cleanup ? run(cleanup) : { ok: false, output: 'cleanup command unavailable' };
+          if (!cleanupOutcome.ok) {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and compensating cleanup failed: ${cleanupOutcome.output || 'command failed'}. Definition preserved at ${unitPath}.`,
+              unitPath,
+            };
+          }
+        }
+        return {
+          ok: false,
+          message: `Could not enable start-at-login (${invocation.command} ${invocation.args.join(' ')}): ${outcome.output || 'command failed'}. Definition preserved at ${unitPath}.`,
+          unitPath,
+        };
+      }
       if (state.managerState === 'enabled') {
         const cleanupFailures = disableCommands(platform, unitPath, label)
           .map((cleanup) => run(cleanup))
@@ -516,30 +553,62 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
     return { ok: true, message: 'Meta-Proxy is not set to start at login.' };
   }
 
-  const failures: string[] = [];
-  if (state.managerState === 'enabled') {
-    const commands = disableCommands(platform, unitPath, label);
-    const unregister = commands[0];
-    if (unregister) {
-      const outcome = run(unregister);
-      if (!outcome.ok) failures.push(outcome.output || `${unregister.command} failed`);
+  if (platform === 'win32' && state.managerState === 'enabled') {
+    // Deleting a running task loses the only manager handle while its child
+    // can remain alive. End first and require an authoritative stopped state.
+    const end = stopCommand(platform, label);
+    if (!end) return { ok: false, message: 'Could not construct the Windows stop command.', unitPath };
+    run(end);
+    const stopped = metaProxyServiceState(platform, home, run, label);
+    if (stopped.managerState === 'unknown' || stopped.running !== false) {
+      return {
+        ok: false,
+        message: `Could not confirm the Meta-Proxy task stopped; preserved task and ${unitPath}.`,
+        unitPath,
+      };
+    }
+    const removeTask = disableCommands(platform, unitPath, label)[0];
+    const removed = removeTask ? run(removeTask) : { ok: false, output: 'delete command unavailable' };
+    if (!removed.ok) {
+      return {
+        ok: false,
+        message: `Could not delete the stopped Meta-Proxy task: ${removed.output || 'command failed'}. Definition preserved at ${unitPath}.`,
+        unitPath,
+      };
+    }
+    rmSync(unitPath, { force: true });
+    return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
+  }
+
+  const unregister = state.managerState === 'enabled'
+    ? disableCommands(platform, unitPath, label)[0]
+    : undefined;
+  if (unregister) {
+    const outcome = run(unregister);
+    if (!outcome.ok) {
+      return {
+        ok: false,
+        message: `Could not disable start-at-login: ${outcome.output || `${unregister.command} failed`}. Definition preserved at ${unitPath}.`,
+        unitPath,
+      };
     }
   }
-  if (failures.length > 0) {
-    return {
-      ok: false,
-      message: `Could not disable start-at-login: ${failures.join('; ')}. Definition preserved at ${unitPath}.`,
-      unitPath,
-    };
-  }
+
+  const definition = state.definitionPresent ? readFileSync(unitPath, 'utf8') : null;
   rmSync(unitPath, { force: true });
   if (platform === 'linux') {
     const refresh = disableCommands(platform, unitPath, label)[1];
-    if (refresh) {
-      const outcome = run(refresh);
-      if (!outcome.ok) {
-        return { ok: false, message: `Disabled service, but daemon-reload failed: ${outcome.output || 'command failed'}.` };
+    const outcome = refresh ? run(refresh) : { ok: false, output: 'daemon-reload command unavailable' };
+    if (!outcome.ok) {
+      if (definition !== null) {
+        mkdirSync(dirname(unitPath), { recursive: true, mode: 0o700 });
+        writeFileSync(unitPath, definition, { encoding: 'utf8', mode: 0o600 });
       }
+      return {
+        ok: false,
+        message: `Disabled service, but daemon-reload failed: ${outcome.output || 'command failed'}. Definition restored at ${unitPath}.`,
+        unitPath,
+      };
     }
   }
   return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -31,6 +31,12 @@ import { metaProxyBinaryPath, metaProxyDataDir } from './meta-proxy.js';
 /** Reverse-DNS label, shared by the launchd job and the scheduled task. */
 export const SERVICE_LABEL = 'one.cognitum.meta-proxy';
 
+function assertServiceLabel(label: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9.-]{0,127}$/.test(label)) {
+    throw new Error('Invalid service label.');
+  }
+}
+
 export interface ServiceCommand {
   command: string;
   args: string[];
@@ -39,6 +45,7 @@ export interface ServiceCommand {
 export interface CommandOutcome {
   ok: boolean;
   output: string;
+  error?: string;
 }
 
 export type CommandRunner = (invocation: ServiceCommand) => CommandOutcome;
@@ -55,6 +62,8 @@ export interface ServiceState {
   /** A definition exists on disk (macOS/Linux) or the task is registered (Windows). */
   installed: boolean;
   unitPath: string | null;
+  managerState: 'enabled' | 'disabled' | 'unknown';
+  definitionPresent: boolean;
 }
 
 function defaultRunner(invocation: ServiceCommand): CommandOutcome {
@@ -64,14 +73,15 @@ function defaultRunner(invocation: ServiceCommand): CommandOutcome {
     windowsHide: true,
   });
   const output = `${result.stdout ?? ''}${result.stderr ?? ''}`.trim();
-  if (result.error) return { ok: false, output: result.error.message };
+  if (result.error) return { ok: false, output: result.error.message, error: result.error.message };
   return { ok: result.status === 0, output };
 }
 
 // --- unit file locations ----------------------------------------------------
 
-export function launchAgentPath(home = homedir()): string {
-  return join(home, 'Library', 'LaunchAgents', `${SERVICE_LABEL}.plist`);
+export function launchAgentPath(home = homedir(), label = SERVICE_LABEL): string {
+  assertServiceLabel(label);
+  return join(home, 'Library', 'LaunchAgents', `${label}.plist`);
 }
 
 export function systemdUnitPath(home = homedir()): string {
@@ -83,8 +93,8 @@ export function scheduledTaskPath(home = homedir()): string {
   return join(metaProxyDataDir(home), 'meta-proxy-task.xml');
 }
 
-export function serviceUnitPath(platform: NodeJS.Platform, home = homedir()): string | null {
-  if (platform === 'darwin') return launchAgentPath(home);
+export function serviceUnitPath(platform: NodeJS.Platform, home = homedir(), label = SERVICE_LABEL): string | null {
+  if (platform === 'darwin') return launchAgentPath(home, label);
   if (platform === 'linux') return systemdUnitPath(home);
   if (platform === 'win32') return scheduledTaskPath(home);
   return null;
@@ -108,13 +118,13 @@ function escapeXml(value: string): string {
  * `proxy stop` (SIGTERM, exit 0) stay stopped — a plain `KeepAlive: true` would
  * fight the user's own stop command forever.
  */
-export function renderLaunchAgent(binaryPath: string, logPath: string): string {
+export function renderLaunchAgent(binaryPath: string, logPath: string, label = SERVICE_LABEL): string {
   return `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>Label</key>
-  <string>${SERVICE_LABEL}</string>
+  <string>${escapeXml(label)}</string>
   <key>ProgramArguments</key>
   <array>
     <string>${escapeXml(binaryPath)}</string>
@@ -196,13 +206,13 @@ export function renderScheduledTask(binaryPath: string): string {
 
 // --- the OS commands, as data so they can be asserted -----------------------
 
-export function enableCommands(platform: NodeJS.Platform, unitPath: string): ServiceCommand[] {
+export function enableCommands(platform: NodeJS.Platform, unitPath: string, label = SERVICE_LABEL): ServiceCommand[] {
   if (platform === 'darwin') {
     // `bootstrap` is the modern replacement for `load -w`; `kickstart` starts it
     // now so the user does not have to log out and back in to get a daemon.
     return [
       { command: 'launchctl', args: ['bootstrap', `gui/${process.getuid?.() ?? 0}`, unitPath] },
-      { command: 'launchctl', args: ['kickstart', `gui/${process.getuid?.() ?? 0}/${SERVICE_LABEL}`] },
+      { command: 'launchctl', args: ['kickstart', `gui/${process.getuid?.() ?? 0}/${label}`] },
     ];
   }
   if (platform === 'linux') {
@@ -220,9 +230,9 @@ export function enableCommands(platform: NodeJS.Platform, unitPath: string): Ser
   return [];
 }
 
-export function disableCommands(platform: NodeJS.Platform, unitPath: string): ServiceCommand[] {
+export function disableCommands(platform: NodeJS.Platform, unitPath: string, label = SERVICE_LABEL): ServiceCommand[] {
   if (platform === 'darwin') {
-    return [{ command: 'launchctl', args: ['bootout', `gui/${process.getuid?.() ?? 0}`, unitPath] }];
+    return [{ command: 'launchctl', args: ['bootout', `gui/${process.getuid?.() ?? 0}/${label}`] }];
   }
   if (platform === 'linux') {
     return [
@@ -236,29 +246,51 @@ export function disableCommands(platform: NodeJS.Platform, unitPath: string): Se
   return [];
 }
 
+export function serviceStateCommand(platform: NodeJS.Platform, label = SERVICE_LABEL): ServiceCommand | null {
+  if (platform === 'darwin') {
+    return { command: 'launchctl', args: ['print', `gui/${process.getuid?.() ?? 0}/${label}`] };
+  }
+  if (platform === 'linux') {
+    return { command: 'systemctl', args: ['--user', 'is-enabled', 'meta-proxy.service'] };
+  }
+  if (platform === 'win32') {
+    return { command: 'schtasks', args: ['/query', '/tn', SERVICE_LABEL] };
+  }
+  return null;
+}
+
 // --- public API -------------------------------------------------------------
 
 export function metaProxyServiceState(
   platform: NodeJS.Platform = process.platform,
   home = homedir(),
+  run: CommandRunner = defaultRunner,
+  label = SERVICE_LABEL,
 ): ServiceState {
-  const unitPath = serviceUnitPath(platform, home);
-  if (!unitPath) return { supported: false, installed: false, unitPath: null };
-  return { supported: true, installed: existsSync(unitPath), unitPath };
+  const unitPath = serviceUnitPath(platform, home, label);
+  if (!unitPath) return { supported: false, installed: false, unitPath: null, managerState: 'unknown', definitionPresent: false };
+  const definitionPresent = existsSync(unitPath);
+  const command = serviceStateCommand(platform, label);
+  const outcome = command ? run(command) : { ok: false, output: '', error: 'unsupported' };
+  const managerState = outcome.error ? 'unknown' : outcome.ok ? 'enabled' : 'disabled';
+  return { supported: true, installed: managerState === 'enabled', unitPath, managerState, definitionPresent };
 }
 
 export interface ServiceOptions {
   home?: string;
   platform?: NodeJS.Platform;
   run?: CommandRunner;
+  /** Test/enterprise isolation hook; normal users always use SERVICE_LABEL. */
+  label?: string;
 }
 
 export function enableMetaProxyService(options: ServiceOptions = {}): ServiceResult {
   const home = options.home ?? homedir();
   const platform = options.platform ?? process.platform;
   const run = options.run ?? defaultRunner;
+  const label = options.label ?? SERVICE_LABEL;
 
-  const unitPath = serviceUnitPath(platform, home);
+  const unitPath = serviceUnitPath(platform, home, label);
   if (!unitPath) {
     return { ok: false, message: `Start-at-login is not supported on ${platform}.` };
   }
@@ -274,7 +306,7 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   const logPath = join(metaProxyDataDir(home), 'meta-proxy.log');
   const definition =
     platform === 'darwin'
-      ? renderLaunchAgent(binaryPath, logPath)
+      ? renderLaunchAgent(binaryPath, logPath, label)
       : platform === 'linux'
         ? renderSystemdUnit(binaryPath)
         : renderScheduledTask(binaryPath);
@@ -282,11 +314,28 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   mkdirSync(dirname(unitPath), { recursive: true, mode: 0o700 });
   writeFileSync(unitPath, definition, { encoding: 'utf8', mode: 0o600 });
 
-  for (const invocation of enableCommands(platform, unitPath)) {
+  for (const invocation of enableCommands(platform, unitPath, label)) {
     const outcome = run(invocation);
     if (!outcome.ok) {
-      // Leave nothing half-installed: a unit file present but never loaded
-      // would make `proxy status` claim start-at-login is on when it is not.
+      const state = metaProxyServiceState(platform, home, run, label);
+      if (state.managerState === 'enabled') {
+        const cleanupFailures = disableCommands(platform, unitPath, label)
+          .map((cleanup) => run(cleanup))
+          .filter((cleanup) => !cleanup.ok);
+        if (cleanupFailures.length > 0) {
+          return {
+            ok: false,
+            message: `Could not enable start-at-login and compensating cleanup failed: ${cleanupFailures.map((failure) => failure.output || 'command failed').join('; ')}. Definition preserved at ${unitPath}.`,
+            unitPath,
+          };
+        }
+      } else if (state.managerState === 'unknown') {
+        return {
+          ok: false,
+          message: `Could not enable start-at-login and manager state is unknown. Definition preserved at ${unitPath}.`,
+          unitPath,
+        };
+      }
       rmSync(unitPath, { force: true });
       return {
         ok: false,
@@ -306,31 +355,45 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
   const home = options.home ?? homedir();
   const platform = options.platform ?? process.platform;
   const run = options.run ?? defaultRunner;
+  const label = options.label ?? SERVICE_LABEL;
 
-  const unitPath = serviceUnitPath(platform, home);
+  const unitPath = serviceUnitPath(platform, home, label);
   if (!unitPath) {
     return { ok: true, message: `Start-at-login is not supported on ${platform}; nothing to disable.` };
   }
-  if (!existsSync(unitPath)) {
+  const state = metaProxyServiceState(platform, home, run, label);
+  if (state.managerState === 'unknown') {
+    return { ok: false, message: `Could not determine service-manager state; preserved ${unitPath}.`, unitPath };
+  }
+  if (state.managerState === 'disabled' && !state.definitionPresent) {
     return { ok: true, message: 'Meta-Proxy is not set to start at login.' };
   }
 
-  // Best-effort: the unit file is removed even if the OS command complains,
-  // because a stale definition left behind is the state that lies to
-  // `proxy status`. The daemon binary is untouched — disabling supervision is
-  // not uninstalling the proxy.
   const failures: string[] = [];
-  for (const invocation of disableCommands(platform, unitPath)) {
-    const outcome = run(invocation);
-    if (!outcome.ok) failures.push(outcome.output || `${invocation.command} failed`);
+  if (state.managerState === 'enabled') {
+    const commands = disableCommands(platform, unitPath, label);
+    const unregister = commands[0];
+    if (unregister) {
+      const outcome = run(unregister);
+      if (!outcome.ok) failures.push(outcome.output || `${unregister.command} failed`);
+    }
   }
-  rmSync(unitPath, { force: true });
-
   if (failures.length > 0) {
     return {
-      ok: true,
-      message: `Removed ${unitPath}, but the service manager reported: ${failures.join('; ')}. The Meta-Proxy binary is untouched.`,
+      ok: false,
+      message: `Could not disable start-at-login: ${failures.join('; ')}. Definition preserved at ${unitPath}.`,
+      unitPath,
     };
+  }
+  rmSync(unitPath, { force: true });
+  if (platform === 'linux') {
+    const refresh = disableCommands(platform, unitPath, label)[1];
+    if (refresh) {
+      const outcome = run(refresh);
+      if (!outcome.ok) {
+        return { ok: false, message: `Disabled service, but daemon-reload failed: ${outcome.output || 'command failed'}.` };
+      }
+    }
   }
   return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
 }

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -421,10 +421,14 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   if (before.managerState === 'unknown') {
     return { ok: false, message: `Could not determine service-manager state; preserved ${unitPath}.`, unitPath };
   }
-  if (platform === 'win32' && before.loaded === true && !before.definitionPresent) {
+  if (before.loaded === true && !before.definitionPresent) {
+    // Something answers to our label but no owned definition exists — another
+    // installer's job, or a unit shadowing ours from a different path. On
+    // darwin/linux a failed enable from this state would be "compensated" by
+    // booting out that foreign service, so refuse up front on every platform.
     return {
       ok: false,
-      message: `A Meta-Proxy task is registered without the owned definition at ${unitPath}. Inspect and remove it manually before replacement.`,
+      message: `A Meta-Proxy ${platform === 'win32' ? 'task' : 'service'} is registered without the owned definition at ${unitPath}. Inspect and remove it manually before replacement.`,
       unitPath,
     };
   }
@@ -693,10 +697,13 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
   if (state.managerState === 'disabled' && !state.definitionPresent) {
     return { ok: true, message: 'Meta-Proxy is not set to start at login.' };
   }
-  if (platform === 'win32' && state.loaded === true && !state.definitionPresent) {
+  if (state.loaded === true && !state.definitionPresent) {
+    // Same ownership rule as enable: without the owned definition on disk we
+    // cannot prove the registered job is ours, and unregistering by label
+    // alone would stop another installer's service.
     return {
       ok: false,
-      message: `A Meta-Proxy task is registered without the owned definition at ${unitPath}; refusing to stop or delete it by label alone.`,
+      message: `A Meta-Proxy ${platform === 'win32' ? 'task' : 'service'} is registered without the owned definition at ${unitPath}; refusing to stop or delete it by label alone.`,
       unitPath,
     };
   }

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -96,14 +96,16 @@ export function systemdUnitPath(home = homedir()): string {
 }
 
 /** The XML definition handed to `schtasks /create /xml`. */
-export function scheduledTaskPath(home = homedir()): string {
-  return join(metaProxyDataDir(home), 'meta-proxy-task.xml');
+export function scheduledTaskPath(home = homedir(), label = SERVICE_LABEL): string {
+  assertServiceLabel(label);
+  const filename = label === SERVICE_LABEL ? 'meta-proxy-task.xml' : `${label}-task.xml`;
+  return join(metaProxyDataDir(home), filename);
 }
 
 export function serviceUnitPath(platform: NodeJS.Platform, home = homedir(), label = SERVICE_LABEL): string | null {
   if (platform === 'darwin') return launchAgentPath(home, label);
   if (platform === 'linux') return systemdUnitPath(home);
-  if (platform === 'win32') return scheduledTaskPath(home);
+  if (platform === 'win32') return scheduledTaskPath(home, label);
   return null;
 }
 
@@ -182,11 +184,19 @@ WantedBy=default.target
 
 /** Task Scheduler definition — Windows has no launchd/systemd equivalent. */
 export function renderScheduledTask(binaryPath: string): string {
-  return `<?xml version="1.0" encoding="UTF-16"?>
+  // This string is persisted with Node's utf8 encoding. Keep the declaration
+  // truthful or Task Scheduler may reject the definition on stricter hosts.
+  return `<?xml version="1.0" encoding="UTF-8"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>Cognitum Meta-Proxy sidecar</Description>
   </RegistrationInfo>
+  <Principals>
+    <Principal id="Author">
+      <LogonType>InteractiveToken</LogonType>
+      <RunLevel>LeastPrivilege</RunLevel>
+    </Principal>
+  </Principals>
   <Triggers>
     <LogonTrigger>
       <Enabled>true</Enabled>
@@ -232,8 +242,8 @@ export function enableCommands(platform: NodeJS.Platform, unitPath: string, labe
   }
   if (platform === 'win32') {
     return [
-      { command: 'schtasks', args: ['/create', '/tn', SERVICE_LABEL, '/xml', unitPath, '/f'] },
-      { command: 'schtasks', args: ['/run', '/tn', SERVICE_LABEL] },
+      { command: 'schtasks', args: ['/create', '/tn', label, '/xml', unitPath, '/f'] },
+      { command: 'schtasks', args: ['/run', '/tn', label] },
     ];
   }
   return [];
@@ -250,7 +260,7 @@ export function disableCommands(platform: NodeJS.Platform, unitPath: string, lab
     ];
   }
   if (platform === 'win32') {
-    return [{ command: 'schtasks', args: ['/delete', '/tn', SERVICE_LABEL, '/f'] }];
+    return [{ command: 'schtasks', args: ['/delete', '/tn', label, '/f'] }];
   }
   return [];
 }
@@ -266,7 +276,9 @@ export function serviceStateCommand(platform: NodeJS.Platform, label = SERVICE_L
     };
   }
   if (platform === 'win32') {
-    return { command: 'schtasks', args: ['/query', '/tn', SERVICE_LABEL] };
+    // LIST /v provides the stable `Status: Running|Ready` field consumed below;
+    // the default table format is column-aligned and locale/width dependent.
+    return { command: 'schtasks', args: ['/query', '/tn', label, '/fo', 'LIST', '/v'] };
   }
   return null;
 }
@@ -362,6 +374,12 @@ export interface ServiceOptions {
   run?: CommandRunner;
   /** Test/enterprise isolation hook; normal users always use SERVICE_LABEL. */
   label?: string;
+  /** Bounded synchronous polling seam; production waits without spawning. */
+  wait?: (milliseconds: number) => void;
+}
+
+function defaultWait(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
 }
 
 export function enableMetaProxyService(options: ServiceOptions = {}): ServiceResult {
@@ -424,6 +442,37 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
         // This enable started from an existing owned definition. Never erase it
         // or stop a pre-existing active service while compensating a failed
         // attempt to change only its login-start state.
+        if (platform === 'linux') {
+          const restore: ServiceCommand[] = [];
+          if (!before.enabledAtLogin && state.enabledAtLogin) {
+            // Deliberately omit --now: a service that was already active must
+            // remain active while only its prior login-enable bit is restored.
+            restore.push({ command: 'systemctl', args: ['--user', 'disable', 'meta-proxy.service'] });
+          }
+          if (before.running === false && state.running === true) {
+            restore.push({ command: 'systemctl', args: ['--user', 'stop', 'meta-proxy.service'] });
+          }
+          const restoreFailure = restore.map((command) => run(command)).find((result) => !result.ok);
+          if (restoreFailure) {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and restoring the prior service state failed: ${restoreFailure.output || 'command failed'}. Definition preserved at ${unitPath}.`,
+              unitPath,
+            };
+          }
+          const restored = metaProxyServiceState(platform, home, run, label);
+          if (
+            restored.managerState === 'unknown'
+            || restored.enabledAtLogin !== before.enabledAtLogin
+            || restored.running !== before.running
+          ) {
+            return {
+              ok: false,
+              message: `Could not prove the prior service state was restored. Definition preserved at ${unitPath}.`,
+              unitPath,
+            };
+          }
+        }
         if (before.loaded === false && state.managerState === 'enabled') {
           const cleanup = disableCommands(platform, unitPath, label)[0];
           const cleanupOutcome = cleanup ? run(cleanup) : { ok: false, output: 'cleanup command unavailable' };
@@ -477,7 +526,7 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
 function startCommand(platform: NodeJS.Platform, label = SERVICE_LABEL): ServiceCommand | null {
   if (platform === 'darwin') return { command: 'launchctl', args: ['kickstart', `gui/${process.getuid?.() ?? 0}/${label}`] };
   if (platform === 'linux') return { command: 'systemctl', args: ['--user', 'start', 'meta-proxy.service'] };
-  if (platform === 'win32') return { command: 'schtasks', args: ['/run', '/tn', SERVICE_LABEL] };
+  if (platform === 'win32') return { command: 'schtasks', args: ['/run', '/tn', label] };
   return null;
 }
 
@@ -488,7 +537,7 @@ function stopCommand(platform: NodeJS.Platform, label = SERVICE_LABEL): ServiceC
   // explicit stop stays stopped now and remains configured for next login.
   if (platform === 'darwin') return { command: 'launchctl', args: ['bootout', `gui/${process.getuid?.() ?? 0}/${label}`] };
   if (platform === 'linux') return { command: 'systemctl', args: ['--user', 'stop', 'meta-proxy.service'] };
-  if (platform === 'win32') return { command: 'schtasks', args: ['/end', '/tn', SERVICE_LABEL] };
+  if (platform === 'win32') return { command: 'schtasks', args: ['/end', '/tn', label] };
   return null;
 }
 
@@ -540,6 +589,7 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
   const platform = options.platform ?? process.platform;
   const run = options.run ?? defaultRunner;
   const label = options.label ?? SERVICE_LABEL;
+  const wait = options.wait ?? defaultWait;
 
   const unitPath = serviceUnitPath(platform, home, label);
   if (!unitPath) {
@@ -559,7 +609,11 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
     const end = stopCommand(platform, label);
     if (!end) return { ok: false, message: 'Could not construct the Windows stop command.', unitPath };
     run(end);
-    const stopped = metaProxyServiceState(platform, home, run, label);
+    let stopped = metaProxyServiceState(platform, home, run, label);
+    for (let attempt = 0; attempt < 20 && stopped.managerState !== 'unknown' && stopped.running !== false; attempt++) {
+      wait(100);
+      stopped = metaProxyServiceState(platform, home, run, label);
+    }
     if (stopped.managerState === 'unknown' || stopped.running !== false) {
       return {
         ok: false,

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -22,7 +22,7 @@
 // in meta-proxy.ts, which already takes an injected `run`.
 
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -64,6 +64,11 @@ export interface ServiceState {
   unitPath: string | null;
   managerState: 'enabled' | 'disabled' | 'unknown';
   definitionPresent: boolean;
+  /** Whether the service remains configured to start on the user's next login. */
+  enabledAtLogin: boolean;
+  /** null means the manager answered but does not expose a portable run state. */
+  running: boolean | null;
+  pid: number | null;
 }
 
 function defaultRunner(invocation: ServiceCommand): CommandOutcome {
@@ -128,6 +133,7 @@ export function renderLaunchAgent(binaryPath: string, logPath: string, label = S
   <key>ProgramArguments</key>
   <array>
     <string>${escapeXml(binaryPath)}</string>
+    <string>--supervised</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -163,7 +169,7 @@ After=network-online.target
 
 [Service]
 Type=simple
-ExecStart=${binaryPath}
+ExecStart=${binaryPath} --supervised
 Restart=on-failure
 RestartSec=10
 
@@ -198,6 +204,7 @@ export function renderScheduledTask(binaryPath: string): string {
   <Actions Context="Author">
     <Exec>
       <Command>${escapeXml(binaryPath)}</Command>
+      <Arguments>--supervised</Arguments>
     </Exec>
   </Actions>
 </Task>
@@ -251,12 +258,68 @@ export function serviceStateCommand(platform: NodeJS.Platform, label = SERVICE_L
     return { command: 'launchctl', args: ['print', `gui/${process.getuid?.() ?? 0}/${label}`] };
   }
   if (platform === 'linux') {
-    return { command: 'systemctl', args: ['--user', 'is-enabled', 'meta-proxy.service'] };
+    return {
+      command: 'systemctl',
+      args: ['--user', 'show', 'meta-proxy.service', '--property=LoadState,UnitFileState,ActiveState,MainPID'],
+    };
   }
   if (platform === 'win32') {
     return { command: 'schtasks', args: ['/query', '/tn', SERVICE_LABEL] };
   }
   return null;
+}
+
+function knownMissingService(platform: NodeJS.Platform, output: string): boolean {
+  const text = output.toLowerCase();
+  if (platform === 'darwin') {
+    return text.includes('could not find service') || text.includes('service not found');
+  }
+  if (platform === 'linux') {
+    return text.includes('loadstate=not-found') || text.includes('unit meta-proxy.service could not be found');
+  }
+  if (platform === 'win32') {
+    return text.includes('cannot find the file specified') || text.includes('task does not exist');
+  }
+  return false;
+}
+
+function parseManagerState(platform: NodeJS.Platform, outcome: CommandOutcome): Pick<ServiceState, 'managerState' | 'running' | 'pid'> {
+  if (outcome.error) return { managerState: 'unknown', running: null, pid: null };
+  if (!outcome.ok) {
+    return knownMissingService(platform, outcome.output)
+      ? { managerState: 'disabled', running: false, pid: null }
+      : { managerState: 'unknown', running: null, pid: null };
+  }
+
+  if (platform === 'darwin') {
+    const pid = outcome.output.match(/\bpid\s*=\s*(\d+)/)?.[1];
+    return {
+      managerState: 'enabled',
+      running: /\bstate\s*=\s*running\b/.test(outcome.output) || pid !== undefined,
+      pid: pid ? Number.parseInt(pid, 10) : null,
+    };
+  }
+  if (platform === 'linux') {
+    if (/^LoadState=not-found$/m.test(outcome.output)) {
+      return { managerState: 'disabled', running: false, pid: null };
+    }
+    const enabled = /^UnitFileState=(?:enabled|enabled-runtime|linked|linked-runtime)$/m.test(outcome.output);
+    const pidText = outcome.output.match(/^MainPID=(\d+)$/m)?.[1];
+    const pid = pidText && pidText !== '0' ? Number.parseInt(pidText, 10) : null;
+    return {
+      managerState: enabled ? 'enabled' : 'disabled',
+      running: /^ActiveState=active$/m.test(outcome.output),
+      pid,
+    };
+  }
+  if (platform === 'win32') {
+    return {
+      managerState: 'enabled',
+      running: /^Status:\s+Running\s*$/im.test(outcome.output),
+      pid: null,
+    };
+  }
+  return { managerState: 'unknown', running: null, pid: null };
 }
 
 // --- public API -------------------------------------------------------------
@@ -268,12 +331,13 @@ export function metaProxyServiceState(
   label = SERVICE_LABEL,
 ): ServiceState {
   const unitPath = serviceUnitPath(platform, home, label);
-  if (!unitPath) return { supported: false, installed: false, unitPath: null, managerState: 'unknown', definitionPresent: false };
+  if (!unitPath) return { supported: false, installed: false, unitPath: null, managerState: 'unknown', definitionPresent: false, enabledAtLogin: false, running: null, pid: null };
   const definitionPresent = existsSync(unitPath);
   const command = serviceStateCommand(platform, label);
   const outcome = command ? run(command) : { ok: false, output: '', error: 'unsupported' };
-  const managerState = outcome.error ? 'unknown' : outcome.ok ? 'enabled' : 'disabled';
-  return { supported: true, installed: managerState === 'enabled', unitPath, managerState, definitionPresent };
+  const manager = parseManagerState(platform, outcome);
+  const enabledAtLogin = manager.managerState === 'enabled' || (platform === 'darwin' && definitionPresent);
+  return { supported: true, installed: manager.managerState === 'enabled', unitPath, definitionPresent, enabledAtLogin, ...manager };
 }
 
 export interface ServiceOptions {
@@ -310,6 +374,28 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
       : platform === 'linux'
         ? renderSystemdUnit(binaryPath)
         : renderScheduledTask(binaryPath);
+
+  const before = metaProxyServiceState(platform, home, run, label);
+  if (before.managerState === 'unknown') {
+    return { ok: false, message: `Could not determine service-manager state; preserved ${unitPath}.`, unitPath };
+  }
+  if (before.definitionPresent && readFileSync(unitPath, 'utf8') !== definition) {
+    return {
+      ok: false,
+      message: `A different Meta-Proxy service definition already exists at ${unitPath}. Disable it before replacement.`,
+      unitPath,
+    };
+  }
+  if (before.managerState === 'enabled') {
+    if (before.definitionPresent) {
+      return { ok: true, message: `Meta-Proxy is already set to start at login. Definition: ${unitPath}`, unitPath };
+    }
+    return {
+      ok: false,
+      message: `A Meta-Proxy service is already registered with a different or missing definition. Disable it before replacing ${unitPath}.`,
+      unitPath,
+    };
+  }
 
   mkdirSync(dirname(unitPath), { recursive: true, mode: 0o700 });
   writeFileSync(unitPath, definition, { encoding: 'utf8', mode: 0o600 });
@@ -349,6 +435,67 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
     message: `Meta-Proxy will start at login. Definition: ${unitPath}\nDisable with: metaharness proxy disable`,
     unitPath,
   };
+}
+
+function startCommand(platform: NodeJS.Platform, label = SERVICE_LABEL): ServiceCommand | null {
+  if (platform === 'darwin') return { command: 'launchctl', args: ['kickstart', `gui/${process.getuid?.() ?? 0}/${label}`] };
+  if (platform === 'linux') return { command: 'systemctl', args: ['--user', 'start', 'meta-proxy.service'] };
+  if (platform === 'win32') return { command: 'schtasks', args: ['/run', '/tn', SERVICE_LABEL] };
+  return null;
+}
+
+function stopCommand(platform: NodeJS.Platform, label = SERVICE_LABEL): ServiceCommand | null {
+  // `launchctl kill SIGTERM` may still be classified by launchd as an
+  // unsuccessful termination and restarted under KeepAlive. Bootout unloads
+  // the current job but deliberately leaves the plist in LaunchAgents, so the
+  // explicit stop stays stopped now and remains configured for next login.
+  if (platform === 'darwin') return { command: 'launchctl', args: ['bootout', `gui/${process.getuid?.() ?? 0}/${label}`] };
+  if (platform === 'linux') return { command: 'systemctl', args: ['--user', 'stop', 'meta-proxy.service'] };
+  if (platform === 'win32') return { command: 'schtasks', args: ['/end', '/tn', SERVICE_LABEL] };
+  return null;
+}
+
+export function startMetaProxyService(options: ServiceOptions = {}): ServiceResult {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const run = options.run ?? defaultRunner;
+  const label = options.label ?? SERVICE_LABEL;
+  const state = metaProxyServiceState(platform, home, run, label);
+  if (state.managerState === 'unknown') return { ok: false, message: 'Could not determine service-manager state.' };
+  if (state.managerState !== 'enabled' && !(platform === 'darwin' && state.definitionPresent)) {
+    return { ok: false, message: 'Meta-Proxy is not enabled at login.' };
+  }
+  if (state.running) return { ok: true, message: `Meta-Proxy is already running${state.pid ? ` (pid ${state.pid})` : ''}.` };
+  const commands = platform === 'darwin' && state.managerState === 'disabled' && state.unitPath
+    ? enableCommands(platform, state.unitPath, label)
+    : [startCommand(platform, label)].filter((command): command is ServiceCommand => command !== null);
+  if (commands.length === 0) return { ok: false, message: `Managed start is not supported on ${platform}.` };
+  for (const command of commands) {
+    const outcome = run(command);
+    if (!outcome.ok) return { ok: false, message: `Could not start Meta-Proxy: ${outcome.output || 'command failed'}` };
+  }
+  return { ok: true, message: 'Meta-Proxy managed start requested.' };
+}
+
+export function stopMetaProxyService(options: ServiceOptions = {}): ServiceResult {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const run = options.run ?? defaultRunner;
+  const label = options.label ?? SERVICE_LABEL;
+  const state = metaProxyServiceState(platform, home, run, label);
+  if (state.managerState === 'unknown') return { ok: false, message: 'Could not determine service-manager state.' };
+  if (state.managerState !== 'enabled') {
+    return state.enabledAtLogin
+      ? { ok: true, message: 'Meta-Proxy managed service is already stopped.' }
+      : { ok: false, message: 'Meta-Proxy is not enabled at login.' };
+  }
+  if (state.running === false) return { ok: true, message: 'Meta-Proxy managed service is already stopped.' };
+  const command = stopCommand(platform, label);
+  if (!command) return { ok: false, message: `Managed stop is not supported on ${platform}.` };
+  const outcome = run(command);
+  return outcome.ok
+    ? { ok: true, message: 'Meta-Proxy managed stop requested.' }
+    : { ok: false, message: `Could not stop Meta-Proxy: ${outcome.output || 'command failed'}` };
 }
 
 export function disableMetaProxyService(options: ServiceOptions = {}): ServiceResult {

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -421,6 +421,13 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   if (before.managerState === 'unknown') {
     return { ok: false, message: `Could not determine service-manager state; preserved ${unitPath}.`, unitPath };
   }
+  if (platform === 'win32' && before.loaded === true && !before.definitionPresent) {
+    return {
+      ok: false,
+      message: `A Meta-Proxy task is registered without the owned definition at ${unitPath}. Disable it explicitly before replacement.`,
+      unitPath,
+    };
+  }
   const persistedEncoding = platform === 'win32' ? 'utf16le' : 'utf8';
   if (before.definitionPresent && readFileSync(unitPath, persistedEncoding) !== definition) {
     return {
@@ -498,6 +505,24 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
           };
         }
         if (platform === 'win32' && before.loaded === true && !before.enabledAtLogin) {
+          if (state.managerState === 'unknown') {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and manager state is unknown. Prior definition preserved at ${unitPath}.`,
+              unitPath,
+            };
+          }
+          if (state.loaded === false) {
+            const recreate = enableCommands('win32', unitPath, label)[0];
+            const recreated = recreate ? run(recreate) : { ok: false, output: 'create command unavailable' };
+            if (!recreated.ok) {
+              return {
+                ok: false,
+                message: `Could not enable start-at-login and recreating the prior disabled task failed: ${recreated.output || 'command failed'}. Definition preserved at ${unitPath}.`,
+                unitPath,
+              };
+            }
+          }
           const stopped = confirmWindowsTaskStopped(home, unitPath, label, run, wait);
           if (!stopped.ok) {
             return {

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -424,7 +424,7 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   if (platform === 'win32' && before.loaded === true && !before.definitionPresent) {
     return {
       ok: false,
-      message: `A Meta-Proxy task is registered without the owned definition at ${unitPath}. Disable it explicitly before replacement.`,
+      message: `A Meta-Proxy task is registered without the owned definition at ${unitPath}. Inspect and remove it manually before replacement.`,
       unitPath,
     };
   }
@@ -692,6 +692,13 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
   }
   if (state.managerState === 'disabled' && !state.definitionPresent) {
     return { ok: true, message: 'Meta-Proxy is not set to start at login.' };
+  }
+  if (platform === 'win32' && state.loaded === true && !state.definitionPresent) {
+    return {
+      ok: false,
+      message: `A Meta-Proxy task is registered without the owned definition at ${unitPath}; refusing to stop or delete it by label alone.`,
+      unitPath,
+    };
   }
 
   if (platform === 'win32' && state.managerState === 'enabled') {

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -184,9 +184,9 @@ WantedBy=default.target
 
 /** Task Scheduler definition — Windows has no launchd/systemd equivalent. */
 export function renderScheduledTask(binaryPath: string): string {
-  // This string is persisted with Node's utf8 encoding. Keep the declaration
-  // truthful or Task Scheduler may reject the definition on stricter hosts.
-  return `<?xml version="1.0" encoding="UTF-8"?>
+  // Task Scheduler's XML importer requires its canonical BOM-marked UTF-16
+  // representation; enableMetaProxyService persists this string as utf16le.
+  return `\uFEFF<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.2" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
   <RegistrationInfo>
     <Description>Cognitum Meta-Proxy sidecar</Description>
@@ -413,7 +413,8 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   if (before.managerState === 'unknown') {
     return { ok: false, message: `Could not determine service-manager state; preserved ${unitPath}.`, unitPath };
   }
-  if (before.definitionPresent && readFileSync(unitPath, 'utf8') !== definition) {
+  const persistedEncoding = platform === 'win32' ? 'utf16le' : 'utf8';
+  if (before.definitionPresent && readFileSync(unitPath, persistedEncoding) !== definition) {
     return {
       ok: false,
       message: `A different Meta-Proxy service definition already exists at ${unitPath}. Disable it before replacement.`,
@@ -432,7 +433,7 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   }
 
   mkdirSync(dirname(unitPath), { recursive: true, mode: 0o700 });
-  writeFileSync(unitPath, definition, { encoding: 'utf8', mode: 0o600 });
+  writeFileSync(unitPath, definition, { encoding: persistedEncoding, mode: 0o600 });
 
   for (const invocation of enableCommands(platform, unitPath, label)) {
     const outcome = run(invocation);

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -482,6 +482,45 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
             };
           }
         }
+        if (platform === 'win32' && before.loaded === false && state.loaded === true) {
+          const cleanup = stopAndDeleteWindowsTask(home, unitPath, label, run, wait, false);
+          if (!cleanup.ok) {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and restoring the prior absent task failed: ${cleanup.message}`,
+              unitPath,
+            };
+          }
+          return {
+            ok: false,
+            message: `Could not enable start-at-login (${invocation.command} ${invocation.args.join(' ')}): ${outcome.output || 'command failed'}. Prior definition preserved at ${unitPath}.`,
+            unitPath,
+          };
+        }
+        if (platform === 'win32' && before.loaded === true && !before.enabledAtLogin) {
+          const stopped = confirmWindowsTaskStopped(home, unitPath, label, run, wait);
+          if (!stopped.ok) {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and restoring the prior disabled task failed: ${stopped.message}`,
+              unitPath,
+            };
+          }
+          const disabled = run({ command: 'schtasks', args: ['/change', '/tn', label, '/disable'] });
+          const restored = disabled.ok ? metaProxyServiceState('win32', home, run, label) : null;
+          if (!disabled.ok || restored?.loaded !== true || restored.enabledAtLogin || restored.running !== false) {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and restoring the prior disabled task failed: ${disabled.output || 'state mismatch'}. Definition preserved at ${unitPath}.`,
+              unitPath,
+            };
+          }
+          return {
+            ok: false,
+            message: `Could not enable start-at-login (${invocation.command} ${invocation.args.join(' ')}): ${outcome.output || 'command failed'}. Prior disabled task and definition restored at ${unitPath}.`,
+            unitPath,
+          };
+        }
         if (before.loaded === false && state.managerState === 'enabled') {
           const cleanup = disableCommands(platform, unitPath, label)[0];
           const cleanupOutcome = cleanup ? run(cleanup) : { ok: false, output: 'cleanup command unavailable' };
@@ -636,6 +675,43 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
   if (unregister) {
     const outcome = run(unregister);
     if (!outcome.ok) {
+      if (platform === 'linux') {
+        const after = metaProxyServiceState(platform, home, run, label);
+        if (after.managerState === 'unknown') {
+          return {
+            ok: false,
+            message: `Could not disable start-at-login and could not determine whether it partially changed state: ${outcome.output || `${unregister.command} failed`}. Definition preserved at ${unitPath}.`,
+            unitPath,
+          };
+        }
+        const restore: ServiceCommand[] = [];
+        if (state.enabledAtLogin !== after.enabledAtLogin) {
+          restore.push({ command: 'systemctl', args: ['--user', state.enabledAtLogin ? 'enable' : 'disable', 'meta-proxy.service'] });
+        }
+        if (state.running !== after.running) {
+          restore.push({ command: 'systemctl', args: ['--user', state.running ? 'start' : 'stop', 'meta-proxy.service'] });
+        }
+        const restoreFailure = restore.map((command) => run(command)).find((result) => !result.ok);
+        const restored = restoreFailure ? null : metaProxyServiceState(platform, home, run, label);
+        if (
+          restoreFailure
+          || restored?.managerState === 'unknown'
+          || restored?.loaded !== state.loaded
+          || restored?.enabledAtLogin !== state.enabledAtLogin
+          || restored?.running !== state.running
+        ) {
+          return {
+            ok: false,
+            message: `Could not disable start-at-login and restoring its possible partial changes failed: ${restoreFailure?.output || 'state mismatch'}. Definition preserved at ${unitPath}.`,
+            unitPath,
+          };
+        }
+        return {
+          ok: false,
+          message: `Could not disable start-at-login (${outcome.output || `${unregister.command} failed`}); prior login enablement and running state were restored. Definition preserved at ${unitPath}.`,
+          unitPath,
+        };
+      }
       return {
         ok: false,
         message: `Could not disable start-at-login: ${outcome.output || `${unregister.command} failed`}. Definition preserved at ${unitPath}.`,
@@ -690,6 +766,25 @@ function stopAndDeleteWindowsTask(
   label: string,
   run: CommandRunner,
   wait: (milliseconds: number) => void,
+  removeDefinition = true,
+): ServiceResult {
+  const stopped = confirmWindowsTaskStopped(home, unitPath, label, run, wait);
+  if (!stopped.ok) return stopped;
+  const removeTask = disableCommands('win32', unitPath, label)[0];
+  const removed = removeTask ? run(removeTask) : { ok: false, output: 'delete command unavailable' };
+  if (!removed.ok) {
+    return { ok: false, message: `Could not delete the stopped Meta-Proxy task: ${removed.output || 'command failed'}. Definition preserved at ${unitPath}.`, unitPath };
+  }
+  if (removeDefinition) rmSync(unitPath, { force: true });
+  return { ok: true, message: removeDefinition ? `Meta-Proxy will no longer start at login. Removed ${unitPath}.` : 'Newly-created Meta-Proxy task removed; prior definition preserved.', unitPath };
+}
+
+function confirmWindowsTaskStopped(
+  home: string,
+  unitPath: string,
+  label: string,
+  run: CommandRunner,
+  wait: (milliseconds: number) => void,
 ): ServiceResult {
   const end = stopCommand('win32', label);
   if (!end) return { ok: false, message: 'Could not construct the Windows stop command.', unitPath };
@@ -704,11 +799,5 @@ function stopAndDeleteWindowsTask(
   if (stopped.managerState === 'unknown' || consecutiveStopped < 2) {
     return { ok: false, message: `Could not confirm the Meta-Proxy task stopped; preserved task and ${unitPath}.`, unitPath };
   }
-  const removeTask = disableCommands('win32', unitPath, label)[0];
-  const removed = removeTask ? run(removeTask) : { ok: false, output: 'delete command unavailable' };
-  if (!removed.ok) {
-    return { ok: false, message: `Could not delete the stopped Meta-Proxy task: ${removed.output || 'command failed'}. Definition preserved at ${unitPath}.`, unitPath };
-  }
-  rmSync(unitPath, { force: true });
-  return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
+  return { ok: true, message: 'Meta-Proxy task is stably stopped.', unitPath };
 }

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -276,9 +276,11 @@ export function serviceStateCommand(platform: NodeJS.Platform, label = SERVICE_L
     };
   }
   if (platform === 'win32') {
-    // LIST /v provides the stable `Status: Running|Ready` field consumed below;
-    // the default table format is column-aligned and locale/width dependent.
-    return { command: 'schtasks', args: ['/query', '/tn', label, '/fo', 'LIST', '/v'] };
+    // schtasks renders both headings and states in the user's UI language.
+    // Query the ScheduledTasks API and serialize numeric enum/bool values so
+    // state and login enablement are authoritative and locale-neutral.
+    const script = `$task = Get-ScheduledTask -ErrorAction Stop | Where-Object { $_.TaskName -ceq '${label}' -and $_.TaskPath -eq '\\' } | Select-Object -First 1; if ($null -eq $task) { Write-Output 'TaskState=Missing'; exit 0 }; Write-Output ('TaskState=' + [int]$task.State)`;
+    return { command: 'powershell.exe', args: ['-NoProfile', '-NonInteractive', '-Command', script] };
   }
   return null;
 }
@@ -292,7 +294,7 @@ function knownMissingService(platform: NodeJS.Platform, output: string): boolean
     return text.includes('loadstate=not-found') || text.includes('unit meta-proxy.service could not be found');
   }
   if (platform === 'win32') {
-    return text.includes('cannot find the file specified') || text.includes('task does not exist');
+    return /^taskstate=missing$/m.test(text);
   }
   return false;
 }
@@ -336,15 +338,20 @@ function parseManagerState(
     };
   }
   if (platform === 'win32') {
+    if (/^TaskState=Missing$/m.test(outcome.output)) {
+      return { managerState: 'disabled', loaded: false, enabledAtLogin: false, running: false, pid: null };
+    }
+    const state = outcome.output.match(/^TaskState=(\d+)$/m)?.[1];
+    if (state === undefined || !['0', '1', '2', '3', '4'].includes(state)) {
+      return { managerState: 'unknown', loaded: null, enabledAtLogin: false, running: null, pid: null };
+    }
     return {
       managerState: 'enabled',
       loaded: true,
-      enabledAtLogin: true,
-      running: /^Status:\s+Running\s*$/im.test(outcome.output)
-        ? true
-        : /^Status:\s+(?:Ready|Disabled)\s*$/im.test(outcome.output)
-          ? false
-          : null,
+      // TASK_STATE_DISABLED is the authoritative registered-but-disabled state;
+      // all other known registered states remain enabled for their triggers.
+      enabledAtLogin: state !== '1',
+      running: state === '4' ? true : state === '1' || state === '3' ? false : null,
       pid: null,
     };
   }
@@ -387,6 +394,7 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
   const platform = options.platform ?? process.platform;
   const run = options.run ?? defaultRunner;
   const label = options.label ?? SERVICE_LABEL;
+  const wait = options.wait ?? defaultWait;
 
   const unitPath = serviceUnitPath(platform, home, label);
   if (!unitPath) {
@@ -492,6 +500,20 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
         };
       }
       if (state.managerState === 'enabled') {
+        if (platform === 'win32') {
+          const cleanup = stopAndDeleteWindowsTask(home, unitPath, label, run, wait);
+          if (!cleanup.ok) {
+            return {
+              ok: false,
+              message: `Could not enable start-at-login and compensating cleanup failed: ${cleanup.message}`,
+              unitPath,
+            };
+          }
+          return {
+            ok: false,
+            message: `Could not enable start-at-login (${invocation.command} ${invocation.args.join(' ')}): ${outcome.output || 'command failed'}`,
+          };
+        }
         const cleanupFailures = disableCommands(platform, unitPath, label)
           .map((cleanup) => run(cleanup))
           .filter((cleanup) => !cleanup.ok);
@@ -605,36 +627,7 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
   }
 
   if (platform === 'win32' && state.managerState === 'enabled') {
-    // Deleting a running task loses the only manager handle while its child
-    // can remain alive. End first and require an authoritative stopped state.
-    const end = stopCommand(platform, label);
-    if (!end) return { ok: false, message: 'Could not construct the Windows stop command.', unitPath };
-    run(end);
-    let stopped = metaProxyServiceState(platform, home, run, label);
-    let consecutiveStopped = stopped.running === false ? 1 : 0;
-    for (let attempt = 0; attempt < 20 && stopped.managerState !== 'unknown' && consecutiveStopped < 2; attempt++) {
-      wait(100);
-      stopped = metaProxyServiceState(platform, home, run, label);
-      consecutiveStopped = stopped.running === false ? consecutiveStopped + 1 : 0;
-    }
-    if (stopped.managerState === 'unknown' || consecutiveStopped < 2) {
-      return {
-        ok: false,
-        message: `Could not confirm the Meta-Proxy task stopped; preserved task and ${unitPath}.`,
-        unitPath,
-      };
-    }
-    const removeTask = disableCommands(platform, unitPath, label)[0];
-    const removed = removeTask ? run(removeTask) : { ok: false, output: 'delete command unavailable' };
-    if (!removed.ok) {
-      return {
-        ok: false,
-        message: `Could not delete the stopped Meta-Proxy task: ${removed.output || 'command failed'}. Definition preserved at ${unitPath}.`,
-        unitPath,
-      };
-    }
-    rmSync(unitPath, { force: true });
-    return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
+    return stopAndDeleteWindowsTask(home, unitPath, label, run, wait);
   }
 
   const unregister = state.managerState === 'enabled'
@@ -661,12 +654,61 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
         mkdirSync(dirname(unitPath), { recursive: true, mode: 0o700 });
         writeFileSync(unitPath, definition, { encoding: 'utf8', mode: 0o600 });
       }
+      const restoreReload = refresh ? run(refresh) : { ok: false, output: 'daemon-reload command unavailable' };
+      const restoreCommands: ServiceCommand[] = [];
+      if (state.enabledAtLogin) restoreCommands.push({ command: 'systemctl', args: ['--user', 'enable', 'meta-proxy.service'] });
+      if (state.running) restoreCommands.push({ command: 'systemctl', args: ['--user', 'start', 'meta-proxy.service'] });
+      const restoreFailure = !restoreReload.ok
+        ? restoreReload
+        : restoreCommands.map((command) => run(command)).find((result) => !result.ok);
+      const restored = restoreFailure ? null : metaProxyServiceState(platform, home, run, label);
+      if (
+        restoreFailure
+        || restored?.managerState === 'unknown'
+        || restored?.enabledAtLogin !== state.enabledAtLogin
+        || restored?.running !== state.running
+      ) {
+        return {
+          ok: false,
+          message: `Disabled service and daemon-reload failed; restoring the prior manager state also failed: ${restoreFailure?.output || 'state mismatch'}. Definition preserved at ${unitPath}.`,
+          unitPath,
+        };
+      }
       return {
         ok: false,
-        message: `Disabled service, but daemon-reload failed: ${outcome.output || 'command failed'}. Definition restored at ${unitPath}.`,
+        message: `Disable rolled back after daemon-reload failed: ${outcome.output || 'command failed'}. Prior definition, login enablement, and running state restored at ${unitPath}.`,
         unitPath,
       };
     }
   }
+  return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
+}
+
+function stopAndDeleteWindowsTask(
+  home: string,
+  unitPath: string,
+  label: string,
+  run: CommandRunner,
+  wait: (milliseconds: number) => void,
+): ServiceResult {
+  const end = stopCommand('win32', label);
+  if (!end) return { ok: false, message: 'Could not construct the Windows stop command.', unitPath };
+  run(end);
+  let stopped = metaProxyServiceState('win32', home, run, label);
+  let consecutiveStopped = stopped.running === false ? 1 : 0;
+  for (let attempt = 0; attempt < 20 && stopped.managerState !== 'unknown' && consecutiveStopped < 2; attempt++) {
+    wait(100);
+    stopped = metaProxyServiceState('win32', home, run, label);
+    consecutiveStopped = stopped.running === false ? consecutiveStopped + 1 : 0;
+  }
+  if (stopped.managerState === 'unknown' || consecutiveStopped < 2) {
+    return { ok: false, message: `Could not confirm the Meta-Proxy task stopped; preserved task and ${unitPath}.`, unitPath };
+  }
+  const removeTask = disableCommands('win32', unitPath, label)[0];
+  const removed = removeTask ? run(removeTask) : { ok: false, output: 'delete command unavailable' };
+  if (!removed.ok) {
+    return { ok: false, message: `Could not delete the stopped Meta-Proxy task: ${removed.output || 'command failed'}. Definition preserved at ${unitPath}.`, unitPath };
+  }
+  rmSync(unitPath, { force: true });
   return { ok: true, message: `Meta-Proxy will no longer start at login. Removed ${unitPath}.` };
 }

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -611,11 +611,13 @@ export function disableMetaProxyService(options: ServiceOptions = {}): ServiceRe
     if (!end) return { ok: false, message: 'Could not construct the Windows stop command.', unitPath };
     run(end);
     let stopped = metaProxyServiceState(platform, home, run, label);
-    for (let attempt = 0; attempt < 20 && stopped.managerState !== 'unknown' && stopped.running !== false; attempt++) {
+    let consecutiveStopped = stopped.running === false ? 1 : 0;
+    for (let attempt = 0; attempt < 20 && stopped.managerState !== 'unknown' && consecutiveStopped < 2; attempt++) {
       wait(100);
       stopped = metaProxyServiceState(platform, home, run, label);
+      consecutiveStopped = stopped.running === false ? consecutiveStopped + 1 : 0;
     }
-    if (stopped.managerState === 'unknown' || stopped.running !== false) {
+    if (stopped.managerState === 'unknown' || consecutiveStopped < 2) {
       return {
         ok: false,
         message: `Could not confirm the Meta-Proxy task stopped; preserved task and ${unitPath}.`,

--- a/packages/create-agent-harness/src/meta-proxy-service.ts
+++ b/packages/create-agent-harness/src/meta-proxy-service.ts
@@ -515,10 +515,14 @@ export function enableMetaProxyService(options: ServiceOptions = {}): ServiceRes
           if (state.loaded === false) {
             const recreate = enableCommands('win32', unitPath, label)[0];
             const recreated = recreate ? run(recreate) : { ok: false, output: 'create command unavailable' };
-            if (!recreated.ok) {
+            // `/create /f` can apply and still lose its response. Its exit
+            // status is not authoritative; re-read before deciding whether
+            // the prior task is still absent or available for restoration.
+            const afterRecreate = metaProxyServiceState('win32', home, run, label);
+            if (afterRecreate.managerState === 'unknown' || afterRecreate.loaded !== true) {
               return {
                 ok: false,
-                message: `Could not enable start-at-login and recreating the prior disabled task failed: ${recreated.output || 'command failed'}. Definition preserved at ${unitPath}.`,
+                message: `Could not enable start-at-login and could not prove the prior disabled task was recreated: ${recreated.output || 'state mismatch'}. Definition preserved at ${unitPath}.`,
                 unitPath,
               };
             }

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -487,7 +487,14 @@ function parseRunArgs(args: string[]): { policy: WorktreePolicy; commandArgs: st
 export async function runThroughMetaProxy(args: string[], home = homedir()): Promise<ProxyCommandResult> {
   const parsed = parseRunArgs(args);
   if (typeof parsed === 'string') return { code: 2, lines: [parsed] };
-  const started = startMetaProxy(home);
+  const service = await import('./meta-proxy-service.js');
+  const serviceState = service.metaProxyServiceState(process.platform, home);
+  if (serviceState.managerState === 'unknown') {
+    return { code: 1, lines: ['Could not determine Meta-Proxy service-manager state; refusing to start a competing process.'] };
+  }
+  const started = serviceState.enabledAtLogin
+    ? service.startMetaProxyService({ home })
+    : startMetaProxy(home);
   if (!started.ok) return { code: 1, lines: [started.message] };
 
   let clientEnv: Record<string, string>;
@@ -556,11 +563,20 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     // conflating them is why "it worked yesterday" reports were unanswerable.
     const { metaProxyServiceState } = await import('./meta-proxy-service.js');
     const service = metaProxyServiceState();
+    const running = service.managerState === 'enabled'
+      ? service.running === null
+        ? 'unknown (service manager did not expose process state)'
+        : service.running
+          ? `running under service manager${service.pid ? ` (pid ${service.pid})` : ''}`
+          : 'stopped under service manager'
+      : status.running
+        ? `running (pid ${status.pid})`
+        : 'not running';
     const startAtLogin = !service.supported
       ? 'not supported on this platform'
       : service.managerState === 'unknown'
         ? `unknown — manager query failed (definition ${service.definitionPresent ? 'present' : 'absent'})`
-      : service.installed
+      : service.enabledAtLogin
         ? `enabled (${service.unitPath})`
         : 'disabled — enable with `metaharness proxy enable`';
     return {
@@ -570,7 +586,7 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
         `  installed: ${status.installed ? 'yes' : 'no'}`,
         `  binary: ${status.binaryPath}`,
         `  version: ${status.version ?? 'unknown'}`,
-        `  managed process: ${status.running ? `running (pid ${status.pid})` : 'not running'}`,
+        `  managed process: ${running}`,
         `  start at login: ${startAtLogin}`,
       ],
     };
@@ -580,11 +596,25 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     return { code: status.installed ? 0 : 1, lines: status.installed ? [status.binaryPath] : ['Meta-Proxy is not installed. Run `metaharness proxy install --yes`.'] };
   }
   if (subcommand === 'start') {
-    const result = startMetaProxy();
+    const service = await import('./meta-proxy-service.js');
+    const state = service.metaProxyServiceState();
+    if (state.managerState === 'unknown') {
+      return { code: 1, lines: ['Could not determine Meta-Proxy service-manager state; refusing to start a competing process.'] };
+    }
+    const result = state.enabledAtLogin
+      ? service.startMetaProxyService()
+      : startMetaProxy();
     return { code: result.ok ? 0 : 1, lines: [result.message] };
   }
   if (subcommand === 'stop') {
-    const result = stopMetaProxy();
+    const service = await import('./meta-proxy-service.js');
+    const state = service.metaProxyServiceState();
+    if (state.managerState === 'unknown') {
+      return { code: 1, lines: ['Could not determine Meta-Proxy service-manager state; refusing to signal an unverified process.'] };
+    }
+    const result = state.enabledAtLogin
+      ? service.stopMetaProxyService()
+      : stopMetaProxy();
     return { code: result.ok ? 0 : 1, lines: [result.message] };
   }
   if (subcommand === 'enable') {

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -16,6 +16,7 @@ import {
   mkdirSync,
   mkdtempSync,
   openSync,
+  readSync,
   readFileSync,
   readdirSync,
   renameSync,
@@ -26,7 +27,7 @@ import {
 import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 
-export const META_PROXY_VERSION = '0.7.2';
+export const META_PROXY_VERSION = '0.7.4';
 export const META_PROXY_RELEASE_BASE = 'https://github.com/cognitum-one/meta-proxy-dist/releases/download';
 
 /** The release signing key, pinned in the client rather than fetched from GitHub. */
@@ -184,6 +185,58 @@ function pidPath(home = homedir()): string {
 
 function versionPath(bin: string): string {
   return `${bin}.version`;
+}
+
+export function metaProxyLogLines(home = homedir(), count = 100): string[] {
+  const safeCount = Number.isSafeInteger(count) && count > 0 ? Math.min(count, 10_000) : 100;
+  const path = join(metaProxyDataDir(home), 'meta-proxy.log');
+  let descriptor: number | null = null;
+  try {
+    const size = statSync(path).size;
+    const byteCount = Math.min(size, 1024 * 1024);
+    const bytes = Buffer.alloc(byteCount);
+    descriptor = openSync(path, 'r');
+    readSync(descriptor, bytes, 0, byteCount, size - byteCount);
+    return bytes.toString('utf8')
+      .split(/\r?\n/)
+      .filter(Boolean)
+      .slice(-safeCount);
+  } catch {
+    return [];
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+export interface UninstallMetaProxyOptions {
+  home?: string;
+  platform?: NodeJS.Platform;
+  run?: import('./meta-proxy-service.js').CommandRunner;
+}
+
+export async function uninstallMetaProxy(options: UninstallMetaProxyOptions = {}): Promise<MetaProxyInstallResult> {
+  const home = options.home ?? homedir();
+  const platform = options.platform ?? process.platform;
+  const service = await import('./meta-proxy-service.js');
+  const disabled = service.disableMetaProxyService({ home, platform, run: options.run });
+  if (!disabled.ok) {
+    return { ok: false, message: `Refusing to uninstall while service cleanup is incomplete: ${disabled.message}` };
+  }
+
+  const stopped = stopMetaProxy(home, platform);
+  if (!stopped.ok) return stopped;
+
+  const binary = metaProxyBinaryPath(platform, home);
+  for (const ownedPath of [
+    binary,
+    versionPath(binary),
+    pidPath(home),
+    join(metaProxyDataDir(home), 'meta-proxy.log'),
+    service.scheduledTaskPath(home),
+  ]) {
+    rmSync(ownedPath, { force: true });
+  }
+  return { ok: true, message: 'Uninstalled Meta-Proxy owned files. Routing credentials and configuration were preserved.' };
 }
 
 export interface FetchResponse {
@@ -372,12 +425,15 @@ export function startMetaProxy(home = homedir(), platform: NodeJS.Platform = pro
   }
 }
 
-export function stopMetaProxy(home = homedir()): MetaProxyInstallResult {
+export function stopMetaProxy(
+  home = homedir(),
+  platform: NodeJS.Platform = process.platform,
+): MetaProxyInstallResult {
   let pid: number;
   try { pid = Number.parseInt(readFileSync(pidPath(home), 'utf8').trim(), 10); } catch {
     return { ok: true, message: 'Meta-Proxy is not running (no managed pid file).' };
   }
-  const status = metaProxyStatus(home);
+  const status = metaProxyStatus(home, platform);
   if (!Number.isSafeInteger(pid) || pid <= 0 || !status.running || status.pid !== pid) {
     rmSync(pidPath(home), { force: true });
     return { ok: true, message: 'Meta-Proxy is not running under this managed binary (stale pid file removed).' };
@@ -469,13 +525,15 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     return {
       code: 0,
       lines: [
-        'Usage: metaharness proxy <install|status|start|stop|enable|disable|path|login|logout|run> [options]',
+        'Usage: metaharness proxy <install|status|start|stop|enable|disable|logs|uninstall|path|login|logout|run> [options]',
         '',
         'Optional signed Meta-Proxy sidecar for local Claude-compatible routing.',
         `  install [--version ${META_PROXY_VERSION}] --yes  download, verify, and install`,
         '  status                                      show installed version and managed process state',
         '  start | stop | path                         manage the optional local sidecar',
         '  enable | disable                            start the sidecar at login (opt-in), or stop doing so',
+        '  logs [--lines N]                            show the bounded daemon log tail',
+        '  uninstall --yes                             disable service and remove only owned files',
         '  login | logout                              run Meta-Proxy Cognitum OAuth login/logout',
         '  run [--policy <critical|standard|economy>] [--] <client> [args...]',
         '                                               launch Claude-compatible client through Meta-Proxy',
@@ -500,6 +558,8 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     const service = metaProxyServiceState();
     const startAtLogin = !service.supported
       ? 'not supported on this platform'
+      : service.managerState === 'unknown'
+        ? `unknown — manager query failed (definition ${service.definitionPresent ? 'present' : 'absent'})`
       : service.installed
         ? `enabled (${service.unitPath})`
         : 'disabled — enable with `metaharness proxy enable`';
@@ -537,6 +597,22 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     const result = disableMetaProxyService();
     return { code: result.ok ? 0 : 1, lines: result.message.split('\n') };
   }
+  if (subcommand === 'logs') {
+    const lineIndex = args.indexOf('--lines');
+    const parsed = lineIndex >= 0 ? Number.parseInt(args[lineIndex + 1] ?? '', 10) : 100;
+    if (!Number.isSafeInteger(parsed) || parsed <= 0 || parsed > 10_000) {
+      return { code: 2, lines: ['--lines must be an integer between 1 and 10000.'] };
+    }
+    const lines = metaProxyLogLines(homedir(), parsed);
+    return { code: 0, lines: lines.length > 0 ? lines : ['Meta-Proxy log is empty or unavailable.'] };
+  }
+  if (subcommand === 'uninstall') {
+    if (!args.includes('--yes')) {
+      return { code: 2, lines: ['Refusing to uninstall without explicit consent. Re-run: metaharness proxy uninstall --yes'] };
+    }
+    const result = await uninstallMetaProxy();
+    return { code: result.ok ? 0 : 1, lines: [result.message] };
+  }
   if (subcommand === 'run') {
     return runThroughMetaProxy(args.slice(1));
   }
@@ -547,5 +623,5 @@ export async function metaProxyCmd(args: string[]): Promise<ProxyCommandResult> 
     if (result.error) return { code: 1, lines: [`Could not run Meta-Proxy ${subcommand}: ${result.error.message}`] };
     return { code: result.status ?? 1, lines: [] };
   }
-  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | enable | disable | path | login | logout | run`] };
+  return { code: 2, lines: [`Unknown proxy subcommand "${subcommand}". Try: install | status | start | stop | enable | disable | logs | uninstall | path | login | logout | run`] };
 }

--- a/packages/create-agent-harness/src/meta-proxy.ts
+++ b/packages/create-agent-harness/src/meta-proxy.ts
@@ -212,6 +212,8 @@ export interface UninstallMetaProxyOptions {
   home?: string;
   platform?: NodeJS.Platform;
   run?: import('./meta-proxy-service.js').CommandRunner;
+  /** Test seam for the locked-file retry delay. */
+  wait?: (milliseconds: number) => Promise<void>;
 }
 
 export async function uninstallMetaProxy(options: UninstallMetaProxyOptions = {}): Promise<MetaProxyInstallResult> {
@@ -226,7 +228,9 @@ export async function uninstallMetaProxy(options: UninstallMetaProxyOptions = {}
   const stopped = stopMetaProxy(home, platform);
   if (!stopped.ok) return stopped;
 
+  const wait = options.wait ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
   const binary = metaProxyBinaryPath(platform, home);
+  const stillPresent: string[] = [];
   for (const ownedPath of [
     binary,
     versionPath(binary),
@@ -234,7 +238,30 @@ export async function uninstallMetaProxy(options: UninstallMetaProxyOptions = {}
     join(metaProxyDataDir(home), 'meta-proxy.log'),
     service.scheduledTaskPath(home),
   ]) {
-    rmSync(ownedPath, { force: true });
+    // On Windows the just-stopped executable can stay locked for seconds after
+    // the task reports stopped; `force` only suppresses ENOENT and rmSync has
+    // no retry for a plain file. Retry the locked-file codes briefly, and keep
+    // removing the remaining owned files instead of leaking a raw exception.
+    let lastError: unknown = null;
+    for (let attempt = 0; attempt < 20; attempt++) {
+      try {
+        rmSync(ownedPath, { force: true });
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== 'EBUSY' && code !== 'EPERM') break;
+        await wait(250);
+      }
+    }
+    if (lastError !== null) stillPresent.push(ownedPath);
+  }
+  if (stillPresent.length > 0) {
+    return {
+      ok: false,
+      message: `Uninstalled the Meta-Proxy service, but these owned files are still in use and were not removed: ${stillPresent.join(', ')}. Close whatever is using them and re-run: metaharness proxy uninstall --yes`,
+    };
   }
   return { ok: true, message: 'Uninstalled Meta-Proxy owned files. Routing credentials and configuration were preserved.' };
 }

--- a/packages/create-agent-harness/src/secrets.ts
+++ b/packages/create-agent-harness/src/secrets.ts
@@ -46,23 +46,55 @@ export const defaultRunner: GcloudRunner = {
   },
 };
 
-function isGcloudOnPath(): Promise<boolean> {
+export interface PathLookupProcess {
+  once(event: string, listener: (value: unknown) => void): PathLookupProcess;
+  kill(): boolean;
+}
+
+export type PathSpawner = (
+  command: string,
+  args: string[],
+  options: { stdio: 'ignore'; windowsHide: boolean },
+) => PathLookupProcess;
+
+/** PATH discovery is diagnostic, so it must never hang the command or CI. */
+export function commandOnPath(
+  executable: string,
+  platform: NodeJS.Platform = process.platform,
+  spawnCommand: PathSpawner = (command, args, options) => spawn(command, args, options) as PathLookupProcess,
+  timeoutMs = 2_000,
+): Promise<boolean> {
   return new Promise(resolve => {
-    const cmd = process.platform === 'win32' ? 'where' : 'which';
-    const p = spawn(cmd, ['gcloud'], { stdio: 'ignore', windowsHide: true });
-    p.on('error', () => resolve(false));
-    p.on('exit', code => resolve(code === 0));
+    const cmd = platform === 'win32' ? 'where' : 'which';
+    const child = spawnCommand(cmd, [executable], { stdio: 'ignore', windowsHide: true });
+    let settled = false;
+    const finish = (found: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(found);
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(false);
+    }, timeoutMs);
+    child.once('error', () => finish(false));
+    child.once('exit', code => finish(code === 0));
   });
 }
 
 /** Validate full GCP setup for publish-time secret fetch. */
-export async function check(args: string[], runner: GcloudRunner = defaultRunner): Promise<SubcommandResult> {
+export async function check(
+  args: string[],
+  runner: GcloudRunner = defaultRunner,
+  pathProbe: () => Promise<boolean> = () => commandOnPath('gcloud'),
+): Promise<SubcommandResult> {
   const lines: string[] = ['harness secrets check'];
   let problems = 0;
   const projectFromFlag = args.find(a => a.startsWith('--project='))?.slice('--project='.length);
   const secretName = args.find(a => a.startsWith('--secret='))?.slice('--secret='.length) ?? 'NPM_TOKEN';
 
-  if (!(await isGcloudOnPath())) {
+  if (!(await pathProbe())) {
     lines.push('  FAIL gcloud CLI not on PATH');
     lines.push('       install: https://cloud.google.com/sdk/docs/install');
     return { code: 1, lines };


### PR DESCRIPTION
## Summary
- make service-manager state authoritative over definition-file presence
- compensate partial enablement and preserve evidence on failed disable/uninstall
- add bounded log tail and explicit-consent clean uninstall that removes only owned files
- pin the compatible Meta-Proxy daemon at 0.7.4 and bump the CLI to 0.4.5
- add a collision-free real macOS LaunchAgent acceptance test

## Adversarial evidence
- focused lifecycle, CLI, workflow, and Windows PATH-timeout tests: 46 passed; real LaunchAgent acceptance passed separately
- real isolated label proved RunAtLoad, SIGKILL restart with a new PID, managed stop staying stopped beyond the throttle interval, explicit restart, disable, and cleanup
- clean `npm ci`, full ordered build, and reproducible lockfile passed
- full workspace test passed
- package lint passed
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities
- `git diff --check`

The real test uses a unique `one.cognitum.meta-proxy.qe.*` label and temporary home. A `finally` bootout plus recursive removal guarantees cleanup; it never addresses the normal user label.

## Release dependency / rollback
Blocked on cognitum-one/meta-proxy#89 and publication of its signed v0.7.4 artifacts. Do not merge or publish this package while that asset is absent.

This clean successor supersedes #165 without rewriting its user-owned branch. Rollback is MetaHarness 0.4.4 pinned to the previous signed v0.7.3 daemon; no user credential or routing-state migration is performed.

Relates to cognitum-one/meta-proxy#82. Keep the issue open until the signed daemon and paired package pass native acceptance.

### Gate 3 remediation
- separates manager load, active/PID, and login-enable state; active disabled systemd units remain stoppable
- Linux reload failure restores the exact unit; Windows ends and confirms stopped before delete and preserves evidence on uncertainty
- required aggregate macOS CI job runs the real isolated LaunchAgent lifecycle
