### PR TITLE
feat: orchestrate execution state unlearning across hosts

### DIFF
--- a/docs/adrs/ADR-296-execution-unlearning-lifecycle.md
+++ b/docs/adrs/ADR-296-execution-unlearning-lifecycle.md
@@ -1,0 +1,107 @@
+# ADR 296: Execution Unlearning Lifecycle Across Hosts
+
+Status: proposed
+
+Date: 2026-09-08
+
+Related: ruvnet/core-memory#65, ruvnet/core-memory#66, ruvnet/metaharness#295
+
+## Context
+
+Core Memory now provides durable forgetting plus an execution-state unlearning receipt that binds a selective replay plan. That is necessary but not sufficient at the harness layer. A running host can retain derived information in model context, summaries, plans, retrieval caches, MCP or tool sessions, browser state, subprocesses, filesystem artifacts, KV cache, or opaque provider-side state.
+
+A harness must not claim successful forgetting when it cannot inspect or invalidate one of those surfaces.
+
+## Decision
+
+MetaHarness adds a provider-independent execution unlearning lifecycle contract in `@metaharness/projects`.
+
+The lifecycle does not reproduce Core Memory's forget or replay logic. Instead, it consumes Core Memory plan and receipt digests and evaluates host-level completion using four evidence classes:
+
+1. declared host state inventory
+2. purge completion for purgeable surfaces
+3. replay completion for replayable surfaces
+4. adversarial probe outcomes after rebuild
+
+The output status is one of:
+
+* `PASS`: every declared surface is observable and purgeable, all required purge and replay work completed, and all probes are clean
+* `FAIL`: a required purge or replay step is missing, or any probe leaks
+* `INCOMPLETE`: no direct failure is observed, but at least one declared surface is opaque or cannot be purged
+
+All receipts carry `authority: none`.
+
+## Host state inventory
+
+Each host adapter must declare its runtime surfaces before an unlearning claim can be evaluated. Initial state kinds are:
+
+* model context
+* summary
+* plan
+* retrieval cache
+* tool session
+* browser state
+* subprocess
+* filesystem
+* KV cache
+* provider cache
+* other
+
+Each surface records whether it is observable, purgeable, replayable, and remote.
+
+Unknown runtime state must not be silently omitted. A production host integration requires a documented inventory completeness review.
+
+## Probe classes
+
+MetaHarness supports evidence receipts for:
+
+* explicit elicitation
+* string-free behavioral probes
+* retrieval attempts
+* tool-state recovery attempts
+* delegation to another agent
+* session resume
+
+Probe receipts store only an evidence digest and leak boolean, never the forgotten payload.
+
+## Security boundaries
+
+Core Memory owns durable forget and selective replay evidence.
+
+RVM owns authority to pause, clear, restart, resume, or invoke privileged tools.
+
+MetaHarness owns orchestration, host inventory, and verification only.
+
+A host-provided counter is not sufficient evidence if the host itself is inside the threat boundary. Production integrations should prefer independently observed state and witness receipts where possible.
+
+Provider-side caches are especially important. If the provider does not expose a verifiable deletion or reset mechanism, the result is `INCOMPLETE` even if all local probes pass.
+
+## Falsification
+
+Do not add learned or host-specific unlearning machinery if a complete runtime reset is cheaper and operationally acceptable for the target workload.
+
+Reject this abstraction if host inventories cannot be made complete enough to distinguish `PASS` from `INCOMPLETE` in real supported hosts.
+
+## Benchmark
+
+For each supported host, inject a unique synthetic value at a known step into at least 100 sessions. Compare:
+
+1. durable deletion only
+2. complete runtime reset
+3. Core Memory selective replay plus MetaHarness lifecycle verification
+
+Probe memory, model context, retrieval, tool state, delegation, resume behavior, and any host-specific surfaces.
+
+Report task utility, leakage, recomputed tokens, latency, model cost, purge failures, replay failures, opaque surfaces, and reproduction commands.
+
+Promotion requires zero leakage on tracked state, utility within 2 absolute percentage points of complete reset, at least 30 percent fewer recomputed tokens than complete reset where selective replay is used, and no `PASS` result from an inventory containing opaque or unpurgeable state.
+
+## Migration and rollback
+
+The feature is additive. Existing hosts do not change behavior until they explicitly integrate the lifecycle contract.
+
+Rollback removes the module and export. Core Memory forgetting behavior remains unchanged.
+
+## Governance
+
+No autonomous merge, deployment, credential escalation, provider policy change, or irreversible state migration. MetaHarness issue 295 remains the independent reproduction gate.

