### PR TITLE
chore(release): darwin 0.9.0 + router 0.4.0 — published post-#176

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5049,9 +5049,21 @@
         }
       }
     },
+    "packages/create-agent-harness/node_modules/@metaharness/darwin": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.8.3.tgz",
+      "integrity": "sha512-v5Ph7y9U6nqfvWajOjJiSuQDjPwvCKwOui793cSGUxIYUcfMoVoMzDfEDxOczFU61z0UUd7lD0I1b2zl+eYnag==",
+      "license": "MIT",
+      "bin": {
+        "metaharness-darwin": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "packages/darwin-mode": {
       "name": "@metaharness/darwin",
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "bin": {
         "metaharness-darwin": "dist/cli.js"
@@ -5431,7 +5443,7 @@
     },
     "packages/router": {
       "name": "@metaharness/router",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "@ruvector/tiny-dancer": "^0.1.21",

--- a/packages/darwin-mode/package.json
+++ b/packages/darwin-mode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@metaharness/darwin",
-  "version": "0.8.3",
-  "description": "Freeze the model, evolve the harness. Two measured applications: (1) SWE-bench code-repair \u2014 conformant GLM->Opus empty-patch cascade resolves 51.3% Lite (n=300) and 55.6% Verified (278/500, Wilson 95% CI [51.2, 59.9], official swebench gold eval, no gold tests in-loop, ~$0.15/instance est.); the same cheap->frontier cascade generalizes across both splits at ~56x cheaper than frontier-only; (2) Darwin Shield (v0.3.0) \u2014 a defensive zero-day discovery harness (Semgrep + fuzz oracles, safety-gated, deterministic replay). The harness, not the model, is the lever. Dependency-free (Node built-ins).",
+  "version": "0.9.0",
+  "description": "Freeze the model, evolve the harness. Two measured applications: (1) SWE-bench code-repair — conformant GLM->Opus empty-patch cascade resolves 51.3% Lite (n=300) and 55.6% Verified (278/500, Wilson 95% CI [51.2, 59.9], official swebench gold eval, no gold tests in-loop, ~$0.15/instance est.); the same cheap->frontier cascade generalizes across both splits at ~56x cheaper than frontier-only; (2) Darwin Shield (v0.3.0) — a defensive zero-day discovery harness (Semgrep + fuzz oracles, safety-gated, deterministic replay). The harness, not the model, is the lever. Dependency-free (Node built-ins).",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/router",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Cost-optimal model router for AI agent harnesses — route each query to the cheapest model that's good enough (k-NN over labelled embeddings). The productized DRACO Phase-2 finding.",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- #176 added a genuine new capability to `@metaharness/darwin` (ADR-249 signal seams) and `@metaharness/router` (calibration module) without bumping their package versions.
- Both packages are already published on npm at 0.9.0 / 0.4.0 respectively (minor bumps, matching this repo's own precedent for new-capability PRs). This PR brings `package.json` back in sync with what's live on the registry.

## Test plan
- [x] Both packages rebuild clean (`npm run build`)
- [x] Full test suites pass post-bump: darwin-mode 626/626, router 34/34
- [x] Verified live on npm: `npm view @metaharness/darwin dist-tags` -> 0.9.0, `npm view @metaharness/router dist-tags` -> 0.4.0

🤖 Generated with [RuFlo](https://github.com/ruvnet/ruflo)