### PR TITLE
fix(proxy): make the pin-drift watcher self-resolving and key-aware (…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,12 @@ jobs:
           node scripts/nightly-sota-gate.test.mjs
           node packages/darwin-mode/bench/swebench/solver-trajectory.test.mjs
           node packages/darwin-mode/bench/swebench/test-critic.test.mjs
+      - name: Meta-Proxy pin-drift watcher gate (#174)
+        # The watcher decides whether to open, retitle, or close a drift issue and
+        # whether the pinned signing key still verifies the pinned release. Its `gh`
+        # and network calls are injected, so this is $0 and offline.
+        shell: bash
+        run: node scripts/proxy-pin-drift.test.mjs
       - name: Native-router interop guard (ADR-043 — CJS default-unwrap regression)
         # tiny-dancer is CJS; vitest's interop masks the ESM `.default` unwrap, so
         # this runs under plain `node` (the real install condition) and fails if a

--- a/.github/workflows/proxy-pin-drift.yml
+++ b/.github/workflows/proxy-pin-drift.yml
@@ -4,6 +4,12 @@
 # the pre-existing watcher was built in cognitum-one/metaharness guarding a
 # different constant, so drift here went unnoticed (#149). This ports the check
 # to the repo that actually publishes the pin.
+#
+# The comparison itself moved out of this file and into scripts/proxy-pin-drift.mjs
+# (#174): as inline shell it could not be tested, and the untested branches were
+# exactly the ones that were wrong — it never closed a resolved issue, it opened a
+# fresh one whenever either version moved, it called every mismatch "behind", and it
+# never checked the signing key its own issue text told maintainers to confirm.
 name: proxy-pin-drift
 
 on:
@@ -21,30 +27,11 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
       - name: Compare META_PROXY_VERSION to meta-proxy-dist latest release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          PINNED=$(grep -oP "META_PROXY_VERSION = '\K[^']+" packages/create-agent-harness/src/meta-proxy.ts)
-          LATEST=$(gh release list --repo cognitum-one/meta-proxy-dist --limit 1 --json tagName --jq '.[0].tagName' | sed 's/^v//')
-          echo "pinned=$PINNED  latest=$LATEST"
-          if [ -z "$LATEST" ]; then echo "could not read meta-proxy-dist latest release — skipping (not a drift)"; exit 0; fi
-          if [ "$PINNED" = "$LATEST" ]; then echo "✓ META_PROXY_VERSION is current."; exit 0; fi
-          TITLE="meta-proxy pin drift — META_PROXY_VERSION ($PINNED) is behind meta-proxy-dist v$LATEST"
-          BODY_FILE=/tmp/body.md
-          {
-            echo "\`META_PROXY_VERSION\` is pinned at \`$PINNED\` but \`cognitum-one/meta-proxy-dist\`"
-            echo "latest release is \`v$LATEST\`. \`metaharness proxy install\` downloads the pinned"
-            echo "version, so users are getting a stale proxy and being told it succeeded."
-            echo ""
-            echo "**To resolve:** confirm \`META_PROXY_SIGNING_PUBKEY_PEM\` still matches meta-proxy's"
-            echo "\`signing-key.pub.pem\` for \`v$LATEST\` (re-pin it in the same change if the key"
-            echo "rotated), then bump \`META_PROXY_VERSION\` in"
-            echo "\`packages/create-agent-harness/src/meta-proxy.ts\` and publish the CLI."
-          } > "$BODY_FILE"
-          EXISTING=$(gh issue list --repo "$GITHUB_REPOSITORY" --search "$TITLE in:title" --state open --json number --jq '.[0].number' 2>/dev/null || true)
-          if [ -n "$EXISTING" ]; then
-            gh issue comment "$EXISTING" --repo "$GITHUB_REPOSITORY" --body-file "$BODY_FILE"
-          else
-            gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" --label bug --body-file "$BODY_FILE"
-          fi
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: node scripts/proxy-pin-drift.mjs

--- a/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
+++ b/packages/create-agent-harness/__tests__/meta-proxy-workflow.test.ts
@@ -29,3 +29,24 @@ describe('Meta-Proxy native lifecycle gate', () => {
     expect(workflow).toMatch(/ci-pass:\n[\s\S]*needs:.*meta-proxy-scheduled-task/);
   });
 });