--- a/packages/projects/__tests__/unlearning.test.ts
+++ b/packages/projects/__tests__/unlearning.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { evaluateExecutionUnlearningLifecycle, type HostStateInventory } from '../src/unlearning.js';
+
+const D1 = '1'.repeat(64);
+const D2 = '2'.repeat(64);
+const D3 = '3'.repeat(64);
+
+function inventory(overrides: Partial<HostStateInventory> = {}): HostStateInventory {
+  return {
+    hostId: 'codex',
+    hostVersion: '1.0.0',
+    runtimeDigest: D3,
+    surfaces: [
+      { id: 'ctx', kind: 'model-context', observable: true, purgeable: true, replayable: true, remote: false },
+      { id: 'retrieval', kind: 'retrieval-cache', observable: true, purgeable: true, replayable: true, remote: false },
+      { id: 'tools', kind: 'tool-session', observable: true, purgeable: true, replayable: false, remote: false },
+    ],
+    ...overrides,
+  };
+}
+
+function input(inv: HostStateInventory = inventory()) {
+  return {
+    coreMemoryPlanDigest: D1,
+    coreMemoryReceiptDigest: D2,
+    inventory: inv,
+    purgedSurfaceIds: inv.surfaces.filter((s) => s.purgeable).map((s) => s.id),
+    replayedSurfaceIds: inv.surfaces.filter((s) => s.replayable).map((s) => s.id),
+    probeResults: [
+      { id: 'p-explicit', kind: 'explicit' as const, leaked: false, evidenceDigest: D1 },
+      { id: 'p-resume', kind: 'resume' as const, leaked: false, evidenceDigest: D2 },
+    ],
+    utilityBefore: 0.9,
+    utilityAfter: 0.89,
+  };
+}
+
+describe('execution unlearning lifecycle', () => {
+  it('returns PASS only when declared state is observable, purged, replayed, and probes are clean', () => {
+    const receipt = evaluateExecutionUnlearningLifecycle(input());
+    expect(receipt.status).toBe('PASS');
+    expect(receipt.authority).toBe('none');
+    expect(receipt.leakedProbeIds).toEqual([]);
+    expect(receipt.missingPurgeSurfaceIds).toEqual([]);
+    expect(receipt.missingReplaySurfaceIds).toEqual([]);
+    expect(receipt.utilityDelta).toBe(-0.01);
+  });
+
+  it('returns INCOMPLETE for opaque remote provider state instead of claiming success', () => {
+    const inv = inventory({
+      surfaces: [
+        ...inventory().surfaces,
+        { id: 'provider', kind: 'provider-cache', observable: false, purgeable: false, replayable: false, remote: true },
+      ],
+    });
+    const receipt = evaluateExecutionUnlearningLifecycle(input(inv));
+    expect(receipt.status).toBe('INCOMPLETE');
+    expect(receipt.unobservableSurfaceIds).toEqual(['provider']);
+    expect(receipt.unpurgeableSurfaceIds).toEqual(['provider']);
+  });
+
+  it('returns FAIL when a probe leaks after cleanup', () => {
+    const value = input();
+    value.probeResults = [{ id: 'p-tool', kind: 'tool', leaked: true, evidenceDigest: D1 }];
+    const receipt = evaluateExecutionUnlearningLifecycle(value);
+    expect(receipt.status).toBe('FAIL');
+    expect(receipt.leakedProbeIds).toEqual(['p-tool']);
+  });
+
+  it('returns FAIL when a purgeable surface was not purged', () => {
+    const value = input();
+    value.purgedSurfaceIds = ['ctx', 'tools'];
+    const receipt = evaluateExecutionUnlearningLifecycle(value);
+    expect(receipt.status).toBe('FAIL');
+    expect(receipt.missingPurgeSurfaceIds).toEqual(['retrieval']);
+  });
+
+  it('returns FAIL when a replayable surface was not replayed', () => {
+    const value = input();
+    value.replayedSurfaceIds = ['ctx'];
+    const receipt = evaluateExecutionUnlearningLifecycle(value);
+    expect(receipt.status).toBe('FAIL');
+    expect(receipt.missingReplaySurfaceIds).toEqual(['retrieval']);
+  });
+
+  it('is deterministic regardless of inventory, purge, replay, and probe order', () => {
+    const a = input();
+    const b = input({ ...inventory(), surfaces: [...inventory().surfaces].reverse() });
+    b.purgedSurfaceIds = [...b.purgedSurfaceIds].reverse();
+    b.replayedSurfaceIds = [...b.replayedSurfaceIds].reverse();
+    b.probeResults = [...b.probeResults].reverse();
+    expect(evaluateExecutionUnlearningLifecycle(a).digest).toBe(evaluateExecutionUnlearningLifecycle(b).digest);
+  });
+
+  it('rejects duplicate and unknown state surfaces', () => {
+    const dup = inventory({ surfaces: [inventory().surfaces[0], inventory().surfaces[0]] });
+    expect(() => evaluateExecutionUnlearningLifecycle(input(dup))).toThrow(/duplicate surface id/);
+
+    const unknown = input();
+    unknown.purgedSurfaceIds = [...unknown.purgedSurfaceIds, 'not-declared'];
+    expect(() => evaluateExecutionUnlearningLifecycle(unknown)).toThrow(/unknown surface id/);
+  });
+
+  it('rejects malformed digests and impossible utility telemetry', () => {
+    expect(() => evaluateExecutionUnlearningLifecycle({ ...input(), coreMemoryPlanDigest: 'bad' })).toThrow(/sha256/);
+    expect(() => evaluateExecutionUnlearningLifecycle({ ...input(), utilityAfter: 1.2 })).toThrow(/utilityAfter/);
+  });
+});

