### PR TITLE
release: metaharness 0.4.7 — score taskCoverage fix (#171)

### DIFF
--- a/packages/create-agent-harness/package.json
+++ b/packages/create-agent-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metaharness",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "MetaHarness — mint a custom AI agent harness from any repo. Browser Studio + `npx metaharness` CLI. Runs on Claude Code, Codex, pi.dev, Hermes, OpenClaw, RVM, Prime Agent.",
   "homepage": "https://github.com/ruvnet/agent-harness-generator",
   "repository": {


### PR DESCRIPTION
Version bump for the #171 fix (merged in #196): `taskCoverage` now measures the repo from real signals instead of the recommended template's plan size, and `score` refuses an empty directory.

Published to npm as `metaharness@0.4.7`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)