### PR TITLE
fix(arc-agi-3-chatgpt): give fs-heavy store tests explicit timeouts (main is red on Windows)

### DIFF
--- a/packages/arc-agi-3-chatgpt/__tests__/store.test.ts
+++ b/packages/arc-agi-3-chatgpt/__tests__/store.test.ts
@@ -97,7 +97,7 @@ describe('ArcEpisodeStore isolation and lifecycle', () => {
     expect(store.sizeForPrincipal('one-principal')).toBe(32);
     await store.closeAll();
     await rm(stateRoot, { recursive: true, force: true });
-  });
+  }, 30_000);
 
   it('retains more than 2,048 principal-scoped idempotency records', async () => {
     const stateRoot = await temporaryStateRoot();
@@ -446,7 +446,7 @@ describe('durable content-addressed checkpoints', () => {
 
     await store.closeAll();
     await rm(stateRoot, { recursive: true, force: true });
-  });
+  }, 30_000);
 
   it('rejects 7,000 unreferenced frame objects before durable persistence', async () => {
     const stateRoot = await temporaryStateRoot();
@@ -475,7 +475,7 @@ describe('durable content-addressed checkpoints', () => {
     );
     await store.closeAll();
     await rm(stateRoot, { recursive: true, force: true });
-  });
+  }, 30_000);
 
   it('rejects invalid budgets and duplicate CAS lists before loading checkpoint objects', async () => {
     const stateRoot = await temporaryStateRoot();
@@ -520,7 +520,7 @@ describe('durable content-addressed checkpoints', () => {
 
     await Promise.all([store.closeAll(), reloadedStore.closeAll()]);
     await rm(stateRoot, { recursive: true, force: true });
-  });
+  }, 30_000);
 
   it('persists and reloads a real 6,624-action controller checkpoint below the 64 MiB bound', async () => {
     const stateRoot = await temporaryStateRoot();


### PR DESCRIPTION
## Why

`main` is currently **red**: [run 33589628715](https://github.com/ruvnet/metaharness/actions/runs/33589628715), job `Node 22 / windows-latest`.

```
FAIL __tests__/store.test.ts > durable content-addressed checkpoints >
     serializes concurrent checkpoint commits at the per-episode file cap
  → Test timed out in 5000ms.
  Tests  1 failed | 66 passed (67)
```

## It is not a logic bug, and not #208's fault

The run that went red is the merge of #208, but that PR touched **only `packages/autogenous/*`** (14 files) — it never went near this package or any shared vitest config. Evidence this is Windows filesystem slowness under runner load:

- the **immediately preceding** main run (`cf77c5b2`) passed on the same Windows job, so the code completes there — this is not a deadlock
- the test runs in **46ms on Linux**, and failed at *exactly* the 5000ms vitest default
- it issues **70 concurrent `saveCheckpoint` calls that the store deliberately serializes** into durable writes, so its wall-clock is bound by the filesystem rather than by anything under test

## The fix

Four tests in this file are fs-bound in the same way and all relied on the 5s default. Rather than patch only the one witness that happened to fail, each now carries an explicit timeout:

| line | test | timeout |
|---|---|---|
| 85 | serializes concurrent creates (64 concurrent) | `30_000` |
| 426 | serializes concurrent checkpoint commits (70 concurrent) — **the failure** | `30_000` |
| 451 | rejects 7,000 unreferenced frame objects | `30_000` |
| 480 | rejects invalid budgets / duplicate CAS lists (7,000) | `30_000` |
| 525 | 6,624-action controller checkpoint | `180_000` *(already present)* |

This matches the convention already established in this very file. No package in the repo sets `testTimeout` in a vitest config, so an inline per-test timeout is the idiomatic choice here. **No assertion is weakened** — the 64/6 split and the on-disk file count are untouched.

30s is ~3x the slowest observed Linux time in the file (10.3s, the test that already needed `180_000`) and well under that precedent.

## Verification

- **Negative control:** forcing the timeout to `1` fails with `Test timed out in 1ms` — proving the argument is genuinely honored in that syntactic position, rather than silently parsed as something else.
- **Positive control:** restored to `30_000`, the test passes.
- **Full package suite:** `6 files / 67 tests passed`.

🤖 Generated with [claude-flow](https://github.com/ruvnet/claude-flow)