--- a/packages/projects/bench/unlearning.bench.mjs
+++ b/packages/projects/bench/unlearning.bench.mjs
@@ -1,0 +1,29 @@
+import { performance } from 'node:perf_hooks';
+import { evaluateExecutionUnlearningLifecycle } from '../dist/unlearning.js';
+
+const D1 = '1'.repeat(64);
+const D2 = '2'.repeat(64);
+const D3 = '3'.repeat(64);
+const surfaces = Array.from({ length: 32 }, (_, i) => ({
+  id: `surface-${i}`,
+  kind: i % 3 === 0 ? 'retrieval-cache' : i % 3 === 1 ? 'tool-session' : 'model-context',
+  observable: true,
+  purgeable: true,
+  replayable: i % 3 !== 1,
+  remote: false,
+}));
+const input = {
+  coreMemoryPlanDigest: D1,
+  coreMemoryReceiptDigest: D2,
+  inventory: { hostId: 'bench-host', hostVersion: '1', runtimeDigest: D3, surfaces },
+  purgedSurfaceIds: surfaces.map((s) => s.id),
+  replayedSurfaceIds: surfaces.filter((s) => s.replayable).map((s) => s.id),
+  probeResults: Array.from({ length: 12 }, (_, i) => ({ id: `probe-${i}`, kind: 'behavioral', leaked: false, evidenceDigest: D1 })),
+};
+
+for (let i = 0; i < 100; i += 1) evaluateExecutionUnlearningLifecycle(input);
+const n = 10000;
+const start = performance.now();
+for (let i = 0; i < n; i += 1) evaluateExecutionUnlearningLifecycle(input);
+const elapsed = performance.now() - start;
+console.log(JSON.stringify({ benchmark: 'execution-unlearning-receipt', iterations: n, totalMs: elapsed, usPerReceipt: (elapsed * 1000) / n }));

--- a/packages/projects/src/index.ts
+++ b/packages/projects/src/index.ts
@@ -28,3 +28,4 @@ export * from './taint.js';
 export * from './verifiers.js';
 export * from './sandbox.js';
 export * from './cve-corpus.js';
+export * from './unlearning.js'; // execution-state unlearning orchestration

