### PR TITLE
test(kernel-js): close the #20 guard's scope gap across all build entry points

### DIFF
--- a/packages/kernel-js/__tests__/loader.test.ts
+++ b/packages/kernel-js/__tests__/loader.test.ts
@@ -107,7 +107,7 @@ describe('METAHARNESS_KERNEL_BACKEND selection (GH #22)', () => {
 // `npm install` can reach the fast Rust backend, not silently fall to the JS floor. The bug was the
 // publish workflow building `wasm-pack --target bundler` while the runtime loader expects `--target
 // nodejs` (CommonJS auto-init) — an unloadable mismatch.
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -121,6 +121,30 @@ describe('GH #20 — publish ships a loadable wasm (nodejs target)', () => {
     expect(wf).not.toMatch(/wasm-pack build[^\n]*--target\s+bundler/);
     // it must use build:wasm (nodejs target + fixups) or an explicit --target nodejs
     expect(/build:wasm|--target\s+nodejs/.test(wf)).toBe(true);
+  });
+
+  // GH #192 — the always-on half of this guard must cover EVERY build entry point, not just
+  // publish.yml: #173 shipped a bundler-target build in root package.json aimed at this package's
+  // pkg/ dir, and it stayed invisible because the runtime guard below skips until wasm is built.
+  // Bundler builds without --out-dir are legitimate (they land in crates/kernel-wasm/pkg); the
+  // regression is specifically a bundler artifact written into packages/kernel-js/pkg.
+  it('no build entry point writes a bundler-target artifact into packages/kernel-js/pkg', () => {
+    const repoRoot = join(kjsRoot, '..', '..');
+    const entryPoints = [
+      join(repoRoot, 'package.json'),
+      join(kjsRoot, 'package.json'),
+      join(repoRoot, 'scripts', 'preflight.mjs'),
+      ...readdirSync(join(repoRoot, '.github', 'workflows'))
+        .filter((f) => /\.ya?ml$/.test(f))
+        .map((f) => join(repoRoot, '.github', 'workflows', f)),
+    ].filter((p) => existsSync(p));
+    const bundlerIntoLoaderPkg =
+      /wasm-pack\s+build[^\n]*--target\s+bundler[^\n]*--out-dir\s+\S*packages\/kernel-js\/pkg|wasm-pack\s+build[^\n]*--out-dir\s+\S*packages\/kernel-js\/pkg[^\n]*--target\s+bundler/;
+    for (const p of entryPoints) {
+      expect(readFileSync(p, 'utf8'), `bundler-target build aimed at kernel-js/pkg in ${p}`).not.toMatch(
+        bundlerIntoLoaderPkg,
+      );
+    }
   });
 
   // Only runs where the wasm artifact has been built (locally after `npm run build:wasm`, and in the


### PR DESCRIPTION
## Summary

Fixes #192. The #20 regression guard was a pair with a window between them: the always-on static test read **only** `publish.yml`, and the runtime test `skipIf`s until a wasm artifact exists — so #173's defect (a bundler-target build in **root** `package.json` aimed at `packages/kernel-js/pkg`) passed `npm test` on every clean clone while the guard was live.

Per the issue's suggested fix, this extends the static half rather than un-skipping the runtime half: a new always-on assertion scans **every build entry point** (root `package.json`, `packages/kernel-js/package.json`, `scripts/preflight.mjs`, all workflow files) for a `wasm-pack` bundler-target build whose `--out-dir` lands in `packages/kernel-js/pkg`. Legitimate bundler builds without `--out-dir` (preflight :128, ci.yml :101 — they land in `crates/kernel-wasm/pkg`) still pass. The regex also covers the reversed flag order (`--out-dir … --target bundler`).

## Verification

- kernel-js: **59 passed | 1 skipped**, `tsc --noEmit` clean
- **Non-vacuity**: reintroduced the exact pre-#189 root `build:wasm` command → the new test fails with `bundler-target build aimed at kernel-js/pkg in …/package.json`; restored → green
- The issue's one-flag-three-passes matrix reproduced: the pre-#189 command is the only call site flagged

Test-only change — no published package content is affected (tests are not in the npm tarball), so no npm release is needed.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)