### PR TITLE
release: redblue 0.1.6 + host-hermes 0.1.3 + metaharness 0.4.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5013,12 +5013,12 @@
     },
     "packages/create-agent-harness": {
       "name": "metaharness",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "license": "MIT",
       "dependencies": {
         "@metaharness/darwin": "^0.9.1",
         "@metaharness/flywheel": "^0.1.1",
-        "@metaharness/redblue": "^0.1.1",
+        "@metaharness/redblue": "^0.1.6",
         "@metaharness/turn-credit": "^0.1.0",
         "@metaharness/weight-eft": "^0.1.0",
         "kolorist": "^1.8.0",
@@ -5047,18 +5047,6 @@
         "@metaharness/kernel": {
           "optional": true
         }
-      }
-    },
-    "packages/create-agent-harness/node_modules/@metaharness/darwin": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@metaharness/darwin/-/darwin-0.8.3.tgz",
-      "integrity": "sha512-v5Ph7y9U6nqfvWajOjJiSuQDjPwvCKwOui793cSGUxIYUcfMoVoMzDfEDxOczFU61z0UUd7lD0I1b2zl+eYnag==",
-      "license": "MIT",
-      "bin": {
-        "metaharness-darwin": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "packages/darwin-mode": {
@@ -5246,7 +5234,7 @@
     },
     "packages/host-hermes": {
       "name": "@metaharness/host-hermes",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@metaharness/kernel": "^0.1.0"
@@ -5390,21 +5378,6 @@
         }
       }
     },
-    "packages/kernel-js/node_modules/@metaharness/kernel-darwin-arm64": {
-      "optional": true
-    },
-    "packages/kernel-js/node_modules/@metaharness/kernel-darwin-x64": {
-      "optional": true
-    },
-    "packages/kernel-js/node_modules/@metaharness/kernel-linux-arm64-gnu": {
-      "optional": true
-    },
-    "packages/kernel-js/node_modules/@metaharness/kernel-linux-x64-gnu": {
-      "optional": true
-    },
-    "packages/kernel-js/node_modules/@metaharness/kernel-win32-x64-msvc": {
-      "optional": true
-    },
     "packages/oo-agents": {
       "name": "@metaharness/oo-agents",
       "version": "0.1.0",
@@ -5442,7 +5415,7 @@
     },
     "packages/redblue": {
       "name": "@metaharness/redblue",
-      "version": "0.1.4",
+      "version": "0.1.6",
       "license": "MIT",
       "bin": {
         "metaharness-redblue": "dist/cli/index.js",

--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metaharness",
-  "version": "0.4.5",
-  "description": "MetaHarness \u2014 mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM, Prime Agent.",
+  "version": "0.4.6",
+  "description": "MetaHarness — mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM, Prime Agent.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {
     "type": "git",
@@ -101,7 +101,7 @@
     "prompts": "^2.4.2",
     "@metaharness/darwin": "^0.9.1",
     "@metaharness/weight-eft": "^0.1.0",
-    "@metaharness/redblue": "^0.1.1",
+    "@metaharness/redblue": "^0.1.6",
     "@metaharness/flywheel": "^0.1.1",
     "@metaharness/turn-credit": "^0.1.0"
   },

--- a/packages/host-hermes/package.json
+++ b/packages/host-hermes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/host-hermes",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Hermes Agent (NousResearch) host adapter for agent-harness-generator (MCP + <think>/<tool_call> scrubbing)",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {

--- a/packages/redblue/package.json
+++ b/packages/redblue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@metaharness/redblue",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "AI red-teaming for the AI agents & LLM apps you own: stress-test them with adversarial models to find security failures (prompt injection, tool misuse / excessive agency, data leakage, jailbreaks, denial-of-wallet), auto-patch (blue team), retest, and get a board-ready report. Operationalizes NIST AI RMF + OWASP LLM Top-10 as repeatable tests. Safe by design — capability-contained: no real credentials, no live external targets, no shell, no arbitrary network. Dependency-free (Node built-ins).",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Version bumps for today's fixes:

| package | version | ships |
|---|---|---|
| `@metaharness/redblue` | 0.1.5 → **0.1.6** | #182 cross_session_trace_replay family; #183 live red-model repin + loud OpenRouter errors; #184 skeptic judge pass |
| `@metaharness/host-hermes` | 0.1.2 → **0.1.3** | #188 hermes YAML mapping-key injection fix |
| `metaharness` | 0.4.5 → **0.4.6** | #188 CLI scaffold yamlKey fix; #189 root build:wasm delegation; redblue dep floor → ^0.1.6 |

Full workspace build green; redblue 127 ✓, host-hermes 19 ✓, metaharness 454 ✓.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)