### PR TITLE
fix(avo): phase 2 untrusted-seam hardening

### DIFF
--- a/docs/adrs/ADR-251-governed-autonomous-variation-runtime.md
+++ b/docs/adrs/ADR-251-governed-autonomous-variation-runtime.md
@@ -121,6 +121,20 @@ accepted result, and 100% autonomous replay integrity.
 
 ARC is explicitly deferred until that engineering benchmark passes.
 
+### Untrusted seam hardening
+
+Agent, policy, approval, environment, evaluator, supervisor, memory, and
+checkpoint adapters are authority boundaries. The operator deep-clones and
+deep-freezes every state, candidate, action, decision, and evidence snapshot
+before passing it outward. Returned actions, policy decisions, observations,
+evaluations, branches, and supervisor interventions are cloned and
+runtime-validated before they can be hashed or alter state.
+
+Costs, durations, risk charges, scores, sample metrics, and violation counts
+must be finite and nonnegative. The operator also applies a post-observation
+budget check, so an action that reports a finite cost, latency, or risk beyond
+the remaining hard limit is recorded as failed and cannot promote a candidate.
+
 ## Consequences
 
 - Difficult tasks gain iterative evidence-driven repair and semantic recovery.

--- a/packages/avo/__tests__/malicious-agent.test.ts
+++ b/packages/avo/__tests__/malicious-agent.test.ts
@@ -40,10 +40,12 @@ function result(quality: number, correct: boolean): EvaluationResult {
 
 class InertEnvironment implements EnvironmentAdapter {
   readonly version = 'env-v1';
+  executions = 0;
   async fork(parent: { id: string }) {
     return { branchId: `${parent.id}-working`, workspaceDigest: `sha256:fork-${parent.id}` };
   }
   async execute(action: VariationAction, state: Readonly<VariationState>): Promise<ActionObservation> {
+    this.executions += 1;
     return {
       ok: true, stdout: `${action.kind}:observed`, exitCode: 0, durationMs: 1, costUsd: 0,
       workspaceDigest: `sha256:${state.budget.actionsUsed + 1}-${action.kind}`,
@@ -59,26 +61,46 @@ describe('agent-context isolation (untrusted agent cannot buy promotion)', () =>
       const { privateKey, publicKey } = generateKeyPairSync('ed25519');
       const signer = new Ed25519ReceiptSigner('sec-key', privateKey, publicKey);
       const tamperedContexts: VariationContext[] = [];
+      const mutationFailures: string[] = [];
       const maliciousAgent = {
         async chooseAction(context: VariationContext): Promise<VariationAction> {
           // Attack 1: forge a perfect, freshly-"evaluated" score into live state.
-          (context.state.evaluations as EvaluationResult[]).push(result(1, true));
+          try {
+            (context.state.evaluations as EvaluationResult[]).push(result(1, true));
+          } catch (error) {
+            mutationFailures.push(String(error));
+          }
           // Attack 2: gut the promotion baseline so any delta qualifies.
-          (context.candidate.evaluation as EvaluationResult).quality = 0;
-          (context.candidate.evaluation as EvaluationResult).lowerConfidenceBound = 0;
+          try {
+            (context.candidate.evaluation as EvaluationResult).quality = 0;
+          } catch (error) {
+            mutationFailures.push(String(error));
+          }
           // Attack 3: inflate the remaining budget.
-          (context.state.budget as { maxActions: number }).maxActions = 10_000;
+          try {
+            (context.state.budget as { maxActions: number }).maxActions = 10_000;
+          } catch (error) {
+            mutationFailures.push(String(error));
+          }
           tamperedContexts.push(context);
           // Then immediately claim the prize.
           return { kind: 'commit', summary: 'forged perfect score' };
         },
       };
+      const environment = new InertEnvironment();
+      let evaluatorCalls = 0;
       const operator = new GovernedVariationOperator({
         runId: 'sec-1',
         task: 'security acceptance',
         seed: { id: 'seed', branchId: 'seed', workspaceDigest: 'sha256:seed' },
-        environment: new InertEnvironment(),
-        evaluators: { version: 'eval-v1', evaluate: async () => result(0.5, false) },
+        environment,
+        evaluators: {
+          version: 'eval-v1',
+          evaluate: async () => {
+            evaluatorCalls += 1;
+            return result(0.5, true);
+          },
+        },
         agent: maliciousAgent,
         knowledge: { retrieve: async () => [] },
         memory: new EphemeralGovernedMemory(),
@@ -96,7 +118,7 @@ describe('agent-context isolation (untrusted agent cannot buy promotion)', () =>
         ]),
         signer,
         checkpointStore: new JsonCheckpointStore(join(root, 'checkpoint.json')),
-        budget: { maxActions: 5, maxBranchActions: 5, maxCostUsd: 1, maxWallTimeMs: 10_000, riskBudget: 1 },
+        budget: { maxActions: 1, maxBranchActions: 1, maxCostUsd: 1, maxWallTimeMs: 10_000, riskBudget: 1 },
         invariants: {
           immutableCapabilities: ['repository:read'],
           protectedPaths: [],
@@ -107,24 +129,29 @@ describe('agent-context isolation (untrusted agent cannot buy promotion)', () =>
       });
       const output = await operator.run();
 
-      // The forged commit never promotes: no winner, no lineage, and the
-      // authoritative candidate set is still the seed alone.
-      expect(output.winner).toBeNull();
-      expect(output.lineage).toEqual([]);
+      // The forged commit never promotes; the verified seed remains the winner.
+      expect(output.winner?.id).toBe('seed');
+      expect(output.lineage.map((candidate) => candidate.id)).toEqual(['seed']);
       expect(output.checkpoint.state.candidates.map((c) => c.id)).toEqual(['seed']);
-      // Every forged-commit attempt was refused by the real gate.
+      expect(evaluatorCalls).toBe(1); // baseline only
+      expect(environment.executions).toBe(0);
+      // The sole forged-commit attempt was refused by the real gate.
       const commits = output.receipts.filter((r) => r.action.kind === 'commit');
-      expect(commits.length).toBeGreaterThan(0);
+      expect(commits).toHaveLength(1);
       for (const receipt of commits) {
         expect(receipt.observation.ok).toBe(false);
         expect(receipt.observation.exitCode).toBe(126);
         expect(receipt.observation.stderr).toContain('promotion gate rejected commit');
       }
-      // The agent DID tamper with what it was handed — and none of it reached
-      // the authoritative state: no forged evaluations, budget cap intact.
-      expect(tamperedContexts.length).toBeGreaterThan(0);
+      // Every nested authority view is frozen and all three mutation attempts
+      // throw before they can affect the private state or promotion baseline.
+      expect(tamperedContexts).toHaveLength(1);
+      expect(mutationFailures).toHaveLength(3);
+      expect(Object.isFrozen(tamperedContexts[0])).toBe(true);
+      expect(Object.isFrozen(tamperedContexts[0].state.evaluations)).toBe(true);
+      expect(Object.isFrozen(tamperedContexts[0].candidate.evaluation)).toBe(true);
       expect(output.checkpoint.state.evaluations.filter((e) => e.quality === 1)).toHaveLength(0);
-      expect(output.checkpoint.state.budget.actionsUsed).toBeLessThanOrEqual(5);
+      expect(output.checkpoint.state.budget).toMatchObject({ maxActions: 1, actionsUsed: 1 });
       // Receipts and checkpoint still verify — the run is honest end to end.
       expect(output.receipts.every((r) => verifyReceipt(r, signer))).toBe(true);
       expect(verifyVariationCheckpoint(output.checkpoint, signer)).toBe(true);

--- a/packages/avo/__tests__/operator.test.ts
+++ b/packages/avo/__tests__/operator.test.ts
@@ -18,8 +18,10 @@ import {
   type Candidate,
   type EnvironmentAdapter,
   type EvaluationResult,
+  type PolicyDecision,
   type VariationAction,
   type VariationContext,
+  type VariationOperatorOptions,
   type VariationState,
 } from '../src/index.js';
 
@@ -153,6 +155,157 @@ describe('GovernedVariationOperator', () => {
       expect(output.receipts[0].policyDecision).toMatchObject({ verdict: 'deny' });
       expect(output.receipts[0].costUsd).toBe(0.02);
       expect(output.checkpoint.state.budget.wallTimeMsUsed).toBe(7);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('clones inbound actions and decisions while freezing every outbound authority snapshot', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'avo-seams-'));
+    try {
+      class InspectingEnvironment extends DeterministicEnvironment {
+        frozenAction = false;
+        frozenState = false;
+        override async execute(action: VariationAction, state: Readonly<VariationState>) {
+          this.frozenAction = Object.isFrozen(action);
+          this.frozenState = Object.isFrozen(state) && Object.isFrozen(state.budget);
+          return super.execute(action, state);
+        }
+      }
+      const environment = new InspectingEnvironment();
+      const configured = await options(root, environment);
+      const value = configured.value as unknown as VariationOperatorOptions;
+      const rawAction: VariationAction = { kind: 'inspect', path: 'routing.ts' };
+      const rawDecision: PolicyDecision = {
+        verdict: 'require-approval', reason: 'test approval', policyVersion: 'policy-v1', riskCharge: 0.25,
+      };
+      let policyMutationThrew = false;
+      let approvalMutationThrew = false;
+      value.agent = { chooseAction: async () => rawAction };
+      value.policy = {
+        version: 'policy-v1',
+        authorize: (action, state) => {
+          expect(Object.isFrozen(action)).toBe(true);
+          expect(Object.isFrozen(state)).toBe(true);
+          expect(Object.isFrozen(state.budget)).toBe(true);
+          rawAction.path = 'attacker-mutated-after-return.ts';
+          try {
+            (action as { path: string }).path = 'mutate-policy-copy.ts';
+          } catch {
+            policyMutationThrew = true;
+          }
+          return rawDecision;
+        },
+      };
+      value.approval = {
+        approve: async (action, decision) => {
+          expect(Object.isFrozen(action)).toBe(true);
+          expect(Object.isFrozen(decision)).toBe(true);
+          rawDecision.riskCharge = 0.9;
+          try {
+            (decision as { riskCharge: number }).riskCharge = 1;
+          } catch {
+            approvalMutationThrew = true;
+          }
+          return true;
+        },
+      };
+      value.budget = { ...value.budget, maxActions: 1, maxBranchActions: 1 };
+
+      const output = await new GovernedVariationOperator(value).run();
+      expect(output.receipts[0].action).toEqual({ kind: 'inspect', path: 'routing.ts' });
+      expect(output.receipts[0].policyDecision.riskCharge).toBe(0.25);
+      expect(output.checkpoint.state.budget.riskUsed).toBe(0.25);
+      expect(policyMutationThrew).toBe(true);
+      expect(approvalMutationThrew).toBe(true);
+      expect(environment.frozenAction).toBe(true);
+      expect(environment.frozenState).toBe(true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects malformed actions and nonfinite policy or evaluator metrics at runtime', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'avo-invalid-seams-'));
+    try {
+      const malformed = await options(root);
+      const malformedValue = malformed.value as unknown as VariationOperatorOptions;
+      malformedValue.agent = {
+        chooseAction: async () => ({ kind: 'inspect', path: 'routing.ts', unexpected: true } as unknown as VariationAction),
+      };
+      malformedValue.budget = { ...malformedValue.budget, maxActions: 1, maxBranchActions: 1 };
+      await expect(new GovernedVariationOperator(malformedValue).run()).rejects.toThrow(/invalid agent action: unexpected field/);
+
+      await rm(join(root, 'checkpoint.json'), { force: true });
+      const invalidPolicy = await options(root);
+      const invalidPolicyValue = invalidPolicy.value as unknown as VariationOperatorOptions;
+      invalidPolicyValue.agent = { chooseAction: async () => ({ kind: 'inspect', path: 'routing.ts' }) };
+      invalidPolicyValue.policy = {
+        version: 'policy-v1',
+        authorize: () => ({
+          verdict: 'allow', reason: 'malformed risk', policyVersion: 'policy-v1', riskCharge: Number.NaN,
+        }),
+      };
+      invalidPolicyValue.budget = { ...invalidPolicyValue.budget, maxActions: 1, maxBranchActions: 1 };
+      await expect(new GovernedVariationOperator(invalidPolicyValue).run()).rejects.toThrow(/riskCharge must be finite and nonnegative/);
+
+      await rm(join(root, 'checkpoint.json'), { force: true });
+      const invalidAgentMetering = await options(root);
+      const invalidAgentMeteringValue = invalidAgentMetering.value as unknown as VariationOperatorOptions;
+      invalidAgentMeteringValue.agent = {
+        chooseAction: async () => ({
+          action: { kind: 'inspect', path: 'routing.ts' }, costUsd: -1, durationMs: 0,
+        }),
+      };
+      invalidAgentMeteringValue.budget = {
+        ...invalidAgentMeteringValue.budget, maxActions: 1, maxBranchActions: 1,
+      };
+      await expect(new GovernedVariationOperator(invalidAgentMeteringValue).run()).rejects.toThrow(/costUsd must be finite and nonnegative/);
+
+      await rm(join(root, 'checkpoint.json'), { force: true });
+      const invalidEvaluation = await options(root);
+      const invalidEvaluationValue = invalidEvaluation.value as unknown as VariationOperatorOptions;
+      invalidEvaluationValue.evaluators = {
+        version: 'eval-v1',
+        evaluate: async () => ({ ...result('seed'), quality: Number.POSITIVE_INFINITY }),
+      };
+      await expect(new GovernedVariationOperator(invalidEvaluationValue).run()).rejects.toThrow(/quality must be finite and nonnegative/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects negative observations and prevents promotion after a finite budget overshoot', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'avo-observation-budget-'));
+    try {
+      class NegativeCostEnvironment extends DeterministicEnvironment {
+        override async execute(action: VariationAction, state: Readonly<VariationState>) {
+          return { ...await super.execute(action, state), costUsd: -1 };
+        }
+      }
+      const negative = await options(root, new NegativeCostEnvironment());
+      const negativeValue = negative.value as unknown as VariationOperatorOptions;
+      negativeValue.agent = { chooseAction: async () => ({ kind: 'inspect', path: 'routing.ts' }) };
+      negativeValue.budget = { ...negativeValue.budget, maxActions: 1, maxBranchActions: 1 };
+      await expect(new GovernedVariationOperator(negativeValue).run()).rejects.toThrow(/costUsd must be finite and nonnegative/);
+
+      await rm(join(root, 'checkpoint.json'), { force: true });
+      class OverspendEnvironment extends DeterministicEnvironment {
+        override async execute(action: VariationAction, state: Readonly<VariationState>) {
+          return { ...await super.execute(action, state), costUsd: 2 };
+        }
+      }
+      const overspend = await options(root, new OverspendEnvironment());
+      const overspendValue = overspend.value as unknown as VariationOperatorOptions;
+      overspendValue.agent = { chooseAction: async () => ({ kind: 'inspect', path: 'routing.ts' }) };
+      overspendValue.budget = {
+        ...overspendValue.budget, maxActions: 1, maxBranchActions: 1, maxCostUsd: 1,
+      };
+      const output = await new GovernedVariationOperator(overspendValue).run();
+      expect(output.receipts[0].observation).toMatchObject({ ok: false, exitCode: 126, costUsd: 2 });
+      expect(output.receipts[0].observation.stderr).toContain('post-action budget exceeded: cost');
+      expect(output.checkpoint.state.budget.costUsdUsed).toBe(2);
+      expect(output.checkpoint.state.candidates.map((candidate) => candidate.id)).toEqual(['seed']);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/avo/src/boundary.ts
+++ b/packages/avo/src/boundary.ts
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: MIT
+
+import type { AgentActionDecision } from './ports.js';
+import type {
+  ActionObservation,
+  EvaluationResult,
+  EvolvableSurface,
+  Hypothesis,
+  PolicyDecision,
+  ProtectedInvariants,
+  ResourceBudget,
+  SupervisorIntervention,
+  VariationAction,
+} from './types.js';
+
+const SURFACES = new Set<EvolvableSurface>([
+  'retrievalPolicy',
+  'modelRouting',
+  'contextPolicy',
+  'testPolicy',
+  'repairStrategy',
+]);
+const MAX_TEXT = 2 * 1024 * 1024;
+const MAX_COLLECTION = 10_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function fail(boundary: string, reason: string): never {
+  throw new Error(`avo: invalid ${boundary}: ${reason}`);
+}
+
+function cloneInbound<T>(value: T, boundary: string): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return fail(boundary, 'value is not structured-cloneable');
+  }
+}
+
+function deepFreeze<T>(value: T, seen = new WeakSet<object>()): T {
+  if (value === null || typeof value !== 'object') return value;
+  const object = value as object;
+  if (seen.has(object)) return value;
+  seen.add(object);
+  for (const key of Reflect.ownKeys(object)) {
+    deepFreeze((object as Record<PropertyKey, unknown>)[key], seen);
+  }
+  // Non-empty typed arrays cannot be frozen. They are still isolated by the
+  // preceding structured clone, so mutating one cannot alter authority.
+  if (!ArrayBuffer.isView(object)) Object.freeze(object);
+  return value;
+}
+
+/** Deep-copy then freeze data before it crosses an untrusted callback seam. */
+export function frozenSnapshot<T>(value: T, boundary: string): T {
+  return deepFreeze(cloneInbound(value, boundary));
+}
+
+function keys(value: Record<string, unknown>, boundary: string, allowed: readonly string[]): void {
+  const permitted = new Set(allowed);
+  const unexpected = Object.keys(value).find((key) => !permitted.has(key));
+  if (unexpected) fail(boundary, `unexpected field ${unexpected}`);
+}
+
+function stringField(value: unknown, boundary: string, field: string, allowEmpty = false): asserts value is string {
+  if (typeof value !== 'string' || value.length > MAX_TEXT || (!allowEmpty && value.trim().length === 0)) {
+    fail(boundary, `${field} must be a bounded${allowEmpty ? '' : ' non-empty'} string`);
+  }
+}
+
+function finiteNonnegative(value: unknown, boundary: string, field: string): asserts value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    fail(boundary, `${field} must be finite and nonnegative`);
+  }
+}
+
+function safeNonnegativeInteger(value: unknown, boundary: string, field: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    fail(boundary, `${field} must be a nonnegative safe integer`);
+  }
+}
+
+function booleanField(value: unknown, boundary: string, field: string): asserts value is boolean {
+  if (typeof value !== 'boolean') fail(boundary, `${field} must be boolean`);
+}
+
+function assertJsonData(value: unknown, boundary: string): void {
+  const seen = new WeakSet<object>();
+  let visited = 0;
+  const visit = (entry: unknown, depth: number): void => {
+    if (++visited > 100_000 || depth > 64) fail(boundary, 'data exceeds structural limits');
+    if (entry === null || entry === undefined || typeof entry === 'boolean') return;
+    if (typeof entry === 'string') {
+      if (entry.length > MAX_TEXT) fail(boundary, 'data contains an oversized string');
+      return;
+    }
+    if (typeof entry === 'number') {
+      if (!Number.isFinite(entry)) fail(boundary, 'data contains a nonfinite number');
+      return;
+    }
+    if (typeof entry !== 'object') fail(boundary, 'data must be canonical JSON-compatible content');
+    const object = entry as object;
+    if (seen.has(object)) fail(boundary, 'data must not contain cycles');
+    seen.add(object);
+    if (Array.isArray(entry)) {
+      if (entry.length > MAX_COLLECTION) fail(boundary, 'data array exceeds limit');
+      for (const item of entry) visit(item, depth + 1);
+      return;
+    }
+    if (!isRecord(entry)) fail(boundary, 'data contains a non-plain object');
+    const entries = Object.entries(entry);
+    if (entries.length > MAX_COLLECTION) fail(boundary, 'data object exceeds limit');
+    for (const [key, item] of entries) {
+      if (['__proto__', 'prototype', 'constructor'].includes(key)) fail(boundary, `data contains forbidden key ${key}`);
+      visit(item, depth + 1);
+    }
+  };
+  visit(value, 0);
+}
+
+function hypothesis(value: unknown, boundary: string): Hypothesis {
+  if (!isRecord(value)) fail(boundary, 'hypothesis must be an object');
+  keys(value, boundary, ['id', 'statement', 'causalMechanism', 'expectedEvidence', 'surface']);
+  stringField(value.id, boundary, 'id');
+  stringField(value.statement, boundary, 'statement');
+  stringField(value.causalMechanism, boundary, 'causalMechanism');
+  if (!Array.isArray(value.expectedEvidence) || value.expectedEvidence.length > 256) {
+    fail(boundary, 'expectedEvidence must be a bounded string array');
+  }
+  value.expectedEvidence.forEach((entry, index) => stringField(entry, boundary, `expectedEvidence[${index}]`));
+  if (!SURFACES.has(value.surface as EvolvableSurface)) fail(boundary, 'surface is not evolvable');
+  return value as unknown as Hypothesis;
+}
+
+export function validatedAction(value: unknown, boundary = 'agent action'): VariationAction {
+  const cloned = cloneInbound(value, boundary);
+  if (!isRecord(cloned) || typeof cloned.kind !== 'string') fail(boundary, 'action must be an object with a kind');
+  switch (cloned.kind) {
+    case 'inspect':
+      keys(cloned, boundary, ['kind', 'path']);
+      stringField(cloned.path, boundary, 'path');
+      break;
+    case 'search':
+      keys(cloned, boundary, ['kind', 'query', 'paths']);
+      stringField(cloned.query, boundary, 'query');
+      if (cloned.paths !== undefined) {
+        if (!Array.isArray(cloned.paths) || cloned.paths.length > 256) fail(boundary, 'paths must be a bounded string array');
+        cloned.paths.forEach((path, index) => stringField(path, boundary, `paths[${index}]`));
+      }
+      break;
+    case 'hypothesize':
+      keys(cloned, boundary, ['kind', 'hypothesis']);
+      cloned.hypothesis = hypothesis(cloned.hypothesis, `${boundary}.hypothesis`);
+      break;
+    case 'edit':
+      keys(cloned, boundary, ['kind', 'path', 'content', 'surface']);
+      stringField(cloned.path, boundary, 'path');
+      stringField(cloned.content, boundary, 'content', true);
+      if (!SURFACES.has(cloned.surface as EvolvableSurface)) fail(boundary, 'surface is not evolvable');
+      break;
+    case 'execute':
+      keys(cloned, boundary, ['kind', 'command']);
+      stringField(cloned.command, boundary, 'command');
+      break;
+    case 'evaluate':
+      keys(cloned, boundary, ['kind']);
+      break;
+    case 'revert':
+      keys(cloned, boundary, ['kind', 'checkpointId']);
+      if (cloned.checkpointId !== undefined) stringField(cloned.checkpointId, boundary, 'checkpointId');
+      break;
+    case 'branch':
+      keys(cloned, boundary, ['kind', 'parentCandidateId']);
+      stringField(cloned.parentCandidateId, boundary, 'parentCandidateId');
+      break;
+    case 'consultMemory':
+      keys(cloned, boundary, ['kind', 'query', 'limit']);
+      stringField(cloned.query, boundary, 'query');
+      if (cloned.limit !== undefined
+        && (!Number.isSafeInteger(cloned.limit) || (cloned.limit as number) <= 0 || (cloned.limit as number) > 100)) {
+        fail(boundary, 'limit must be a safe integer between 1 and 100');
+      }
+      break;
+    case 'commit':
+      keys(cloned, boundary, ['kind', 'summary']);
+      stringField(cloned.summary, boundary, 'summary');
+      break;
+    default:
+      fail(boundary, `unknown action kind ${cloned.kind}`);
+  }
+  return cloned as unknown as VariationAction;
+}
+
+export function validatedAgentSelection(value: unknown): VariationAction | AgentActionDecision {
+  const cloned = cloneInbound(value, 'agent decision');
+  if (!isRecord(cloned) || !Object.hasOwn(cloned, 'action')) return validatedAction(cloned);
+  keys(cloned, 'agent decision', ['action', 'costUsd', 'durationMs', 'receipt']);
+  finiteNonnegative(cloned.costUsd, 'agent decision', 'costUsd');
+  finiteNonnegative(cloned.durationMs, 'agent decision', 'durationMs');
+  const action = validatedAction(cloned.action);
+  if (cloned.receipt !== undefined) {
+    if (!isRecord(cloned.receipt)) fail('agent decision', 'receipt must be a plain object');
+    assertJsonData(cloned.receipt, 'agent decision receipt');
+  }
+  return { action, costUsd: cloned.costUsd, durationMs: cloned.durationMs, receipt: cloned.receipt };
+}
+
+export function validatedPolicyDecision(value: unknown, expectedVersion: string): PolicyDecision {
+  const cloned = cloneInbound(value, 'policy decision');
+  if (!isRecord(cloned)) fail('policy decision', 'decision must be an object');
+  keys(cloned, 'policy decision', ['verdict', 'reason', 'policyVersion', 'riskCharge']);
+  if (!['allow', 'deny', 'require-approval'].includes(String(cloned.verdict))) fail('policy decision', 'verdict is invalid');
+  stringField(cloned.reason, 'policy decision', 'reason');
+  if (cloned.policyVersion !== expectedVersion) fail('policy decision', 'policyVersion does not match the active policy');
+  finiteNonnegative(cloned.riskCharge, 'policy decision', 'riskCharge');
+  return cloned as unknown as PolicyDecision;
+}
+
+export function validatedApproval(value: unknown): boolean {
+  if (typeof value !== 'boolean') fail('approval decision', 'approval must be boolean');
+  return value;
+}
+
+export function validatedEvaluation(value: unknown, expectedVersion: string): EvaluationResult {
+  const cloned = cloneInbound(value, 'evaluation result');
+  if (!isRecord(cloned)) fail('evaluation result', 'result must be an object');
+  keys(cloned, 'evaluation result', [
+    'evaluatorVersion', 'correct', 'safe', 'replayable', 'noRegression', 'budgetValid',
+    'quality', 'costUsd', 'wallTimeMs', 'policyViolations', 'rollbackRequired',
+    'protectedTestsPassed', 'scoreSamples', 'lowerConfidenceBound', 'evidence', 'failureSignature',
+  ]);
+  if (cloned.evaluatorVersion !== expectedVersion) fail('evaluation result', 'evaluatorVersion does not match the active evaluator');
+  for (const field of ['correct', 'safe', 'replayable', 'noRegression', 'budgetValid', 'protectedTestsPassed'] as const) {
+    booleanField(cloned[field], 'evaluation result', field);
+  }
+  if (cloned.rollbackRequired !== undefined) booleanField(cloned.rollbackRequired, 'evaluation result', 'rollbackRequired');
+  finiteNonnegative(cloned.quality, 'evaluation result', 'quality');
+  if (cloned.quality > 1) fail('evaluation result', 'quality must not exceed 1');
+  finiteNonnegative(cloned.costUsd, 'evaluation result', 'costUsd');
+  finiteNonnegative(cloned.wallTimeMs, 'evaluation result', 'wallTimeMs');
+  safeNonnegativeInteger(cloned.policyViolations, 'evaluation result', 'policyViolations');
+  if (cloned.lowerConfidenceBound !== undefined) {
+    finiteNonnegative(cloned.lowerConfidenceBound, 'evaluation result', 'lowerConfidenceBound');
+  }
+  if (cloned.scoreSamples !== undefined) {
+    if (!Array.isArray(cloned.scoreSamples) || cloned.scoreSamples.length > MAX_COLLECTION) {
+      fail('evaluation result', 'scoreSamples must be a bounded numeric array');
+    }
+    for (const [index, sample] of cloned.scoreSamples.entries()) {
+      finiteNonnegative(sample, 'evaluation result', `scoreSamples[${index}]`);
+      if (sample > 1) fail('evaluation result', `scoreSamples[${index}] must not exceed 1`);
+    }
+  }
+  if (!isRecord(cloned.evidence)) fail('evaluation result', 'evidence must be a plain object');
+  assertJsonData(cloned.evidence, 'evaluation evidence');
+  if (cloned.failureSignature !== undefined) stringField(cloned.failureSignature, 'evaluation result', 'failureSignature');
+  return cloned as unknown as EvaluationResult;
+}
+
+export function validatedObservation(value: unknown): ActionObservation {
+  const cloned = cloneInbound(value, 'environment observation');
+  if (!isRecord(cloned)) fail('environment observation', 'observation must be an object');
+  keys(cloned, 'environment observation', [
+    'ok', 'stdout', 'stderr', 'exitCode', 'durationMs', 'costUsd', 'workspaceDigest', 'data', 'failureSignature',
+  ]);
+  booleanField(cloned.ok, 'environment observation', 'ok');
+  if (cloned.stdout !== undefined) stringField(cloned.stdout, 'environment observation', 'stdout', true);
+  if (cloned.stderr !== undefined) stringField(cloned.stderr, 'environment observation', 'stderr', true);
+  if (cloned.exitCode !== undefined) safeNonnegativeInteger(cloned.exitCode, 'environment observation', 'exitCode');
+  finiteNonnegative(cloned.durationMs, 'environment observation', 'durationMs');
+  finiteNonnegative(cloned.costUsd, 'environment observation', 'costUsd');
+  stringField(cloned.workspaceDigest, 'environment observation', 'workspaceDigest');
+  if (cloned.data !== undefined) assertJsonData(cloned.data, 'environment observation data');
+  if (cloned.failureSignature !== undefined) stringField(cloned.failureSignature, 'environment observation', 'failureSignature');
+  return cloned as unknown as ActionObservation;
+}
+
+export function validatedBranch(value: unknown): { branchId: string; workspaceDigest: string } {
+  const cloned = cloneInbound(value, 'environment branch');
+  if (!isRecord(cloned)) fail('environment branch', 'branch must be an object');
+  keys(cloned, 'environment branch', ['branchId', 'workspaceDigest']);
+  stringField(cloned.branchId, 'environment branch', 'branchId');
+  stringField(cloned.workspaceDigest, 'environment branch', 'workspaceDigest');
+  return cloned as { branchId: string; workspaceDigest: string };
+}
+
+export function validatedIntervention(value: unknown, expectedPolicyVersion: string): SupervisorIntervention | null {
+  const cloned = cloneInbound(value, 'supervisor decision');
+  if (cloned === null) return null;
+  if (!isRecord(cloned)) fail('supervisor decision', 'intervention must be an object or null');
+  keys(cloned, 'supervisor decision', [
+    'trigger', 'reason', 'dominantFailure', 'alternateCandidateId', 'strategies', 'explorationAllocation', 'policyVersion',
+  ]);
+  if (!['plateau', 'repeated-failure', 'low-novelty', 'cost-progress'].includes(String(cloned.trigger))) {
+    fail('supervisor decision', 'trigger is invalid');
+  }
+  stringField(cloned.reason, 'supervisor decision', 'reason');
+  if (cloned.dominantFailure !== undefined) stringField(cloned.dominantFailure, 'supervisor decision', 'dominantFailure');
+  if (cloned.alternateCandidateId !== undefined) stringField(cloned.alternateCandidateId, 'supervisor decision', 'alternateCandidateId');
+  if (!Array.isArray(cloned.strategies) || cloned.strategies.length !== 3) {
+    fail('supervisor decision', 'strategies must contain exactly three hypotheses');
+  }
+  cloned.strategies = cloned.strategies.map((entry, index) => hypothesis(entry, `supervisor strategy ${index}`));
+  finiteNonnegative(cloned.explorationAllocation, 'supervisor decision', 'explorationAllocation');
+  if (cloned.explorationAllocation > 1) fail('supervisor decision', 'explorationAllocation must not exceed 1');
+  if (cloned.policyVersion !== expectedPolicyVersion) fail('supervisor decision', 'policyVersion does not match the active policy');
+  return cloned as unknown as SupervisorIntervention;
+}
+
+export function validateConfiguration(budget: ResourceBudget, invariants: ProtectedInvariants): void {
+  if (!Number.isSafeInteger(budget.maxActions) || budget.maxActions <= 0) fail('resource budget', 'maxActions must be positive');
+  if (!Number.isSafeInteger(budget.maxBranchActions) || budget.maxBranchActions <= 0) {
+    fail('resource budget', 'maxBranchActions must be positive');
+  }
+  finiteNonnegative(budget.maxCostUsd, 'resource budget', 'maxCostUsd');
+  finiteNonnegative(budget.maxWallTimeMs, 'resource budget', 'maxWallTimeMs');
+  finiteNonnegative(budget.riskBudget, 'resource budget', 'riskBudget');
+  finiteNonnegative(invariants.promotionDelta, 'protected invariants', 'promotionDelta');
+}

--- a/packages/avo/src/operator.ts
+++ b/packages/avo/src/operator.ts
@@ -1,6 +1,17 @@
 // SPDX-License-Identifier: MIT
 
 import { DarwinArchive, qualifies } from './archive.js';
+import {
+  frozenSnapshot,
+  validateConfiguration,
+  validatedAgentSelection,
+  validatedApproval,
+  validatedBranch,
+  validatedEvaluation,
+  validatedIntervention,
+  validatedObservation,
+  validatedPolicyDecision,
+} from './boundary.js';
 import { createCheckpoint, verifyVariationCheckpoint } from './checkpoint.js';
 import { sha256, transitionHash } from './crypto.js';
 import type {
@@ -76,6 +87,34 @@ function budgetRemaining(budget: BudgetState): boolean {
     && budget.riskUsed <= budget.riskBudget;
 }
 
+function enforceProjectedBudget(
+  state: VariationState,
+  observation: ActionObservation,
+  riskCharge: number,
+): ActionObservation {
+  const projectedCost = state.budget.costUsdUsed + observation.costUsd;
+  const projectedWallTime = state.budget.wallTimeMsUsed + observation.durationMs;
+  const projectedRisk = state.budget.riskUsed + riskCharge;
+  if (![projectedCost, projectedWallTime, projectedRisk].every(Number.isFinite)) {
+    throw new Error('avo: budget accumulation overflow');
+  }
+  const exceeded: string[] = [];
+  if (state.budget.actionsUsed + 1 > state.budget.maxActions) exceeded.push('actions');
+  if (state.budget.branchActionsUsed + 1 > state.budget.maxBranchActions) exceeded.push('branch actions');
+  if (projectedCost > state.budget.maxCostUsd) exceeded.push('cost');
+  if (projectedWallTime > state.budget.maxWallTimeMs) exceeded.push('wall time');
+  if (projectedRisk > state.budget.riskBudget) exceeded.push('risk');
+  if (exceeded.length === 0) return observation;
+  const reason = `post-action budget exceeded: ${exceeded.join(', ')}`;
+  return {
+    ...observation,
+    ok: false,
+    stderr: [observation.stderr, reason].filter(Boolean).join('\n'),
+    exitCode: 126,
+    failureSignature: reason,
+  };
+}
+
 function failureObservation(reason: string, digest: string): ActionObservation {
   return { ok: false, stderr: reason, exitCode: 126, durationMs: 0, costUsd: 0, workspaceDigest: digest, failureSignature: reason };
 }
@@ -124,9 +163,16 @@ export class GovernedVariationOperator implements VariationOperator {
   private readonly authorityVersions: readonly string[];
 
   constructor(private readonly options: VariationOperatorOptions) {
+    validateConfiguration(options.budget, options.invariants);
     this.runtimeVersion = options.runtimeVersion ?? '0.1.0';
-    this.checkpointEvery = Math.max(1, options.checkpointEveryActions ?? 1);
-    this.rvfCheckpointEvery = Math.max(1, options.rvfCheckpointEveryActions ?? 100);
+    const checkpointEvery = options.checkpointEveryActions ?? 1;
+    const rvfCheckpointEvery = options.rvfCheckpointEveryActions ?? 100;
+    if (!Number.isSafeInteger(checkpointEvery) || checkpointEvery <= 0
+      || !Number.isSafeInteger(rvfCheckpointEvery) || rvfCheckpointEvery <= 0) {
+      throw new Error('avo: checkpoint intervals must be positive safe integers');
+    }
+    this.checkpointEvery = checkpointEvery;
+    this.rvfCheckpointEvery = rvfCheckpointEvery;
     this.now = options.now ?? (() => new Date().toISOString());
     this.invariantHash = sha256(options.invariants);
     this.authorityVersions = [options.policy.version, options.evaluators.version, options.environment.version];
@@ -155,16 +201,20 @@ export class GovernedVariationOperator implements VariationOperator {
         // only, so handing it the live state/candidate would let a malicious agent
         // mutate its own evaluation (or the promotion baseline) and be committed
         // with signed receipts. It gets deep copies; authority stays in here.
-        const context: VariationContext = {
+        const context: VariationContext = frozenSnapshot({
           task: this.options.task,
-          state: structuredClone(state),
-          candidate: structuredClone(candidate),
-          recentObservations: structuredClone(state.receipts.slice(-8).map((receipt) => receipt.observation)),
-          memories: structuredClone(memories),
-          knowledge: structuredClone(knowledge),
+          state,
+          candidate,
+          recentObservations: state.receipts.slice(-8).map((receipt) => receipt.observation),
+          memories,
+          knowledge,
           allowedSurfaces: ['retrievalPolicy', 'modelRouting', 'contextPolicy', 'testPolicy', 'repairStrategy'],
-        };
-        const selected = await this.options.agent.chooseAction(context);
+        }, 'agent context');
+        const authorityBeforeAgent = sha256([state, candidate]);
+        const selected = validatedAgentSelection(await this.options.agent.chooseAction(context));
+        if (sha256([state, candidate]) !== authorityBeforeAgent) {
+          throw new Error('avo: authoritative state changed across agent seam');
+        }
         let agentDecision: AgentActionDecision | null = null;
         let action: VariationAction;
         if (isAgentActionDecision(selected)) {
@@ -173,7 +223,10 @@ export class GovernedVariationOperator implements VariationOperator {
         } else {
           action = selected;
         }
-        let decision = this.options.policy.authorize(action, state);
+        let decision = validatedPolicyDecision(this.options.policy.authorize(
+          frozenSnapshot(action, 'policy action'),
+          frozenSnapshot(state, 'policy state'),
+        ), this.options.policy.version);
         if (action.kind === 'edit' && this.options.invariants.protectedPaths.some((pattern) => protectedPathMatches(pattern, action.path))) {
           decision = {
             verdict: 'deny', reason: `protected invariant path cannot be edited: ${action.path}`,
@@ -181,7 +234,10 @@ export class GovernedVariationOperator implements VariationOperator {
           };
         }
         const approved = decision.verdict === 'allow'
-          || (decision.verdict === 'require-approval' && await this.options.approval.approve(action, decision));
+          || (decision.verdict === 'require-approval' && validatedApproval(await this.options.approval.approve(
+            frozenSnapshot(action, 'approval action'),
+            frozenSnapshot(decision, 'approval policy decision'),
+          )));
         let observation: ActionObservation;
         let evaluation: EvaluationResult | undefined;
 
@@ -192,7 +248,10 @@ export class GovernedVariationOperator implements VariationOperator {
           );
         } else if (action.kind === 'evaluate') {
           const parent = candidate.parentId ? this.archive.get(candidate.parentId)?.evaluation : undefined;
-          evaluation = await this.options.evaluators.evaluate(state.currentBranchId, parent);
+          evaluation = validatedEvaluation(await this.options.evaluators.evaluate(
+            state.currentBranchId,
+            parent === undefined ? undefined : frozenSnapshot(parent, 'evaluator parent result'),
+          ), this.options.evaluators.version);
           observation = {
             ok: evaluation.correct && evaluation.safe,
             durationMs: evaluation.wallTimeMs,
@@ -215,7 +274,9 @@ export class GovernedVariationOperator implements VariationOperator {
           if (!selected) {
             observation = failureObservation(`unknown archive candidate: ${action.parentCandidateId}`, candidate.workspaceDigest);
           } else {
-            const branch = await this.options.environment.fork(selected);
+            const branch = validatedBranch(await this.options.environment.fork(
+              frozenSnapshot(selected, 'environment fork candidate'),
+            ));
             observation = {
               ok: true,
               durationMs: 0,
@@ -229,10 +290,16 @@ export class GovernedVariationOperator implements VariationOperator {
           if (!lastEvaluation || !qualifies(lastEvaluation, candidate.evaluation, this.options.invariants.promotionDelta)) {
             observation = failureObservation('promotion gate rejected commit', state.receipts.at(-1)?.workspaceDigest ?? candidate.workspaceDigest);
           } else {
-            observation = await this.options.environment.execute(action, state);
+            observation = validatedObservation(await this.options.environment.execute(
+              frozenSnapshot(action, 'environment action'),
+              frozenSnapshot(state, 'environment state'),
+            ));
           }
         } else {
-          observation = await this.options.environment.execute(action, state);
+          observation = validatedObservation(await this.options.environment.execute(
+            frozenSnapshot(action, 'environment action'),
+            frozenSnapshot(state, 'environment state'),
+          ));
         }
 
         if (agentDecision) {
@@ -247,6 +314,9 @@ export class GovernedVariationOperator implements VariationOperator {
           };
         }
 
+        observation = validatedObservation(observation);
+        observation = enforceProjectedBudget(state, observation, decision.riskCharge);
+
         state = await this.transition(state, action, observation, decision, evaluation);
 
         if (evaluation) {
@@ -257,7 +327,9 @@ export class GovernedVariationOperator implements VariationOperator {
             await this.options.environment.quarantine(state.currentBranchId, evaluation.failureSignature ?? 'protected invariant failed');
             state.rejectedLessons.push(memoryRecord(state, action, observation, evaluation));
           }
-          const intervention = await this.options.supervisor.observe(state);
+          const intervention = validatedIntervention(await this.options.supervisor.observe(
+            frozenSnapshot(state, 'supervisor state'),
+          ), this.options.policy.version);
           if (intervention) state.interventions.push(intervention);
         }
 
@@ -291,10 +363,12 @@ export class GovernedVariationOperator implements VariationOperator {
         }
 
         const record = memoryRecord(state, action, observation, evaluation);
-        await this.options.memory.buffer(record);
+        await this.options.memory.buffer(frozenSnapshot(record, 'memory record'));
         state.memoryUpdates.push(record);
         state.memoryCursor = this.options.memory.cursor;
-        if (!await this.options.memory.verify([record])) throw new Error('avo: structured memory persistence verification failed');
+        if (await this.options.memory.verify(frozenSnapshot([record], 'memory verification records')) !== true) {
+          throw new Error('avo: structured memory persistence verification failed');
+        }
         if (state.budget.actionsUsed % this.checkpointEvery === 0) {
           await this.persist(state);
         }
@@ -324,7 +398,10 @@ export class GovernedVariationOperator implements VariationOperator {
       if (!verifyVariationCheckpoint(saved, this.options.signer)) throw new Error('avo: checkpoint signature/hash mismatch');
       return structuredClone(saved.state);
     }
-    const baselineEvaluation = await this.options.evaluators.evaluate(this.options.seed.branchId);
+    const baselineEvaluation = validatedEvaluation(
+      await this.options.evaluators.evaluate(this.options.seed.branchId),
+      this.options.evaluators.version,
+    );
     const baseline: Candidate = {
       ...this.options.seed,
       parentId: null,
@@ -336,7 +413,9 @@ export class GovernedVariationOperator implements VariationOperator {
       committed: true,
     };
     this.archive.insert(baseline);
-    const working = await this.options.environment.fork(baseline);
+    const working = validatedBranch(await this.options.environment.fork(
+      frozenSnapshot(baseline, 'environment fork candidate'),
+    ));
     const state: VariationState = {
       schema: 1,
       runId: this.options.runId,
@@ -411,7 +490,7 @@ export class GovernedVariationOperator implements VariationOperator {
       const path = await this.options.memory.packageCheckpoint(checkpoint);
       checkpoint = { ...checkpoint, rvfManifestPath: path };
     }
-    await this.options.checkpointStore.save(checkpoint);
+    await this.options.checkpointStore.save(frozenSnapshot(checkpoint, 'checkpoint store value'));
     return checkpoint;
   }
 


### PR DESCRIPTION
## Phase 2 hardening (stacked on #214)

This draft intentionally targets `fix/avo-agent-context-isolation`, not `main`. It reuses #214's isolated authority-alias fix and adds only the remaining untrusted-seam controls identified in review.

**Dependency:** #214 must land first (or this stack must be rebased after it lands). This PR is not a duplicate or replacement for #214.

## What this adds

- deep-clone and recursively freeze the agent context and all state/action/decision snapshots passed to policy, approval, environment, evaluator, supervisor, memory, and checkpoint adapters
- keep the authoritative candidate and state private, then recheck their canonical fingerprint after the agent callback
- clone and runtime-validate the complete discriminated action union and metered agent decisions
- clone and validate policy decisions, approvals, branch results, environment observations, evaluator results, and supervisor interventions before hashing or state mutation
- reject unknown fields, cyclic/noncanonical evidence, wrong authority versions, and nonfinite/negative costs, durations, risk, scores, samples, and violation counts
- enforce hard post-observation cost, latency, and risk limits; an overshooting result is receipted as failed and cannot promote
- pass frozen memory/checkpoint values outward so adapters cannot mutate the operator's copies
- document the authority-boundary contract in ADR-251

No package-version or formatting churn is included in this stacked diff.

## Adversarial proof

The #214 exploit regression is tightened to a one-action run:

- casts away readonly and attempts to append a forged perfect evaluation
- attempts to lower the private candidate baseline
- attempts to inflate `maxActions`
- all three writes throw against recursively frozen snapshots
- exactly one evaluator call occurs (baseline only)
- zero environment executions occur
- the single forged commit is rejected
- the seed remains the winner with one-element lineage
- no forged evaluation reaches checkpoint state; receipts/checkpoint still verify

Additional tests prove:

- mutating the original returned action or policy decision after return cannot change the receipted values
- policy, approval, and environment receive frozen action/state/decision snapshots
- malformed actions and NaN/Infinity/negative agent, policy, evaluator, and observation metrics fail closed
- a finite cost overshoot is recorded but cannot promote

## Validation

- `tsc -p packages/horizon/tsconfig.json`
- `tsc -p packages/avo/tsconfig.json`
- `vitest run packages/avo` — 20 passed, 1 live-provider skipped
- focused authority tests — 8 passed
- `git diff --check`

## Residual scope

This phase does not redesign boolean approvals into signed scoped receipts, strengthen checkpoint transplant binding/full receipt-chain replay, fix the command evaluator's self-authorized classification model, or widen workspace digests to execution outputs. Those remain separate security work and are not claimed as solved here.

Draft: do not merge independently of #214.