### PR TITLE
fix: root build:wasm delegates to the kernel's authoritative nodejs-target script

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "node scripts/build-ordered.mjs",
     "test": "npm run -ws --if-present test",
     "lint": "npm run -ws --if-present lint",
-    "build:wasm": "wasm-pack build crates/kernel-wasm --target bundler --out-dir ../../packages/kernel-js/pkg --release",
+    "build:wasm": "npm run build:wasm --workspace @metaharness/kernel",
     "build:napi": "cd crates/kernel-napi && napi build --platform --release --output-dir ../../packages/kernel-js/native",
     "test:rust": "cargo test --workspace",
     "fmt:rust": "cargo fmt --all",


### PR DESCRIPTION
## Summary

Fixes #173. The root `build:wasm` script built `--target bundler` into `packages/kernel-js/pkg` — an ESM artifact `loadWasm()` cannot load — so the README quickstart's `npm run build:wasm && npm test` failed the GH #20 regression guard on every clean clone. `publish.yml` already treats `packages/kernel-js`'s script (nodejs target + `.gitignore`/`package.json` fixups) as the single source of truth; the root script now delegates to it instead of shadowing it with the opposite target.

## Verification

- Clean `npm install && npm run build:wasm` from the repo root now emits `pkg/` with `"type": "commonjs"` and no stray `.gitignore`
- `packages/kernel-js` `loader.test.ts` — including the #20 guard ("publish ships a loadable wasm (nodejs target)") — passes: 15/15

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)