### PR TITLE
feat(bench): qualify evaluator and tool interface instruments

### DIFF
--- a/docs/adrs/ADR-289-instrument-qualification-before-promotion.md
+++ b/docs/adrs/ADR-289-instrument-qualification-before-promotion.md
@@ -1,0 +1,96 @@
+# ADR-289: Qualify measurement instruments before promotion
+
+Status: Proposed
+
+Date: 2026-09-06
+
+Tracks: #289
+
+## Context
+
+RuV evaluation currently assumes that a configured model endpoint, serving adapter, parser, and execution path constitute a sufficiently stable measurement instrument once the benchmark itself is frozen.
+
+Two September 2026 results challenge that assumption from independent directions.
+
+First, arXiv:2609.04198 reports low repeat ranking reliability for black box LLM observers on shared endpoints even under preregistered measurement gates and byte identical replay.
+
+Second, arXiv:2609.03966 reports interface induced trajectory censoring in which valid tool calls are present in model output but disappear at the serving template and parser boundary, causing observed tool use to substantially understate model capability.
+
+The common failure is that a benchmark can be reproducible at the code and dataset layer while the instrument producing its evidence is not reliable enough to support promotion decisions.
+
+## Decision
+
+Add a dependency free instrument qualification primitive to `@metaharness/bench`.
+
+The primitive evaluates two independent properties.
+
+1. Ranking repeatability. Matched repetitions over the same unique candidate set are compared using deterministic Spearman rank correlation.
+2. Interface preservation. Valid emitted tool calls are accounted through parsed and executed stages so silent parser or execution loss is measurable.
+
+Qualification thresholds are supplied explicitly by the experiment protocol. The library does not invent a universal reliability threshold.
+
+The receipt is evidence only and always carries `authority: none`.
+
+## Invariants
+
+1. Measurement reliability never grants execution authority.
+2. A promotion evaluator cannot certify itself solely from candidate outcomes.
+3. Missing or malformed qualification evidence fails closed when that dimension is required.
+4. Duplicate sample identities, mismatched ranking candidate sets, impossible tool counters, non finite thresholds, and resource bound violations invalidate the receipt.
+5. Ranking and interface qualification remain separable because non tool benchmarks should not fabricate interface evidence.
+6. Thresholds and instrument snapshots are frozen before candidate outcomes are used as promotion evidence.
+7. Negative qualification results are durable experiment results and cannot be discarded by changing the instrument identifier.
+
+## Interface
+
+`RankingRepeat` records a sample identity and two complete permutations over the same candidate identities.
+
+`ToolInterfaceObservation` records valid emitted calls, server parsed calls, and actually executed calls for one sample.
+
+`InstrumentQualificationPolicy` declares which dimensions are required plus sample and loss thresholds.
+
+`InstrumentQualificationReceipt` reports ranking correlations, aggregate parser and execution loss, failure reasons, validity, qualification state, and `authority: none`.
+
+## Security and privacy
+
+The primitive stores only opaque sample and candidate identities plus bounded integer telemetry. It does not require prompt text, tool arguments, model output, user data, credentials, or raw traces.
+
+A dishonest adapter could still falsify emitted, parsed, or executed counters. Production integration must therefore bind observations to independently captured witness or host telemetry where available.
+
+## Benchmark protocol
+
+Baseline A is a stable synthetic control with identical repeated rankings and lossless tool transport.
+
+Baseline B is an unstable ranking control with deliberately reordered candidates.
+
+Baseline C is an interface censorship control with valid emitted calls and zero parsed calls.
+
+Baseline D is a post parser execution loss control.
+
+The external reproduction then pins model identifier, provider endpoint, host adapter commit, template and parser versions, benchmark commit, evaluator commit, seeds, sample size, latency, token usage, monetary cost, hardware where applicable, and timestamps.
+
+Every result reports mean and minimum repeat Spearman, emitted, parsed, and executed call totals, parser loss, execution loss, invalid observations, failures, and exact reproduction commands.
+
+## Falsification
+
+Reject this primitive as unnecessary if existing MetaHarness benchmark instrumentation already catches all silent interface loss cases and repeated observer instability before promotion with no additional state.
+
+Reject a universal default threshold if reliability requirements materially differ by benchmark. Keep policy explicit instead.
+
+Do not treat increased repeatability as evidence of evaluator validity. A perfectly repeatable evaluator can still be systematically wrong.
+
+## Rollback
+
+The new module is additive, has no new runtime dependencies, and does not change existing benchmark execution. Rollback is deletion of the module, tests, and this ADR. No stored format, migration, credential, model, or deployment change is required.
+
+## Consequences
+
+Positive consequences are earlier detection of invalid benchmark runs, explicit measurement of serving stack censorship, reusable qualification receipts across Dream Machine, Ruflo, Cognitum, RVM, Core Memory, and RuVector experiments, and lower risk of promoting regressions because of an unstable evaluator.
+
+Costs are extra repeated samples, extra preflight calls, and the possibility that shared endpoints fail qualification often enough to require a pinned self hosted evaluator or wider confidence intervals.
+
+The largest remaining uncertainty is external validity. A stable preflight slice may still miss later endpoint drift. Long runs therefore need checkpoint qualification or drift detection in addition to the initial preflight.
+
+## Acceptance
+
+The implementation is acceptable only if synthetic stable controls qualify, unstable rankings fail, silent parser censorship fails, execution loss fails, malformed evidence fails closed, non tool ranking only mode works, no runtime dependency is added, existing bench behavior remains unchanged, and repository CI and security checks remain green.

