### PR TITLE
fix(score): taskCoverage measures the repo, not the recommended template

### DIFF
--- a/packages/create-agent-harness/__tests__/repo-scorecard.test.ts
+++ b/packages/create-agent-harness/__tests__/repo-scorecard.test.ts
@@ -55,6 +55,73 @@ describe('buildRepoScorecard', () => {
   });
 });
 
+describe('taskCoverage measures the repo, not the template (#171)', () => {
+  let empty: string;
+  let real: string;
+  let bare: string;
+  let withTests: string;
+  beforeAll(() => {
+    empty = mkdtempSync(join(tmpdir(), 'sc-empty-'));
+
+    // a real project: source + tests + CI + README + manifest
+    real = mkdtempSync(join(tmpdir(), 'sc-real-'));
+    mkdirSync(join(real, 'src'), { recursive: true });
+    mkdirSync(join(real, 'tests'), { recursive: true });
+    mkdirSync(join(real, '.github', 'workflows'), { recursive: true });
+    for (let i = 0; i < 20; i++) writeFileSync(join(real, 'src', `mod${i}.py`), `def f${i}(x):\n    return x * ${i}\n`);
+    for (let i = 0; i < 10; i++) writeFileSync(join(real, 'tests', `test_${i}.py`), `def test_${i}():\n    assert True\n`);
+    writeFileSync(join(real, '.github', 'workflows', 'ci.yml'), 'name: ci\non: [push]\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n');
+    writeFileSync(join(real, 'README.md'), '# real\nA Python data-processing service with a REST API and a worker queue.\n');
+    writeFileSync(join(real, 'package.json'), JSON.stringify({ name: 'real-proj', scripts: { test: 'pytest', build: 'python -m build' } }));
+
+    // the same repo WITHOUT tests + CI — adding them must not lower coverage
+    bare = mkdtempSync(join(tmpdir(), 'sc-bare-'));
+    mkdirSync(join(bare, 'src'), { recursive: true });
+    for (let i = 0; i < 20; i++) writeFileSync(join(bare, 'src', `mod${i}.py`), `def f${i}(x):\n    return x * ${i}\n`);
+    writeFileSync(join(bare, 'README.md'), '# bare\nA Python data-processing service with a REST API and a worker queue.\n');
+    writeFileSync(join(bare, 'package.json'), JSON.stringify({ name: 'bare-proj' }));
+
+    withTests = mkdtempSync(join(tmpdir(), 'sc-tests-'));
+    mkdirSync(join(withTests, 'src'), { recursive: true });
+    mkdirSync(join(withTests, 'tests'), { recursive: true });
+    mkdirSync(join(withTests, '.github', 'workflows'), { recursive: true });
+    for (let i = 0; i < 20; i++) writeFileSync(join(withTests, 'src', `mod${i}.py`), `def f${i}(x):\n    return x * ${i}\n`);
+    for (let i = 0; i < 10; i++) writeFileSync(join(withTests, 'tests', `test_${i}.py`), `def test_${i}():\n    assert True\n`);
+    writeFileSync(join(withTests, '.github', 'workflows', 'ci.yml'), 'name: ci\non: [push]\njobs:\n  t:\n    runs-on: ubuntu-latest\n    steps:\n      - run: pytest\n');
+    writeFileSync(join(withTests, 'README.md'), '# bare\nA Python data-processing service with a REST API and a worker queue.\n');
+    writeFileSync(join(withTests, 'package.json'), JSON.stringify({ name: 'bare-proj', scripts: { test: 'pytest' } }));
+  });
+  afterAll(() => {
+    for (const d of [empty, real, bare, withTests]) rmSync(d, { recursive: true, force: true });
+  });
+
+  it('a real project with source/tests/CI outscores an empty dir on task coverage', () => {
+    const realCov = buildRepoScorecard(real, 'x').taskCoverage;
+    // empty is refused by the CLI, but the pure function still scores it — it must be ~0
+    const emptyCov = buildRepoScorecard(empty, 'x').taskCoverage;
+    expect(emptyCov).toBeLessThan(realCov);
+    expect(emptyCov).toBeLessThanOrEqual(5);
+  });
+
+  it('adding tests + CI never LOWERS task coverage', () => {
+    const before = buildRepoScorecard(bare, 'x').taskCoverage;
+    const after = buildRepoScorecard(withTests, 'x').taskCoverage;
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  it('the CLI refuses an empty directory instead of emitting a scorecard', async () => {
+    const r = await scoreRepoCmd([empty]);
+    expect(r.code).toBe(2);
+    expect(r.lines.join('\n')).toMatch(/[Nn]othing to score/);
+  });
+
+  it('--json refusal for an empty directory carries the empty-repo error code', async () => {
+    const r = await scoreRepoCmd([empty, '--json']);
+    expect(r.code).toBe(2);
+    expect(JSON.parse(r.lines.join('\n')).error).toBe('empty-repo');
+  });
+});
+
 describe('formatRepoScorecard', () => {
   it('renders the 6-line card', () => {
     const lines = formatRepoScorecard(buildRepoScorecard(repo, 'x'));

--- a/packages/create-agent-harness/src/repo-scorecard.ts
+++ b/packages/create-agent-harness/src/repo-scorecard.ts
@@ -74,10 +74,22 @@ export function buildRepoScorecard(dir: string, generatedAt: string = new Date()
       (profile.hasCi ? 10 : 0),
   );
 
-  // Task coverage — how much inferred work the recommended agents/skills/commands
-  // span, tempered by how much repo signal (tokens) we actually observed.
-  const surface = plan.agents.length + plan.skills.length + plan.commands.length;
-  const taskCoverage = clamp100(Math.min(surface, 10) * 7 + Math.min(profile.tokens.length, 20) * 1.5);
+  // Task coverage — how much observable work surface THIS REPO presents for a
+  // harness to cover. Derived from real repo signals only (#171): the previous
+  // formula multiplied the chosen archetype's plan size (a constant per
+  // template), so an empty dir that fell through to a larger fallback plan
+  // outscored a real project mapped to a smaller one, and adding tests/CI could
+  // LOWER the score by switching templates. Grounding it in repo signals makes
+  // it monotonic in the repo — more code, tests, CI, and docs never lower it.
+  const hasDocs = Object.keys(files).some((f) => /(^|\/)readme|\.md$/i.test(f));
+  const taskCoverage = clamp100(
+    Math.min(profile.tokens.length, 30) * 2 + // repo work-vocabulary breadth (0-60)
+      (profile.languages.length ? 12 : 0) + // a detected implementation language
+      (profile.testCommands.length ? 12 : 0) + // tests define coverable work
+      (profile.buildCommands.length ? 8 : 0) + // a build step to wire around
+      (profile.hasCi ? 8 : 0) + // CI to hook into
+      (hasDocs ? 6 : 0), // docs describing the work
+  );
 
   // Tool safety — the default-deny policy posture, minus MCP exposure.
   const p = plan.policy;
@@ -240,6 +252,13 @@ export async function scoreRepoCmd(args: string[]): Promise<SubcommandResult> {
   const dir = resolve(positional[0]!);
   const showConstraints = args.includes('--constraints');
   try {
+    // #171 — a directory with no inventoried signal is not scoreable. Refuse
+    // rather than emit a full scorecard, recommended archetype, and cost
+    // estimate for a repo that isn't there.
+    if (Object.keys(inventory(dir)).length === 0) {
+      const err = { schema: 1 as const, error: 'empty-repo', detail: 'no scoreable files found in target directory', exitCode: 2 };
+      return { code: 2, lines: [json ? JSON.stringify(err, null, 2) : `Nothing to score: no scoreable files found in ${dir}`] };
+    }
     if (showConstraints) {
       const { repo, results } = repoConstraints(dir);
       const s = summarise(results);


### PR DESCRIPTION
## Summary

Fixes #171. `taskCoverage` was computed from `surface = plan.agents.length + plan.skills.length + plan.commands.length` — a **constant per archetype template**, not a property of the repo. So an empty directory that fell through to a larger fallback plan scored **49** and beat a real project mapped to a smaller devops plan at **35**, and adding 15 test files + 20 CI workflows could *lower* the score by switching which template was selected.

### Fix

Rebuilt `taskCoverage` from real repo signals only, so it is monotonic in the repo — more code, tests, CI, and docs never lower it, and the chosen template no longer enters the metric:

```
min(tokens,30)*2  +  lang?12  +  tests?12  +  build?8  +  ci?8  +  docs?6
```

| input | old taskCoverage | new taskCoverage |
|---|---|---|
| empty dir | 49 | **0** (and now refused, see below) |
| full project (20 src + 10 tests + CI + README + package.json) | 35–70 depending on template | **82** |

The inversion (empty **49** > real **35**) is gone; adding tests/CI now only ever raises the score.

### Empty-directory refusal

Per the issue's second point, `metaharness score` on a directory with no inventoried files now **refuses** (exit 2, `error: "empty-repo"` in `--json`) instead of emitting a full scorecard, recommended archetype, and cost estimate for a repo that isn't there. Directories that *do* have files (e.g. 40 `.py` with no tests) are still scored — honestly, and lower.

## Verification

- New tests reproduce the issue's exact scenario (20 `.py` + 10 tests + CI + README + package.json) and assert: empty < real, adding tests/CI never lowers coverage, and the CLI refuses an empty dir (text + `--json`)
- `create-agent-harness` suite green: 16 scorecard tests, 375 package tests

Ships in the `metaharness` CLI package.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)