+
+describe('Meta-Proxy pin-drift watcher', () => {
+  const read = (name: string) =>
+    readFileSync(fileURLToPath(new URL(`../../../.github/workflows/${name}`, import.meta.url)), 'utf8')
+      .replace(/\r\n/g, '\n');
+
+  // #174 — the watcher's decisions used to be inline shell in the cron workflow, where nothing
+  // exercised them. Keeping the logic in a script is what makes it testable at all, so guard it.
+  it('runs its comparison through the tested script rather than inline shell', () => {
+    const workflow = read('proxy-pin-drift.yml');
+
+    expect(workflow).toContain('node scripts/proxy-pin-drift.mjs');
+    expect(workflow).toMatch(/permissions:\n[\s\S]*issues: write/);
+    expect(workflow).toMatch(/GITHUB_REPOSITORY: \$\{\{ github\.repository \}\}/);
+    expect(workflow).not.toContain('gh release list');
+  });
+
+  it('keeps the watcher gate in CI so its branches cannot silently rot again', () => {
+    expect(read('ci.yml')).toContain('node scripts/proxy-pin-drift.test.mjs');
+  });
+});

--- a/scripts/proxy-pin-drift.mjs
+++ b/scripts/proxy-pin-drift.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// proxy-pin-drift.mjs — watch META_PROXY_VERSION against cognitum-one/meta-proxy-dist.
+//
+// The watcher used to live entirely in proxy-pin-drift.yml as inline shell. It compared two
+// version strings and opened an issue on any inequality. That was too coarse in four ways, and
+// #174 is the artifact of all four at once:
+//
+//   1. The issue title embedded both version numbers, so it doubled as the dedupe key. The moment
+//      either side moved, the search stopped matching and the watcher opened a *second* issue
+//      instead of updating the first.
+//   2. Nothing ever closed a drift issue. #174 still asserts the pin is 0.7.2 long after #175
+//      moved it to 0.7.4 — a permanently wrong open bug.
+//   3. Any inequality was reported as "behind". A pin that runs *ahead* of the latest release is
+//      the more dangerous state (`proxy install` 404s on assets that were never published), and it
+//      got the exact opposite advice: "bump META_PROXY_VERSION".
+//   4. `gh release list --limit 1` is newest-by-date, not "latest" — it happily returns a draft or
+//      a prerelease, which would have us pinning every user onto an RC.
+//
+// It also never did the one check #174's own resolution text asks for: that
+// META_PROXY_SIGNING_PUBKEY_PEM still verifies the release. A rotated key does not show up as
+// drift, it shows up as every `metaharness proxy install --yes` failing signature verification.
+// So we verify the pinned key against the pinned release every run, and against the *candidate*
+// release before recommending a bump — otherwise the recommendation is "bump and break installs".
+//
+// Everything below the CLI boundary is pure and unit-tested in proxy-pin-drift.test.mjs; the `gh`
+// and network calls are injected so the tests never touch either.
+import { createPublicKey, verify as verifyEd25519 } from 'node:crypto';
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+export const PIN_SOURCE = 'packages/create-agent-harness/src/meta-proxy.ts';
+export const DIST_REPO = 'cognitum-one/meta-proxy-dist';
+
+/**
+ * Every drift issue this watcher has ever opened matches this search, including the pre-fix ones
+ * whose titles still carry version numbers. That is deliberate: it is what lets the first run
+ * after this lands find #174 and close it rather than orphaning it.
+ */
+export const DRIFT_SEARCH = 'meta-proxy pin drift in:title author:app/github-actions';
+
+/** Stable titles — no version numbers, so the dedupe key survives a version change. */
+export const DRIFT_TITLES = {
+  behind: 'meta-proxy pin drift — META_PROXY_VERSION is behind meta-proxy-dist',
+  ahead: 'meta-proxy pin drift — META_PROXY_VERSION is ahead of meta-proxy-dist',
+  unsigned: 'meta-proxy pin drift — pinned signing key does not verify the pinned release',
+};
+
+// ───────────────────────────────── reading the pin ─────────────────────────────────
+
+// We read the literals out of the TypeScript source rather than importing the built package: the
+// scheduled job checks out the repo and runs, with no `npm ci` and no dist/. Reading the source
+// also means we are checking the values that actually ship, not a stale build artifact.
+
+export function readPinnedVersion(source) {
+  const match = source.match(/META_PROXY_VERSION = '([^']+)'/);
+  if (!match) throw new Error(`Could not find META_PROXY_VERSION in ${PIN_SOURCE}.`);
+  return match[1];
+}
+
+export function readPinnedPublicKey(source) {
+  const match = source.match(/META_PROXY_SIGNING_PUBKEY_PEM = `([^`]+)`/);
+  if (!match) throw new Error(`Could not find META_PROXY_SIGNING_PUBKEY_PEM in ${PIN_SOURCE}.`);
+  return match[1];
+}
+
+export function readReleaseBase(source) {
+  const match = source.match(/META_PROXY_RELEASE_BASE = '([^']+)'/);
+  if (!match) throw new Error(`Could not find META_PROXY_RELEASE_BASE in ${PIN_SOURCE}.`);
+  return match[1];
+}
+
+// ───────────────────────────────── version ordering ─────────────────────────────────
+
+/** -1 / 0 / 1. A prerelease sorts below the release it leads to (0.8.0-rc.1 < 0.8.0). */
+export function compareVersions(a, b) {
+  const split = (value) => {
+    const [core, pre = ''] = value.replace(/^v/, '').split('-');
+    return { parts: core.split('.').map((n) => Number.parseInt(n, 10) || 0), pre };
+  };
+  const left = split(a);
+  const right = split(b);
+  for (let i = 0; i < 3; i++) {
+    const delta = (left.parts[i] ?? 0) - (right.parts[i] ?? 0);
+    if (delta !== 0) return delta > 0 ? 1 : -1;
+  }
+  if (left.pre === right.pre) return 0;
+  if (left.pre === '') return 1;
+  if (right.pre === '') return -1;
+  return left.pre > right.pre ? 1 : -1;
+}
+
+export function classifyPin(pinned, latest) {
+  const order = compareVersions(pinned, latest);
+  if (order === 0) return 'current';
+  return order < 0 ? 'behind' : 'ahead';
+}
+
+// ───────────────────────────────── signature verification ─────────────────────────────────
+
+/** The same check `installMetaProxy` performs, run against a release we have not shipped yet. */
+export function verifyManifestSignature(sums, signatureBase64, publicKeyPem) {
+  try {
+    const signature = Buffer.from(String(signatureBase64).trim(), 'base64');
+    return signature.length > 0
+      && verifyEd25519(null, sums, createPublicKey(publicKeyPem), signature);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Fetch a release's signed manifest and check it against the pinned key. `null` means we could not
+ * reach the assets at all — an unreachable release is not evidence of a rotated key, and reporting
+ * it as one would be its own false alarm.
+ */
+export async function checkReleaseSignature(fetcher, releaseBase, version, publicKeyPem) {
+  const base = `${releaseBase.replace(/\/$/, '')}/v${version}`;
+  const [sums, signature] = await Promise.all([
+    fetcher(`${base}/SHA256SUMS`),
+    fetcher(`${base}/SHA256SUMS.sig`),
+  ]);
+  if (!sums || !signature) return null;
+  return verifyManifestSignature(sums, signature.toString('utf8'), publicKeyPem);
+}
+
+// ───────────────────────────────── the decision ─────────────────────────────────
+
+/**
+ * Reduce the observed state to exactly one action. Returning a single object — rather than
+ * branching inside the workflow's shell — is what makes the interesting cases testable.
+ *
+ * `pinnedKeyOk` / `latestKeyOk` are tri-state: true, false, or null for "could not check".
+ */
+export function decideDriftAction({ pinned, latest, state, pinnedKeyOk, latestKeyOk }) {
+  // A pinned release the pinned key no longer verifies outranks version drift: every install is
+  // already failing closed, and bumping the version would not fix it.
+  if (pinnedKeyOk === false) {
+    return {
+      action: 'open',
+      title: DRIFT_TITLES.unsigned,
+      body: [
+        `\`META_PROXY_SIGNING_PUBKEY_PEM\` no longer verifies the \`SHA256SUMS\` signature for the`,
+        `pinned release \`v${pinned}\`. \`metaharness proxy install --yes\` fails closed for every`,
+        `user on this CLI — it refuses to install rather than trusting an unverified binary.`,
+        ``,
+        `**To resolve:** re-pin \`META_PROXY_SIGNING_PUBKEY_PEM\` in \`${PIN_SOURCE}\` from`,
+        `meta-proxy's current \`signing-key.pub.pem\`, confirm it verifies \`v${pinned}\`, and`,
+        `publish the CLI. Treat an unexplained key change as a security event before assuming a`,
+        `routine rotation.`,
+      ].join('\n'),
+    };
+  }
+
+  if (state === 'current') {
+    return {
+      action: 'close',
+      comment: [
+        `Resolved — \`META_PROXY_VERSION\` is \`${pinned}\`, which matches \`${DIST_REPO}\` latest`,
+        `\`v${latest}\`, and the pinned signing key verifies that release.`,
+        ``,
+        `Closed automatically by \`proxy-pin-drift\`.`,
+      ].join('\n'),
+    };
+  }
+
+  if (state === 'ahead') {
+    return {
+      action: 'open',
+      title: DRIFT_TITLES.ahead,
+      body: [
+        `\`META_PROXY_VERSION\` is pinned at \`${pinned}\`, but the latest \`${DIST_REPO}\` release`,
+        `is \`v${latest}\` — the pin is **ahead** of anything published. \`metaharness proxy install\``,
+        `downloads \`v${pinned}\`, so the release assets 404 and the install fails outright.`,
+        ``,
+        `This usually means a release was retracted after we pinned it, or the pin was hand-edited.`,
+        ``,
+        `**To resolve:** re-pin \`META_PROXY_VERSION\` in \`${PIN_SOURCE}\` down to \`${latest}\`,`,
+        `confirm \`META_PROXY_SIGNING_PUBKEY_PEM\` verifies that release, and publish the CLI.`,
+      ].join('\n'),
+    };
+  }
+
+  // Behind. The bump advice is only safe if the key still verifies the release we are recommending.
+  const keyNote = latestKeyOk === true
+    ? `The pinned \`META_PROXY_SIGNING_PUBKEY_PEM\` still verifies \`v${latest}\`, so a version bump on its own is sufficient.`
+    : latestKeyOk === false
+      ? `⚠️ The pinned \`META_PROXY_SIGNING_PUBKEY_PEM\` does **not** verify \`v${latest}\` — the signing key rotated. Re-pin the key from meta-proxy's \`signing-key.pub.pem\` in the same change, or the bump will break every install.`
+      : `The \`v${latest}\` signing assets could not be fetched, so the key was not confirmed. Verify \`META_PROXY_SIGNING_PUBKEY_PEM\` against \`v${latest}\` by hand before bumping.`;
+
+  return {
+    action: 'open',
+    title: DRIFT_TITLES.behind,
+    body: [
+      `\`META_PROXY_VERSION\` is pinned at \`${pinned}\` but \`${DIST_REPO}\` latest release is`,
+      `\`v${latest}\`. \`metaharness proxy install\` downloads the pinned version, so users are`,
+      `getting a stale proxy and being told it succeeded.`,
+      ``,
+      keyNote,
+      ``,
+      `**To resolve:** bump \`META_PROXY_VERSION\` in \`${PIN_SOURCE}\` to \`${latest}\` (re-pinning`,
+      `the signing key in the same change if the note above says it rotated) and publish the CLI.`,
+    ].join('\n'),
+  };
+}
+
+// ───────────────────────────────── side effects ─────────────────────────────────
+
+const defaultGh = (args) => {
+  const result = spawnSync('gh', args, { encoding: 'utf8', timeout: 60_000 });
+  return { status: result.status ?? 1, stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
+};
+
+const defaultFetcher = async (url) => {
+  try {
+    const response = await fetch(url, { redirect: 'follow' });
+    return response.ok ? Buffer.from(await response.arrayBuffer()) : null;
+  } catch {
+    return null;
+  }
+};
+
+/** The repo's "Latest" release — excludes drafts and prereleases, unlike `gh release list`. */
+export function resolveLatestRelease(gh) {
+  const result = gh(['release', 'view', '--repo', DIST_REPO, '--json', 'tagName', '--jq', '.tagName']);
+  if (result.status !== 0) return null;
+  return result.stdout.trim().replace(/^v/, '') || null;
+}
+
+export function findOpenDriftIssue(gh, repo) {
+  const result = gh([
+    'issue', 'list', '--repo', repo, '--search', DRIFT_SEARCH,
+    '--state', 'open', '--json', 'number,title', '--limit', '1',
+  ]);
+  if (result.status !== 0) return null;
+  try {
+    const [issue] = JSON.parse(result.stdout || '[]');
+    return issue ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * One open issue at a time, always accurate. An existing issue is retitled and commented rather
+ * than duplicated — that is the #174 failure mode, and it is why the title carries no versions.
+ */
+export function applyDriftAction(gh, repo, decision, existing) {
+  if (decision.action === 'close') {
+    if (!existing) return 'nothing to close';
+    gh(['issue', 'comment', String(existing.number), '--repo', repo, '--body', decision.comment]);
+    gh(['issue', 'close', String(existing.number), '--repo', repo]);
+    return `closed #${existing.number}`;
+  }
+
+  if (!existing) {
+    gh(['issue', 'create', '--repo', repo, '--title', decision.title, '--label', 'bug', '--body', decision.body]);
+    return 'opened a new drift issue';
+  }
+
+  if (existing.title !== decision.title) {
+    gh(['issue', 'edit', String(existing.number), '--repo', repo, '--title', decision.title]);
+  }
+  gh(['issue', 'comment', String(existing.number), '--repo', repo, '--body', decision.body]);
+  return `updated #${existing.number}`;
+}
+
+export async function run({ repo, gh = defaultGh, fetcher = defaultFetcher, source } = {}) {
+  const text = source ?? readFileSync(PIN_SOURCE, 'utf8');
+  const pinned = readPinnedVersion(text);
+  const publicKeyPem = readPinnedPublicKey(text);
+  const releaseBase = readReleaseBase(text);
+
+  const latest = resolveLatestRelease(gh);
+  if (!latest) {
+    // A GitHub API blip is not drift. Staying quiet beats crying wolf on a weekly cron.
+    return { ok: true, summary: `could not read ${DIST_REPO} latest release — skipping (not a drift)` };
+  }
+
+  const state = classifyPin(pinned, latest);
+  const pinnedKeyOk = await checkReleaseSignature(fetcher, releaseBase, pinned, publicKeyPem);
+  const latestKeyOk = state === 'behind'
+    ? await checkReleaseSignature(fetcher, releaseBase, latest, publicKeyPem)
+    : pinnedKeyOk;
+
+  const decision = decideDriftAction({ pinned, latest, state, pinnedKeyOk, latestKeyOk });
+  const outcome = applyDriftAction(gh, repo, decision, findOpenDriftIssue(gh, repo));
+  return {
+    ok: true,
+    summary: `pinned=${pinned} latest=${latest} state=${state} pinnedKey=${pinnedKeyOk} → ${outcome}`,
+  };
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!repo) {
+    console.error('GITHUB_REPOSITORY must be set.');
+    process.exit(1);
+  }
+  run({ repo })
+    .then((result) => console.log(result.summary))
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exit(1);
+    });
+}