--- a/packages/bench/__tests__/instrument-qualification.test.ts
+++ b/packages/bench/__tests__/instrument-qualification.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { qualifyInstrument, spearmanRanking } from '../src/instrument-qualification.js';
+
+const strictPolicy = {
+  requireRanking: true,
+  requireInterface: true,
+  minRankingSamples: 2,
+  minMeanSpearman: 0.9,
+  minInterfaceSamples: 2,
+  maxParserLossRate: 0,
+  maxExecutionLossRate: 0,
+};
+
+const stableRankings = [
+  { sampleId: 'r1', reference: ['a', 'b', 'c', 'd'], repeat: ['a', 'b', 'c', 'd'] },
+  { sampleId: 'r2', reference: ['w', 'x', 'y', 'z'], repeat: ['w', 'x', 'y', 'z'] },
+];
+
+const healthyInterface = [
+  { sampleId: 'i1', emittedValidCalls: 4, parsedCalls: 4, executedCalls: 4 },
+  { sampleId: 'i2', emittedValidCalls: 3, parsedCalls: 3, executedCalls: 3 },
+];
+
+function qualify(overrides: Partial<Parameters<typeof qualifyInstrument>[0]> = {}) {
+  return qualifyInstrument({
+    instrumentId: 'provider:model:adapter',
+    snapshotId: 'sha256:fixture',
+    rankings: stableRankings,
+    interfaceObservations: healthyInterface,
+    policy: strictPolicy,
+    ...overrides,
+  });
+}
+
+describe('spearmanRanking', () => {
+  it('returns one for identical rankings', () => {
+    expect(spearmanRanking(['a', 'b', 'c'], ['a', 'b', 'c'])).toBe(1);
+  });
+
+  it('returns negative one for a complete reversal', () => {
+    expect(spearmanRanking(['a', 'b', 'c'], ['c', 'b', 'a'])).toBe(-1);
+  });
+
+  it('returns NaN for mismatched candidate sets', () => {
+    expect(Number.isNaN(spearmanRanking(['a', 'b'], ['a', 'c']))).toBe(true);
+  });
+});
+
+describe('qualifyInstrument', () => {
+  it('qualifies a stable ranking and lossless interface control', () => {
+    const receipt = qualify();
+    expect(receipt.qualified).toBe(true);
+    expect(receipt.invalid).toBe(false);
+    expect(receipt.authority).toBe('none');
+    expect(receipt.ranking.meanSpearman).toBe(1);
+    expect(receipt.interface.parserLossRate).toBe(0);
+    expect(receipt.interface.executionLossRate).toBe(0);
+  });
+
+  it('rejects unstable repeat rankings', () => {
+    const receipt = qualify({
+      rankings: [
+        stableRankings[0]!,
+        { sampleId: 'r2', reference: ['a', 'b', 'c', 'd'], repeat: ['d', 'c', 'b', 'a'] },
+      ],
+    });
+    expect(receipt.qualified).toBe(false);
+    expect(receipt.reasons).toContain('ranking reliability below threshold');
+  });
+
+  it('detects silent parser censorship', () => {
+    const receipt = qualify({
+      interfaceObservations: [
+        { sampleId: 'i1', emittedValidCalls: 5, parsedCalls: 0, executedCalls: 0 },
+        { sampleId: 'i2', emittedValidCalls: 5, parsedCalls: 0, executedCalls: 0 },
+      ],
+    });
+    expect(receipt.qualified).toBe(false);
+    expect(receipt.interface.parserLossRate).toBe(1);
+    expect(receipt.reasons).toContain('parser loss above threshold');
+  });
+
+  it('detects post parser execution loss', () => {
+    const receipt = qualify({
+      interfaceObservations: [
+        { sampleId: 'i1', emittedValidCalls: 5, parsedCalls: 5, executedCalls: 4 },
+        { sampleId: 'i2', emittedValidCalls: 5, parsedCalls: 5, executedCalls: 5 },
+      ],
+    });
+    expect(receipt.qualified).toBe(false);
+    expect(receipt.interface.executionLossRate).toBeCloseTo(0.1);
+    expect(receipt.reasons).toContain('execution loss above threshold');
+  });
+
+  it('fails closed on insufficient observations', () => {
+    const receipt = qualify({ rankings: [stableRankings[0]!], interfaceObservations: [healthyInterface[0]!] });
+    expect(receipt.qualified).toBe(false);
+    expect(receipt.reasons).toContain('insufficient ranking samples');
+    expect(receipt.reasons).toContain('insufficient interface samples');
+  });
+
+  it('fails closed on duplicate ranking identities', () => {
+    const receipt = qualify({
+      rankings: [
+        { sampleId: 'r1', reference: ['a', 'a'], repeat: ['a', 'a'] },
+        stableRankings[1]!,
+      ],
+    });
+    expect(receipt.invalid).toBe(true);
+    expect(receipt.qualified).toBe(false);
+  });
+
+  it('fails closed on impossible interface counters', () => {
+    const receipt = qualify({
+      interfaceObservations: [
+        { sampleId: 'i1', emittedValidCalls: 1, parsedCalls: 2, executedCalls: 0 },
+        healthyInterface[1]!,
+      ],
+    });
+    expect(receipt.invalid).toBe(true);
+    expect(receipt.qualified).toBe(false);
+  });
+
+  it('supports ranking only qualification for non tool benchmarks', () => {
+    const receipt = qualify({
+      interfaceObservations: [],
+      policy: { ...strictPolicy, requireInterface: false, minInterfaceSamples: 0 },
+    });
+    expect(receipt.qualified).toBe(true);
+  });
+});

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -22,6 +22,8 @@
 
 import { performance } from 'node:perf_hooks';
 