--- a/packages/projects/src/unlearning.ts
+++ b/packages/projects/src/unlearning.ts
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: MIT
+//
+// MetaHarness orchestration contract for execution-state unlearning.
+// Core Memory owns durable forget and selective-replay evidence. MetaHarness owns
+// host inventory, orchestration, and adversarial verification across runtimes.
+
+import { hashJson } from './core.js';
+
+export type UnlearningStatus = 'PASS' | 'FAIL' | 'INCOMPLETE';
+
+export type RuntimeStateKind =
+  | 'model-context'
+  | 'summary'
+  | 'plan'
+  | 'retrieval-cache'
+  | 'tool-session'
+  | 'browser-state'
+  | 'subprocess'
+  | 'filesystem'
+  | 'kv-cache'
+  | 'provider-cache'
+  | 'other';
+
+export interface HostStateSurface {
+  id: string;
+  kind: RuntimeStateKind;
+  observable: boolean;
+  purgeable: boolean;
+  replayable: boolean;
+  remote: boolean;
+  notes?: string;
+}
+
+export interface HostStateInventory {
+  hostId: string;
+  hostVersion: string;
+  runtimeDigest: string;
+  surfaces: HostStateSurface[];
+}
+
+export interface UnlearningProbeResult {
+  id: string;
+  kind: 'explicit' | 'behavioral' | 'retrieval' | 'tool' | 'delegation' | 'resume';
+  leaked: boolean;
+  evidenceDigest: string;
+}
+
+export interface ExecutionUnlearningLifecycleInput {
+  coreMemoryPlanDigest: string;
+  coreMemoryReceiptDigest: string;
+  inventory: HostStateInventory;
+  purgedSurfaceIds: string[];
+  replayedSurfaceIds: string[];
+  probeResults: UnlearningProbeResult[];
+  utilityBefore?: number;
+  utilityAfter?: number;
+}
+
+export interface ExecutionUnlearningLifecycleReceipt {
+  version: 1;
+  authority: 'none';
+  status: UnlearningStatus;
+  hostId: string;
+  hostVersion: string;
+  runtimeDigest: string;
+  coreMemoryPlanDigest: string;
+  coreMemoryReceiptDigest: string;
+  inventoryDigest: string;
+  unobservableSurfaceIds: string[];
+  unpurgeableSurfaceIds: string[];
+  missingPurgeSurfaceIds: string[];
+  missingReplaySurfaceIds: string[];
+  leakedProbeIds: string[];
+  utilityDelta: number | null;
+  digest: string;
+}
+
+const HEX64 = /^[a-f0-9]{64}$/;
+const ID = /^[A-Za-z0-9._:/-]{1,180}$/;
+const MAX_SURFACES = 128;
+const MAX_PROBES = 512;
+
+function assertDigest(value: string, name: string): void {
+  if (!HEX64.test(value)) throw new Error(`${name} must be a lowercase sha256 digest`);
+}
+
+function assertId(value: string, name: string): void {
+  if (!ID.test(value)) throw new Error(`${name} is invalid`);
+}
+
+function uniqueSorted(values: string[], name: string): string[] {
+  const set = new Set<string>();
+  for (const value of values) {
+    assertId(value, name);
+    if (set.has(value)) throw new Error(`duplicate ${name}: ${value}`);
+    set.add(value);
+  }
+  return [...set].sort();
+}
+
+function normalizedInventory(inventory: HostStateInventory): HostStateInventory {
+  assertId(inventory.hostId, 'hostId');
+  if (!inventory.hostVersion || inventory.hostVersion.length > 120) throw new Error('hostVersion is invalid');
+  assertDigest(inventory.runtimeDigest, 'runtimeDigest');
+  if (!Array.isArray(inventory.surfaces) || inventory.surfaces.length === 0 || inventory.surfaces.length > MAX_SURFACES) {
+    throw new Error(`inventory must contain 1..${MAX_SURFACES} surfaces`);
+  }
+  const ids = new Set<string>();
+  const surfaces = inventory.surfaces.map((surface) => {
+    assertId(surface.id, 'surface id');
+    if (ids.has(surface.id)) throw new Error(`duplicate surface id: ${surface.id}`);
+    ids.add(surface.id);
+    return { ...surface };
+  }).sort((a, b) => a.id.localeCompare(b.id));
+  return { ...inventory, surfaces };
+}
+
+function normalizedProbes(probes: UnlearningProbeResult[]): UnlearningProbeResult[] {
+  if (!Array.isArray(probes) || probes.length > MAX_PROBES) throw new Error(`at most ${MAX_PROBES} probes are supported`);
+  const ids = new Set<string>();
+  return probes.map((probe) => {
+    assertId(probe.id, 'probe id');
+    assertDigest(probe.evidenceDigest, 'probe evidence digest');
+    if (ids.has(probe.id)) throw new Error(`duplicate probe id: ${probe.id}`);
+    ids.add(probe.id);
+    return { ...probe };
+  }).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/**
+ * Build a host-level unlearning receipt around Core Memory's durable forget and
+ * execution-unlearning receipt. PASS is possible only when every declared state
+ * surface is observable, purgeable, actually purged, replayed when required, and
+ * every adversarial probe is clean. Opaque provider state therefore yields
+ * INCOMPLETE rather than a false success claim.
+ */
+export function evaluateExecutionUnlearningLifecycle(
+  input: ExecutionUnlearningLifecycleInput,
+): ExecutionUnlearningLifecycleReceipt {
+  assertDigest(input.coreMemoryPlanDigest, 'coreMemoryPlanDigest');
+  assertDigest(input.coreMemoryReceiptDigest, 'coreMemoryReceiptDigest');
+  const inventory = normalizedInventory(input.inventory);
+  const probes = normalizedProbes(input.probeResults);
+  const purged = uniqueSorted(input.purgedSurfaceIds, 'purged surface id');
+  const replayed = uniqueSorted(input.replayedSurfaceIds, 'replayed surface id');
+  const known = new Set(inventory.surfaces.map((surface) => surface.id));
+  for (const id of [...purged, ...replayed]) {
+    if (!known.has(id)) throw new Error(`unknown surface id: ${id}`);
+  }
+
+  const unobservableSurfaceIds = inventory.surfaces.filter((s) => !s.observable).map((s) => s.id);
+  const unpurgeableSurfaceIds = inventory.surfaces.filter((s) => !s.purgeable).map((s) => s.id);
+  const missingPurgeSurfaceIds = inventory.surfaces.filter((s) => s.purgeable && !purged.includes(s.id)).map((s) => s.id);
+  const missingReplaySurfaceIds = inventory.surfaces.filter((s) => s.replayable && !replayed.includes(s.id)).map((s) => s.id);
+  const leakedProbeIds = probes.filter((probe) => probe.leaked).map((probe) => probe.id);
+
+  const hasLeakOrMissing = leakedProbeIds.length > 0 || missingPurgeSurfaceIds.length > 0 || missingReplaySurfaceIds.length > 0;
+  const hasOpaqueState = unobservableSurfaceIds.length > 0 || unpurgeableSurfaceIds.length > 0;
+  const status: UnlearningStatus = hasLeakOrMissing ? 'FAIL' : hasOpaqueState ? 'INCOMPLETE' : 'PASS';
+
+  const before = input.utilityBefore;
+  const after = input.utilityAfter;
+  if (before !== undefined && (!Number.isFinite(before) || before < 0 || before > 1)) throw new Error('utilityBefore must be in [0,1]');
+  if (after !== undefined && (!Number.isFinite(after) || after < 0 || after > 1)) throw new Error('utilityAfter must be in [0,1]');
+  const utilityDelta = before === undefined || after === undefined ? null : Number((after - before).toFixed(6));
+
+  const payload = {
+    version: 1 as const,
+    authority: 'none' as const,
+    status,
+    hostId: inventory.hostId,
+    hostVersion: inventory.hostVersion,
+    runtimeDigest: inventory.runtimeDigest,
+    coreMemoryPlanDigest: input.coreMemoryPlanDigest,
+    coreMemoryReceiptDigest: input.coreMemoryReceiptDigest,
+    inventoryDigest: hashJson(inventory),
+    unobservableSurfaceIds,
+    unpurgeableSurfaceIds,
+    missingPurgeSurfaceIds,
+    missingReplaySurfaceIds,
+    leakedProbeIds,
+    utilityDelta,
+  };
+  return { ...payload, digest: hashJson(payload) };
+}


### PR DESCRIPTION
Tracks #295 and integrates with merged ruvnet/core-memory#66.

## What this adds

A provider-independent MetaHarness lifecycle receipt around Core Memory execution-state unlearning:

1. host state inventory across model context, summaries, plans, retrieval caches, tool sessions, browser state, subprocesses, filesystem, KV cache, provider cache, and other declared surfaces
2. explicit purge and replay completion evidence
3. adversarial probe receipts for explicit, behavioral, retrieval, tool, delegation, and resume checks
4. deterministic `PASS`, `FAIL`, or `INCOMPLETE` outcome
5. `INCOMPLETE` rather than false success when opaque or unpurgeable provider state exists
6. `authority: none` on all receipts
7. no duplication of Core Memory durable forget or replay logic

## Safety boundary

Core Memory owns durable forget and selective replay evidence. RVM owns authority to pause, purge, restart, resume, or invoke privileged operations. MetaHarness owns host inventory, orchestration, and verification only.

## Validation

Adds eight deterministic tests plus a receipt microbenchmark. The PR remains draft until repository CI, security workflows, and independent reproduction under #295 are green.

## Acceptance

Across at least 100 synthetic forget sessions on at least three hosts, PASS requires zero recoverable tracked state, utility within 2 absolute percentage points of complete reset, no opaque or unpurgeable surface, and complete purge/replay evidence. Any opaque provider state must remain INCOMPLETE.

No autonomous merge, deployment, credential escalation, or irreversible migration.