--- a/scripts/proxy-pin-drift.test.mjs
+++ b/scripts/proxy-pin-drift.test.mjs
@@ -1,0 +1,265 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: MIT
+// Pure-logic tests for proxy-pin-drift.mjs. NO network, NO `gh` — both are injected.
+// Run: node scripts/proxy-pin-drift.test.mjs
+import assert from 'node:assert';
+import { generateKeyPairSync, sign as edSign } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import {
+  DIST_REPO, DRIFT_SEARCH, DRIFT_TITLES, PIN_SOURCE,
+  applyDriftAction, checkReleaseSignature, classifyPin, compareVersions, decideDriftAction,
+  findOpenDriftIssue, readPinnedPublicKey, readPinnedVersion, readReleaseBase,
+  resolveLatestRelease, run, verifyManifestSignature,
+} from './proxy-pin-drift.mjs';
+
+let pass = 0;
+const t = (name, fn) => { try { fn(); pass++; console.log(`  ok  ${name}`); } catch (e) { console.error(`  FAIL ${name}: ${e.message}`); process.exitCode = 1; } };
+const at = async (name, fn) => { try { await fn(); pass++; console.log(`  ok  ${name}`); } catch (e) { console.error(`  FAIL ${name}: ${e.message}`); process.exitCode = 1; } };
+
+/** Records every `gh` invocation and replays canned output keyed by the subcommand pair. */
+const fakeGh = (responses = {}) => {
+  const calls = [];
+  const gh = (args) => {
+    calls.push(args);
+    const key = `${args[0]} ${args[1]}`;
+    return responses[key] ?? { status: 0, stdout: '', stderr: '' };
+  };
+  gh.calls = calls;
+  gh.ran = (subcommand) => calls.filter((args) => `${args[0]} ${args[1]}` === subcommand);
+  return gh;
+};
+
+console.log('proxy-pin-drift.mjs unit tests:');
+
+// ── the pin is read out of the real shipped source, so a refactor there fails here ──
+
+const REAL_SOURCE = readFileSync(PIN_SOURCE, 'utf8');
+
+t('reads META_PROXY_VERSION out of the real meta-proxy.ts', () => {
+  assert.match(readPinnedVersion(REAL_SOURCE), /^\d+\.\d+\.\d+/);
+});
+
+t('reads the pinned Ed25519 key out of the real meta-proxy.ts', () => {
+  assert.match(readPinnedPublicKey(REAL_SOURCE), /^-----BEGIN PUBLIC KEY-----\n/);
+});
+
+t('reads the release base out of the real meta-proxy.ts', () => {
+  assert.equal(readReleaseBase(REAL_SOURCE), `https://github.com/${DIST_REPO}/releases/download`);
+});
+
+t('fails loudly rather than silently reporting no drift when the pin moves', () => {
+  assert.throws(() => readPinnedVersion('const SOMETHING_ELSE = 1;'), /META_PROXY_VERSION/);
+});
+
+// ── version ordering: the fix for "any inequality is behind" ──
+
+t('compareVersions orders release triples', () => {
+  assert.equal(compareVersions('0.7.4', '0.7.4'), 0);
+  assert.equal(compareVersions('0.7.2', '0.7.3'), -1);
+  assert.equal(compareVersions('0.7.10', '0.7.9'), 1);
+  assert.equal(compareVersions('0.8.0', '0.7.99'), 1);
+  assert.equal(compareVersions('v0.7.4', '0.7.4'), 0);
+});
+
+t('compareVersions sorts a prerelease below the release it leads to', () => {
+  assert.equal(compareVersions('0.8.0-rc.1', '0.8.0'), -1);
+  assert.equal(compareVersions('0.8.0', '0.8.0-rc.1'), 1);
+  assert.equal(compareVersions('0.8.0-rc.1', '0.8.0-rc.2'), -1);
+});
+
+t('classifyPin distinguishes behind from ahead instead of collapsing both', () => {
+  assert.equal(classifyPin('0.7.4', '0.7.4'), 'current');
+  assert.equal(classifyPin('0.7.2', '0.7.3'), 'behind');
+  assert.equal(classifyPin('0.7.4', '0.7.3'), 'ahead');
+});
+
+// ── signature verification ──
+
+const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+const PEM = publicKey.export({ type: 'spki', format: 'pem' });
+const SUMS = Buffer.from('3902fd304ea46a40a5e51f06b0b571a4  meta-proxy-0.7.4-aarch64-apple-darwin.tar.gz\n');
+const SIG = edSign(null, SUMS, privateKey).toString('base64');
+
+t('verifyManifestSignature accepts a genuine signature', () => {
+  assert.equal(verifyManifestSignature(SUMS, SIG, PEM), true);
+});
+
+t('verifyManifestSignature rejects a tampered manifest', () => {
+  assert.equal(verifyManifestSignature(Buffer.from(`${SUMS}tampered`), SIG, PEM), false);
+});
+
+t('verifyManifestSignature rejects a signature from a rotated key', () => {
+  const other = generateKeyPairSync('ed25519');
+  const otherSig = edSign(null, SUMS, other.privateKey).toString('base64');
+  assert.equal(verifyManifestSignature(SUMS, otherSig, PEM), false);
+});
+
+t('verifyManifestSignature returns false rather than throwing on garbage input', () => {
+  assert.equal(verifyManifestSignature(SUMS, '', PEM), false);
+  assert.equal(verifyManifestSignature(SUMS, SIG, 'not a pem'), false);
+});
+
+await at('checkReleaseSignature reports null when the assets are unreachable', async () => {
+  const result = await checkReleaseSignature(async () => null, 'https://example.test', '0.7.4', PEM);
+  assert.equal(result, null, 'an unreachable release must not be reported as a rotated key');
+});
+
+await at('checkReleaseSignature fetches the pinned version tag', async () => {
+  const seen = [];
+  const fetcher = async (url) => {
+    seen.push(url);
+    return url.endsWith('.sig') ? Buffer.from(SIG) : SUMS;
+  };
+  assert.equal(await checkReleaseSignature(fetcher, 'https://example.test/', '0.7.4', PEM), true);
+  assert.deepEqual(seen.sort(), [
+    'https://example.test/v0.7.4/SHA256SUMS',
+    'https://example.test/v0.7.4/SHA256SUMS.sig',
+  ]);
+});
+
+// ── the decision table ──
+
+t('a current pin closes the open drift issue instead of leaving it asserting a stale version', () => {
+  const decision = decideDriftAction({ pinned: '0.7.4', latest: '0.7.4', state: 'current', pinnedKeyOk: true, latestKeyOk: true });
+  assert.equal(decision.action, 'close');
+  assert.match(decision.comment, /Resolved/);
+});
+
+t('a behind pin whose key still verifies says a plain bump is enough', () => {
+  const decision = decideDriftAction({ pinned: '0.7.2', latest: '0.7.3', state: 'behind', pinnedKeyOk: true, latestKeyOk: true });
+  assert.equal(decision.action, 'open');
+  assert.equal(decision.title, DRIFT_TITLES.behind);
+  assert.match(decision.body, /bump on its own is sufficient/);
+});
+
+t('a behind pin whose key rotated warns before the bump breaks every install', () => {
+  const decision = decideDriftAction({ pinned: '0.7.2', latest: '0.7.3', state: 'behind', pinnedKeyOk: true, latestKeyOk: false });
+  assert.match(decision.body, /signing key rotated/);
+  assert.match(decision.body, /Re-pin the key/);
+});
+
+t('a behind pin with unreachable assets asks for a manual key check, not a false rotation claim', () => {
+  const decision = decideDriftAction({ pinned: '0.7.2', latest: '0.7.3', state: 'behind', pinnedKeyOk: true, latestKeyOk: null });
+  assert.match(decision.body, /could not be fetched/);
+  assert.doesNotMatch(decision.body, /signing key rotated/, 'unreachable assets are not evidence of rotation');
+});
+
+t('an ahead pin is reported as ahead, with re-pin-down advice rather than "bump"', () => {
+  const decision = decideDriftAction({ pinned: '0.7.4', latest: '0.7.3', state: 'ahead', pinnedKeyOk: true, latestKeyOk: true });
+  assert.equal(decision.title, DRIFT_TITLES.ahead);
+  assert.match(decision.body, /404/);
+  assert.match(decision.body, /down to `0\.7\.3`/);
+});
+
+t('a pinned release the pinned key cannot verify outranks version drift', () => {
+  const decision = decideDriftAction({ pinned: '0.7.2', latest: '0.7.3', state: 'behind', pinnedKeyOk: false, latestKeyOk: true });
+  assert.equal(decision.title, DRIFT_TITLES.unsigned);
+  assert.match(decision.body, /fails closed/);
+});
+
+t('#174 regression — no title carries a version number, so it stays a stable dedupe key', () => {
+  for (const [state, title] of Object.entries(DRIFT_TITLES)) {
+    assert.doesNotMatch(title, /\d+\.\d+\.\d+/, `${state} title embeds a version`);
+  }
+  assert.doesNotMatch(DRIFT_SEARCH, /\d+\.\d+\.\d+/);
+  // The phrase every pre-fix issue title also opens with, so #174 is still findable.
+  assert.match(DRIFT_SEARCH, /meta-proxy pin drift in:title/);
+});
+
+// ── the gh surface ──
+
+t('resolveLatestRelease uses `release view`, which excludes drafts and prereleases', () => {
+  const gh = fakeGh({ 'release view': { status: 0, stdout: 'v0.7.4\n', stderr: '' } });
+  assert.equal(resolveLatestRelease(gh), '0.7.4');
+  assert.equal(gh.ran('release list').length, 0, '`release list --limit 1` is newest-by-date, not latest');
+});
+
+t('resolveLatestRelease returns null when gh fails, so a blip is not read as drift', () => {
+  assert.equal(resolveLatestRelease(fakeGh({ 'release view': { status: 1, stdout: '', stderr: 'boom' } })), null);
+});
+
+t('findOpenDriftIssue survives malformed gh output', () => {
+  assert.equal(findOpenDriftIssue(fakeGh({ 'issue list': { status: 0, stdout: 'not json', stderr: '' } }), 'o/r'), null);
+  assert.equal(findOpenDriftIssue(fakeGh({ 'issue list': { status: 0, stdout: '[]', stderr: '' } }), 'o/r'), null);
+});
+
+t('#174 regression — an existing issue is retitled and commented, never duplicated', () => {
+  const gh = fakeGh();
+  const existing = { number: 174, title: 'meta-proxy pin drift — META_PROXY_VERSION (0.7.2) is behind meta-proxy-dist v0.7.3' };
+  const outcome = applyDriftAction(gh, 'o/r', { action: 'open', title: DRIFT_TITLES.ahead, body: 'b' }, existing);
+
+  assert.equal(outcome, 'updated #174');
+  assert.equal(gh.ran('issue create').length, 0, 'a second issue must not be opened');
+  assert.deepEqual(gh.ran('issue edit')[0], ['issue', 'edit', '174', '--repo', 'o/r', '--title', DRIFT_TITLES.ahead]);
+  assert.equal(gh.ran('issue comment').length, 1);
+});
+
+t('an accurate existing title is left alone, not churned with a no-op edit', () => {
+  const gh = fakeGh();
+  applyDriftAction(gh, 'o/r', { action: 'open', title: DRIFT_TITLES.behind, body: 'b' }, { number: 9, title: DRIFT_TITLES.behind });
+  assert.equal(gh.ran('issue edit').length, 0);
+});
+
+t('the first drift opens a labelled issue', () => {
+  const gh = fakeGh();
+  assert.equal(applyDriftAction(gh, 'o/r', { action: 'open', title: DRIFT_TITLES.behind, body: 'b' }, null), 'opened a new drift issue');
+  assert.deepEqual(gh.ran('issue create')[0].slice(0, 6), ['issue', 'create', '--repo', 'o/r', '--title', DRIFT_TITLES.behind]);
+});
+
+t('#174 regression — a resolved drift comments and closes the open issue', () => {
+  const gh = fakeGh();
+  const outcome = applyDriftAction(gh, 'o/r', { action: 'close', comment: 'resolved' }, { number: 174, title: 'old' });
+  assert.equal(outcome, 'closed #174');
+  assert.equal(gh.ran('issue comment').length, 1, 'closing silently leaves no trail of why');
+  assert.deepEqual(gh.ran('issue close')[0], ['issue', 'close', '174', '--repo', 'o/r']);
+});
+
+t('a resolved drift with nothing open is a no-op', () => {
+  const gh = fakeGh();
+  assert.equal(applyDriftAction(gh, 'o/r', { action: 'close', comment: 'resolved' }, null), 'nothing to close');
+  assert.equal(gh.calls.length, 0);
+});
+
+// ── end to end, still with no network and no gh ──
+
+const SYNTHETIC_SOURCE = `
+export const META_PROXY_VERSION = '0.7.2';
+export const META_PROXY_RELEASE_BASE = 'https://example.test/releases/download';
+export const META_PROXY_SIGNING_PUBKEY_PEM = \`${PEM}\`;
+`;
+
+await at('run() drives a behind pin to a single updated issue', async () => {
+  const gh = fakeGh({
+    'release view': { status: 0, stdout: 'v0.7.3\n', stderr: '' },
+    'issue list': { status: 0, stdout: JSON.stringify([{ number: 174, title: 'old title' }]), stderr: '' },
+  });
+  const fetcher = async (url) => (url.endsWith('.sig') ? Buffer.from(SIG) : SUMS);
+  const result = await run({ repo: 'o/r', gh, fetcher, source: SYNTHETIC_SOURCE });
+
+  assert.match(result.summary, /pinned=0\.7\.2 latest=0\.7\.3 state=behind/);
+  assert.match(result.summary, /updated #174/);
+  assert.equal(gh.ran('issue create').length, 0);
+});
+
+await at('run() stays quiet when gh cannot reach the release API', async () => {
+  const gh = fakeGh({ 'release view': { status: 1, stdout: '', stderr: 'rate limited' } });
+  const result = await run({ repo: 'o/r', gh, fetcher: async () => null, source: SYNTHETIC_SOURCE });
+
+  assert.match(result.summary, /skipping \(not a drift\)/);
+  assert.equal(gh.ran('issue create').length, 0);
+  assert.equal(gh.ran('issue comment').length, 0);
+});
+
+await at('run() closes the stale issue once the pin catches up — the #174 end state', async () => {
+  const gh = fakeGh({
+    'release view': { status: 0, stdout: 'v0.7.2\n', stderr: '' },
+    'issue list': { status: 0, stdout: JSON.stringify([{ number: 174, title: 'old title' }]), stderr: '' },
+  });
+  const fetcher = async (url) => (url.endsWith('.sig') ? Buffer.from(SIG) : SUMS);
+  const result = await run({ repo: 'o/r', gh, fetcher, source: SYNTHETIC_SOURCE });
+
+  assert.match(result.summary, /state=current/);
+  assert.match(result.summary, /closed #174/);
+});
+
+console.log(`\n${pass} assertions passed.`);


### PR DESCRIPTION
…#174)

META_PROXY_VERSION is already current — #175 moved it 0.7.2 -> 0.7.4, and 0.7.4 is meta-proxy-dist's latest release. The pinned Ed25519 key still verifies that release's SHA256SUMS, so the pin itself needs no change.

What is still broken is the watcher that filed #174. Its logic lived as inline shell in the cron workflow, where nothing exercised it, and four of its untested branches were wrong:

  - The issue title embedded both version numbers and doubled as the dedupe key, so any version movement broke the match and opened a second issue.
  - Nothing ever closed a resolved drift. #174 has asserted "pinned at 0.7.2" for days after the pin reached 0.7.4.
  - Every mismatch was reported as "behind". A pin running ahead of the latest release is the more dangerous case — install 404s on assets that were never published — and it got the exact opposite advice.
  - `gh release list --limit 1` is newest-by-date, so a draft or prerelease would have us pinning users onto an RC.

It also never checked the signing key its own resolution text told maintainers to confirm. A rotated key is invisible to a version comparison; it surfaces as every `proxy install --yes` failing verification.

Move the decision into scripts/proxy-pin-drift.mjs with the `gh` and network calls injected, so the branches are testable offline. Titles no longer carry versions, an existing issue is retitled rather than duplicated, a resolved drift is commented and closed, and the pinned key is verified against both the pinned release and any release we are about to recommend.

The dedupe search still matches the old version-bearing titles, so the first scheduled run closes #174 rather than orphaning it. Verified against live meta-proxy-dist with gh stubbed: state=current, pinnedKey=true, closed #174.