+export * from './instrument-qualification.js';
+
 export type EvalCategory = 'single-hop' | 'temporal' | 'multi-hop' | 'open-domain';
 
 export interface MemoryItem {

--- a/packages/bench/src/instrument-qualification.ts
+++ b/packages/bench/src/instrument-qualification.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+
+export interface RankingRepeat {
+  sampleId: string;
+  reference: string[];
+  repeat: string[];
+}
+
+export interface ToolInterfaceObservation {
+  sampleId: string;
+  emittedValidCalls: number;
+  parsedCalls: number;
+  executedCalls: number;
+}
+
+export interface InstrumentQualificationPolicy {
+  requireRanking: boolean;
+  requireInterface: boolean;
+  minRankingSamples: number;
+  minMeanSpearman: number;
+  minInterfaceSamples: number;
+  maxParserLossRate: number;
+  maxExecutionLossRate: number;
+}
+
+export interface InstrumentQualificationInput {
+  instrumentId: string;
+  snapshotId: string;
+  rankings: RankingRepeat[];
+  interfaceObservations: ToolInterfaceObservation[];
+  policy: InstrumentQualificationPolicy;
+}
+
+export interface InstrumentQualificationReceipt {
+  instrumentId: string;
+  snapshotId: string;
+  authority: 'none';
+  qualified: boolean;
+  invalid: boolean;
+  reasons: string[];
+  ranking: {
+    samples: number;
+    meanSpearman: number | null;
+    minSpearman: number | null;
+  };
+  interface: {
+    samples: number;
+    emittedValidCalls: number;
+    parsedCalls: number;
+    executedCalls: number;
+    parserLossRate: number | null;
+    executionLossRate: number | null;
+  };
+}
+
+const MAX_OBSERVATIONS = 4096;
+const MAX_RANKED_ITEMS = 2048;
+
+function finiteUnit(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value <= 1;
+}
+
+function validPolicy(policy: InstrumentQualificationPolicy): boolean {
+  return (
+    (policy.requireRanking || policy.requireInterface) &&
+    Number.isInteger(policy.minRankingSamples) && policy.minRankingSamples >= 0 &&
+    Number.isInteger(policy.minInterfaceSamples) && policy.minInterfaceSamples >= 0 &&
+    finiteUnit(policy.minMeanSpearman) &&
+    finiteUnit(policy.maxParserLossRate) &&
+    finiteUnit(policy.maxExecutionLossRate)
+  );
+}
+
+function validRanking(repeat: RankingRepeat): boolean {
+  if (!repeat.sampleId || repeat.reference.length < 2 || repeat.reference.length > MAX_RANKED_ITEMS) return false;
+  if (repeat.reference.length !== repeat.repeat.length) return false;
+  const left = new Set(repeat.reference);
+  const right = new Set(repeat.repeat);
+  if (left.size !== repeat.reference.length || right.size !== repeat.repeat.length) return false;
+  if (left.size !== right.size) return false;
+  for (const id of left) if (!right.has(id) || id.length === 0) return false;
+  return true;
+}
+
+/** Spearman rank correlation for two permutations of the same unique identities. */
+export function spearmanRanking(reference: string[], repeat: string[]): number {
+  const observation: RankingRepeat = { sampleId: 'spearman', reference, repeat };
+  if (!validRanking(observation)) return Number.NaN;
+
+  const positions = new Map<string, number>();
+  reference.forEach((id, index) => positions.set(id, index + 1));
+  let squaredDistance = 0;
+  repeat.forEach((id, index) => {
+    const delta = positions.get(id)! - (index + 1);
+    squaredDistance += delta * delta;
+  });
+  const n = reference.length;
+  return 1 - (6 * squaredDistance) / (n * (n * n - 1));
+}
+
+function validInterfaceObservation(observation: ToolInterfaceObservation): boolean {
+  const values = [observation.emittedValidCalls, observation.parsedCalls, observation.executedCalls];
+  return (
+    observation.sampleId.length > 0 &&
+    values.every(value => Number.isSafeInteger(value) && value >= 0) &&
+    observation.parsedCalls <= observation.emittedValidCalls &&
+    observation.executedCalls <= observation.parsedCalls
+  );
+}
+
+/**
+ * Qualify a measurement instrument before its outputs can be used as promotion evidence.
+ * This function never grants execution authority.
+ */
+export function qualifyInstrument(input: InstrumentQualificationInput): InstrumentQualificationReceipt {
+  const reasons: string[] = [];
+  let invalid = false;
+
+  if (!input.instrumentId || !input.snapshotId || !validPolicy(input.policy)) {
+    invalid = true;
+    reasons.push('invalid identity or policy');
+  }
+
+  if (input.rankings.length > MAX_OBSERVATIONS || input.interfaceObservations.length > MAX_OBSERVATIONS) {
+    invalid = true;
+    reasons.push('resource bound exceeded');
+  }
+
+  const rankingIds = new Set<string>();
+  const correlations: number[] = [];
+  for (const repeat of input.rankings) {
+    if (rankingIds.has(repeat.sampleId) || !validRanking(repeat)) {
+      invalid = true;
+      reasons.push(`invalid ranking observation: ${repeat.sampleId || '<empty>'}`);
+      continue;
+    }
+    rankingIds.add(repeat.sampleId);
+    correlations.push(spearmanRanking(repeat.reference, repeat.repeat));
+  }
+
+  const interfaceIds = new Set<string>();
+  let emittedValidCalls = 0;
+  let parsedCalls = 0;
+  let executedCalls = 0;
+  for (const observation of input.interfaceObservations) {
+    if (interfaceIds.has(observation.sampleId) || !validInterfaceObservation(observation)) {
+      invalid = true;
+      reasons.push(`invalid interface observation: ${observation.sampleId || '<empty>'}`);
+      continue;
+    }
+    interfaceIds.add(observation.sampleId);
+    emittedValidCalls += observation.emittedValidCalls;
+    parsedCalls += observation.parsedCalls;
+    executedCalls += observation.executedCalls;
+    if (![emittedValidCalls, parsedCalls, executedCalls].every(Number.isSafeInteger)) {
+      invalid = true;
+      reasons.push('interface count overflow');
+      break;
+    }
+  }
+
+  const meanSpearman = correlations.length === 0
+    ? null
+    : correlations.reduce((sum, value) => sum + value, 0) / correlations.length;
+  const minSpearman = correlations.length === 0 ? null : Math.min(...correlations);
+  const parserLossRate = emittedValidCalls === 0 ? null : (emittedValidCalls - parsedCalls) / emittedValidCalls;
+  const executionLossRate = parsedCalls === 0 ? null : (parsedCalls - executedCalls) / parsedCalls;
+
+  if (input.policy.requireRanking) {
+    if (correlations.length < input.policy.minRankingSamples) reasons.push('insufficient ranking samples');
+    if (meanSpearman === null || meanSpearman < input.policy.minMeanSpearman) reasons.push('ranking reliability below threshold');
+  }
+
+  if (input.policy.requireInterface) {
+    if (interfaceIds.size < input.policy.minInterfaceSamples) reasons.push('insufficient interface samples');
+    if (parserLossRate === null) reasons.push('no valid emitted tool calls observed');
+    else if (parserLossRate > input.policy.maxParserLossRate) reasons.push('parser loss above threshold');
+    if (executionLossRate === null) reasons.push('no parsed tool calls available for execution check');
+    else if (executionLossRate > input.policy.maxExecutionLossRate) reasons.push('execution loss above threshold');
+  }
+
+  return {
+    instrumentId: input.instrumentId,
+    snapshotId: input.snapshotId,
+    authority: 'none',
+    qualified: !invalid && reasons.length === 0,
+    invalid,
+    reasons,
+    ranking: {
+      samples: correlations.length,
+      meanSpearman,
+      minSpearman,
+    },
+    interface: {
+      samples: interfaceIds.size,
+      emittedValidCalls,
+      parsedCalls,
+      executedCalls,
+      parserLossRate,
+      executionLossRate,
+    },
+  };
+}


### PR DESCRIPTION
Tracks #289 and reproduction program #290.

Adds ADR 289 and a dependency free `InstrumentQualificationReceipt` to `@metaharness/bench`.

The primitive separates two pre promotion checks:

1. repeat ranking reliability using deterministic Spearman correlation over matched candidate permutations
2. tool interface preservation from valid emitted call through parse and execution

It fails closed on malformed rankings, mismatched candidate sets, duplicate observations, impossible counters, invalid policy, resource bounds, insufficient samples, parser censorship, and execution loss. Thresholds are explicit experiment policy rather than hidden library defaults. Receipts always carry `authority: none`.

Tests cover stable controls, complete ranking reversal, mismatched candidates, silent parser censorship, execution loss, insufficient observations, duplicate identities, impossible counters, and ranking only qualification for non tool benchmarks.

No existing benchmark execution path changes. No new runtime dependency, deployment, credential change, evaluator mutation, or autonomous promotion is introduced.

Keep draft until repository CI and security gates pass and MetaHarness #290 reproduces one real host plus one shared endpoint.