### PR TITLE
dream(security-adversarial): #297 close score.ts/oia-manifest.ts MCP-detection blindness (evaluated)

### DIFF
--- a/__tests__/harness-oia-manifest.test.ts
+++ b/__tests__/harness-oia-manifest.test.ts
@@ -175,6 +175,30 @@ describe('harness oia-manifest (iter 121 — ADR-034)', () => {
     }
   });
 
+  it('BUG REPRO (pre-fix would report mcp.mode:"off"/security "partial"): .claude/settings.json-only MCP registration is detected as in-use — issue #280', async () => {
+    // Same detection-gap class PR #276 (2026-09-03) closed in threat-model.ts:
+    // readHarnessProfile()'s hasMcp only checked .harness/mcp-policy.json and
+    // .mcp.json, missing .claude/settings.json's mcpServers key.
+    const dir = await mkdtemp(join(tmpdir(), 'ahg-oia-settings-mcp-'));
+    try {
+      await writeFile(join(dir, 'package.json'), JSON.stringify({ name: 'settings-mcp-test', version: '0.1.0' }), 'utf-8');
+      await mkdir(join(dir, '.claude'), { recursive: true });
+      await writeFile(
+        join(dir, '.claude', 'settings.json'),
+        JSON.stringify({ mcpServers: { bot: { command: 'npx' } } }),
+        'utf-8',
+      );
+      const r = await oiaManifestCmd([dir]);
+      expect(r.code).toBe(0);
+      const m = JSON.parse(readFileSync(join(dir, '.harness', 'oia-manifest.json'), 'utf-8'));
+      expect(m.adjacentStandards.mcp.mode).not.toBe('off');
+      expect(m.horizontalSpans.security.status).not.toBe('partial');
+      expect(m.layerAlignment.L4_toolsAndIntegrations).not.toBe('partial');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it('checkOiaManifest passes a freshly-built object', () => {
     const m = buildOiaManifest({
       name: 'unit',

--- a/__tests__/harness-score.test.ts
+++ b/__tests__/harness-score.test.ts
@@ -151,9 +151,19 @@ describe('harness score (iter 111)', () => {
     try {
       const r = await scoreCmd([dir, '--json']);
       const j = JSON.parse(r.lines.join('\n'));
-      // Minimal template scaffolds without MCP enabled by default,
-      // so mcpRisk should be 'None' (no policy + no .mcp.json).
-      expect(['None', 'Low']).toContain(j.mcpRisk);
+      // Dream Cycle 2026-09-08 (security-adversarial, issue #280): this
+      // assertion previously read 'None'/'Low' on the belief that the
+      // `minimal` template scaffolds without MCP enabled by default. That
+      // was itself a symptom of the bug this candidate fixes — the
+      // `minimal` template's `.claude/settings.json.tmpl` DOES register a
+      // self-referential `mcpServers` entry (so a host can call back into
+      // the generated harness's own CLI as an MCP tool), and no template
+      // ships a `.harness/mcp-policy.json`, so every default scaffold is
+      // MCP-in-use and fully ungoverned. `scoreMcpSafety()`'s old
+      // policy-file-or-.mcp.json-only detection missed the
+      // settings.json-only registration and silently reported the safest
+      // possible score for the actual state. Now correctly 'High'.
+      expect(j.mcpRisk).toBe('High');
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/docs/dream-cycle/2026-09-08-evidence.md
+++ b/docs/dream-cycle/2026-09-08-evidence.md
@@ -1,0 +1,72 @@
+# Dream Cycle Evidence Record — 2026-09-08 (security-adversarial)
+
+Durable OBSERVATION/MEASUREMENT/INFERENCE/HYPOTHESIS/DECISION/REJECTION record. See
+`docs/dream-cycle/2026-09-08-gist.md` for the full research writeup and issue/PR for the complete
+evaluation receipt.
+
+## OBSERVATION
+
+- Issue #280 (filed 2026-09-03 by PR #276's own round-2 critic): `score.ts`'s `scoreMcpSafety()` and
+  `oia-manifest.ts`'s `readHarnessProfile()` share the exact narrow MCP-in-use detection bug
+  `threat-model.ts` had before #276 — both check only `.harness/mcp-policy.json`/`.mcp.json`, missing
+  `.claude/settings.json`'s `mcpServers` key.
+- Direct repo inspection (`grep`/`find` over `packages/create-agent-harness/templates/`): 20 of 22
+  scaffold templates unconditionally register a self-referential `mcpServers` entry in
+  `.claude/settings.json.tmpl`; 0 of 22 templates, and no scaffolder code path, ever write
+  `.harness/mcp-policy.json`.
+
+## MEASUREMENT
+
+- Baseline (pre-fix, `main` @ `d5833dc`): `create-agent-harness` package suite 572 passed / 2 skipped
+  (574 total, 45 files). Root `harness-oia-manifest.test.ts` 9/9 passed. Root `harness-score.test.ts` 6/8
+  passed, 2 failed (pre-existing, unrelated `schema`-key shape mismatch — confirmed present on baseline
+  before any candidate change).
+- Non-vacuous red proof: reverting only `score.ts`'s fix against the new
+  `score-mcp-detection.test.ts` fails the BUG REPRO case (`mcpRisk` stays `'None'` for a
+  settings.json-only-registered directory). Reverting only `oia-manifest.ts`'s fix fails the new
+  BUG REPRO case in `harness-oia-manifest.test.ts` (`mcp.mode` stays `'off'`).
+- Candidate (post-fix): `create-agent-harness` package suite 587 passed / 2 skipped (589 total, 47
+  files) — 0 regressions, +15 net new passing tests (5 new in `score-mcp-detection.test.ts`, 1 new in
+  `harness-oia-manifest.test.ts`, 9 pre-existing unrelated new tests accumulated in the working tree
+  independent of this candidate). Root `harness-oia-manifest.test.ts` 10/10. Root `harness-score.test.ts`
+  8 tests: the 1 assertion this candidate's fix legitimately changed now passes (`'High'`, was loosely
+  `['None','Low']`); the 2 pre-existing unrelated failures are unchanged.
+- Full monorepo `npx vitest run`: candidate = 3037 passed / 20 failed / 58 skipped (3115 total, 12 failed
+  files). Verified by isolated re-run against true baseline (all source changes stashed) that all 18
+  non-`harness-score.test.ts` failures plus the same 2 `harness-score.test.ts` failures are present
+  identically on `main` before this candidate — 0 regressions attributable to tonight's change across the
+  full monorepo.
+- `tsc --noEmit -p packages/create-agent-harness/tsconfig.json`: clean, both before and after.
+- `npm audit --omit=dev --audit-level=high --json`: 0 vulnerabilities (no dependency touched).
+- Live CLI smoke test (real built `dist/`, `minimal` template, fresh scaffold): `harness score --json`
+  now returns `score: 55, mcpRisk: "High"` (was `mcpRisk: "None"`); `harness oia-manifest --dry-run` now
+  returns `adjacentStandards.mcp.mode: "local"` (was `"off"`), `layerAlignment.L4_toolsAndIntegrations:
+  "full"` (was `"partial"`).
+
+## INFERENCE
+
+- The detection fix is correct and behaviorally scoped exactly to the settings.json-only case: a
+  directory with zero MCP surfaces is unaffected (still `None`/`off`); a directory with a compliant
+  `.harness/mcp-policy.json` is unaffected (still scores the same, whether or not settings.json also
+  registers MCP — no double-counting).
+- Because 20/22 templates register MCP unconditionally and 0/22 ship a policy file, this bug was not an
+  edge case: it affected the MCP-safety score and OIA-manifest MCP fields of every default-scaffolded
+  harness this generator has ever produced, always in the false-negative (falsely-safe) direction.
+- `oia-manifest.ts`'s `security`/`policyEnforcement` span-status semantics were already on/off-keyed, not
+  governance-depth-keyed, before this fix — that modeling choice is unchanged by tonight's candidate and
+  should not be read as this candidate claiming anything about governance depth.
+
+## DECISION
+
+`evaluated: accepted`. ACCEPT-WITH-CAVEATS-equivalent: real, reproducible, adversarially self-critiqued
+fix to a previously-disclosed detection gap (issue #280), with confirmed real-world blast radius (every
+default scaffold) and a genuine downstream test-suite regression found and correctly fixed (not swept
+under) along the way. Caveats: (1) the deeper "no template ships a governing policy file" architecture
+gap is disclosed, not fixed — see Recommended Next Steps #1 in the gist; (2) 2 pre-existing, unrelated
+`harness-score.test.ts` failures (stale 6-key vs. real 7-key badge shape) were found and left untouched,
+disclosed for a future night.
+
+## REJECTION
+
+None — no hypothesis or candidate was rejected tonight. (STEP 3.2's 4 non-selected candidates are listed
+in the gist/issue's candidate-selection table, not rejected experiments — they were never run.)

--- a/docs/dream-cycle/2026-09-08-gist.md
+++ b/docs/dream-cycle/2026-09-08-gist.md
@@ -1,0 +1,151 @@
+# MCP Detection Blindness in `harness score`/`oia-manifest` — 2026
+
+TL;DR: `score.ts`'s `scoreMcpSafety()` and `oia-manifest.ts`'s `readHarnessProfile()` shared the exact
+narrow MCP-in-use detection bug PR #276 (2026-09-03) closed in `threat-model.ts` — both checked only
+`.harness/mcp-policy.json`/`.mcp.json`, missing `.claude/settings.json`'s `mcpServers` key. Filed as
+issue #280 by #276's own round-2 critic. Fixing it exposed something bigger than the detection gap
+itself: **every one of the 20 non-minimal-variant scaffold templates (20/22) unconditionally registers a
+self-referential MCP server in `.claude/settings.json.tmpl`, and zero templates — including `minimal` —
+ever emit a `.harness/mcp-policy.json`.** Every default-scaffolded harness this generator produces was
+being scored `mcpRisk: "None"` / `oia mcp.mode: "off"` (the safest possible reading) when the true state
+is MCP-in-use and fully ungoverned. Fixed by routing both files' `hasMcp` through `scanMcp()`'s
+`mcpEnabled`, the one place all 3 surfaces are already OR'd (2026-09-03's fix).
+
+## What's New in 2026
+
+| Finding | Source | Confidence |
+|---|---|---|
+| OWASP released the first "Top 10 for Agentic Applications 2026" (Dec 2025), naming MCP/tool-registration integrity as a top-tier risk category | genai.owasp.org (official) | A |
+| Trend Micro found 492 exposed MCP servers with zero authentication in early 2026 | Cycode / StartupDefense summaries of Trend Micro data | B |
+| 30+ CVEs filed against MCP servers/clients/infra Jan–Feb 2026 | multiple 2026 security-vendor blogs (Aembit, Cycode) | B |
+| First confirmed malicious MCP server (`postmark-mcp`) silently BCC'd outgoing email for weeks pre-detection | cross-reported across 2026 security blogs | B |
+| "`.claude/settings.json` and `.mcp.json` are no longer just configuration files — they are execution vectors" | 2026 MCP-security vendor analysis (datastealth.io) | C |
+| CSO Online: "Claude Code has an MCP security problem — and your developers are already using it" (2026) | csoonline.com | C |
+
+Every "MCP scanner" story in the 2026 literature is about *external* MCP servers a project points at.
+None of the sources found are about a *scaffolding generator's own default output* silently registering
+an ungoverned, self-referential MCP server on every project it produces — that is the more specific,
+locally-relevant angle this candidate closes, not a rehash of the general MCP-security news cycle.
+
+## MetaHarness Current Capability (before tonight)
+
+`packages/create-agent-harness/src/mcp-scan.ts`'s `scanMcp()` is the one place all 3 valid MCP
+registration surfaces are already OR'd (fixed 2026-09-03, PR #276): `.harness/mcp-policy.json`,
+`.mcp.json`, and `.claude/settings.json`'s `mcpServers`. But two sibling call sites never adopted it:
+
+- `score.ts`'s `scoreMcpSafety()`: `hasMcp = policy != null || fileExists(dir, '.mcp.json')` — feeds the
+  README-badge `mcpRisk` field and the 20%-weighted "MCP safety" scorecard dimension.
+- `oia-manifest.ts`'s `readHarnessProfile()`: `hasMcp = mcpPolicy != null || existsSync('.mcp.json')` —
+  feeds ADR-034's `adjacentStandards.mcp.mode` and the `security`/`policyEnforcement` horizontal-span
+  status in the emitted `.harness/oia-manifest.json`.
+
+Both false-negative on the settings.json-only case, exactly as `threat-model.ts` did before #276.
+
+## Competitor Comparison
+
+| System | Scaffolds/generates agent projects | Ships a governed-by-default MCP/tool-registration surface | Detects its own scaffold's ungoverned tool registration |
+|---|---|---|---|
+| LangGraph | No (library, not a generator) | N/A | N/A |
+| AutoGen | Templates exist but no security scorer over generated output | No | None found |
+| CrewAI | `crewai create` scaffolds a project; no MCP-safety scorer | No | None found |
+| OpenAI Agents SDK / Codex CLI | Codex scaffolds repos; no equivalent "harness score" security dimension | No | None found |
+| create-mcp-server (Anthropic reference scaffolder) | Yes — scaffolds an MCP *server*, not a consuming harness | Ships a policy stub but no automated post-scaffold audit of it | None found |
+| **MetaHarness (pre-fix)** | Yes | Ships a policy primitive (ADR-022) selectable by mode | **False-negative**: 20/22 templates register MCP unconditionally; 0/22 ship the governing policy file; scorer/manifest layer reported "safest" |
+| **MetaHarness (post-fix)** | Yes | Unchanged (governance-file gap disclosed, not fixed tonight — see below) | Correctly reports High risk / MCP-on for every default scaffold |
+
+No competitor surveyed runs an automated security scorer *over its own generated output* at all — the
+comparison isn't "who detects this better," it's that MetaHarness is nearly alone in even asking the
+question, which makes getting the answer right (not silently wrong) higher-stakes, not lower.
+
+## Hypothesis
+
+Given a harness directory that registers MCP through `.claude/settings.json`'s `mcpServers` key only (no
+`.harness/mcp-policy.json`, no `.mcp.json`), when `harness score --json` or `harness oia-manifest` runs
+against it, then `mcpRisk` should not be `"None"` and `adjacentStandards.mcp.mode` should not be `"off"`,
+subject to: (a) a directory registering no MCP surface at all is unaffected (still `None`/`off`, true
+negative preserved); (b) a compliant `.harness/mcp-policy.json` scores identically before/after (no
+double-counting when multiple surfaces register at once); (c) 0 regressions in the existing suites; (d)
+new tests fail non-vacuously pre-patch. Frozen before implementation, not modified after evaluation began.
+
+## Benchmarks
+
+Deterministic, $0, no LLM calls (`LLM_EVAL=available` tonight but unused — pure static-file-detection
+logic, same evaluation shape as #276's precedent). Evaluator: the package's own vitest suites
+(`packages/create-agent-harness/__tests__`, root `__tests__/harness-oia-manifest.test.ts`,
+`__tests__/harness-score.test.ts`) plus a live real-scaffold smoke check via the built CLI.
+
+## Evaluation
+
+`evaluated: accepted`.
+
+- New tests: `score-mcp-detection.test.ts` (5 cases) + 1 new case in `harness-oia-manifest.test.ts`.
+  Red/green confirmed by reverting each source fix independently: `score.ts`'s bug-repro case fails
+  `mcpRisk` stayed `'None'` pre-patch; `oia-manifest.ts`'s bug-repro case fails `mcp.mode` stayed `'off'`
+  pre-patch. Both pass post-patch.
+- True-negative regression guard: a directory with no MCP surface at all is unaffected (`None`/`off`
+  unchanged) — explicit test case, both files.
+- No-double-counting guard: a compliant `.harness/mcp-policy.json` *plus* a settings.json registration
+  scores identically to policy-only (no inflation from the extra surface being counted twice).
+- **Real downstream regression found and fixed, not swept under the fix**: root `__tests__/harness-score.test.ts`'s
+  `MCP risk reads default-deny policy correctly` test asserted `mcpRisk ∈ {'None','Low'}` for a real
+  scaffolded `minimal`-template harness — built on the same false assumption the bug caused (that
+  `minimal` scaffolds MCP-off by default). It does not: `minimal`'s own `.claude/settings.json.tmpl`
+  registers a self-referential `mcpServers` entry unconditionally. Updated the assertion to `'High'` with
+  a comment explaining why, mirroring #276's precedent of correcting a downstream consumer that had
+  baked in the same bug (there: AGNTCY's badge derivation; here: this repo's own test suite).
+- Package suite: `create-agent-harness` **572 → 587 passed / 2 skipped** (+15: 5 new + 1 new + 9 unrelated
+  new since baseline reflects only the touched-file delta — see full-run numbers in the Witness section),
+  0 regressions. `tsc --noEmit` clean. Root `harness-oia-manifest.test.ts` **9 → 10**, `harness-score.test.ts`
+  **8 tests, 1 assertion corrected, 0 new regressions** (2 pre-existing unrelated failures — see below).
+- **Pre-existing, disclosed, NOT fixed tonight** (confirmed present on baseline `main` before any candidate
+  change, same 2 assertions fail identically pre- and post-patch): `harness-score.test.ts`'s `--json emits
+  the 6-field badges shape` and `--out writes the badges JSON to a file` expect a 6-key badge object but
+  the real output carries a 7th `schema` key (`HARNESS_SCORE_SCHEMA`, shipped by an earlier, unrelated PR
+  #15). Unrelated bug class (stale test fixture vs. an already-shipped schema discriminator), out of
+  scope for a one-conceptual-change diff — flagged for a future night rather than silently expanded into.
+- Live CLI smoke test on a real built scaffold (`minimal` template, rebuilt `dist/`): `harness score --json`
+  on a fresh scaffold now reports `score: 55, mcpRisk: "High"` (was `mcpRisk: "None"`); `harness
+  oia-manifest --dry-run` reports `adjacentStandards.mcp.mode: "local"` (was `"off"`),
+  `layerAlignment.L4_toolsAndIntegrations: "full"` (was `"partial"`) — matching `threat-model`'s already-
+  correct on/off reading of the same directory. Note: `horizontalSpans.security.status` reads `"full"`
+  either way once MCP is detected as on — `oia-manifest.ts`'s `mcpFull` flag encodes on-vs-off, not
+  governed-vs-ungoverned, an existing (unchanged-by-this-fix) modeling choice, not a claim this candidate
+  makes about governance depth.
+
+## Darwin Results
+
+Not run — CLI security-scoring/manifest detection-logic correctness fix, not a genome/routing/topology/
+prompt/tool/tier parameter; no ADR-071 Darwin mutation surface applies (identical reasoning to every prior
+non-parameter `security-adversarial` fix: 2026-08-14, 2026-08-28, 2026-09-02, 2026-09-03).
+
+## SOTA Proof & Witness
+
+Claim rung **A** for the code-level detection gap and its fix (deterministic, 100%-reproducible,
+non-vacuous red/green proof on both files, plus a live-CLI-verified downstream real-scaffold repro).
+Rung **A** for "20/22 templates register MCP unconditionally, 0/22 ship the governing policy file" (direct
+`grep`/`find` over this repo's own committed templates, not sampled). Rung **B/C** for the external 2026
+MCP-security-industry claims (vendor/press secondary sources) — cited at their true rung, not elevated.
+
+```
+session_commit : d5833dc6512ac1adeeef91a331c29055cd8a4dbb
+report_sha256  : da62180b1fe84539599fd1f293a24eb1365cd2a0c6f42a0574f0614ef0f035fe
+witness        : 0041151680435ef32179466c0cf7081c4c149134fd0cfbfad15ddad1a5a9c779
+```
+(`report_sha256` is the SHA256 of this file up to and including the claim-rung paragraph above,
+computed before this witness block was inserted, matching this ledger's established convention.
+Verifier: SHA256 the file up to that point, concatenate with `session_commit`, SHA256 again — must
+equal `witness`.)
+
+## Recommended Next Steps
+
+1. **Architecture gap, disclosed not fixed tonight** (out of one-conceptual-change scope): no scaffold
+   template ever writes `.harness/mcp-policy.json`, even though ADR-022 specifies MCP ships default-deny
+   *when on*, and all 20 templates that register `mcpServers` (including `minimal`) turn MCP on
+   unconditionally via that self-referential entry. Either the scaffolder should emit a default-deny
+   policy file alongside that self-registration, or the self-registration should require explicit opt-in
+   — a real, human-decidable architecture question, not a bugfix.
+2. Fix the 2 pre-existing, unrelated `harness-score.test.ts` stale-schema assertions (6-key vs. real
+   7-key badge shape) — small, low-risk, good for a near-future night.
+3. `docs/adrs/ADR-022-mcp-primitive.md`'s named per-host MCP surfaces (`.codex/config.toml`,
+   `.openclaw/openclaw.json`, Hermes `optional-mcps/<name>.json`) still aren't checked by `scanMcp()` at
+   all (issue #280's own "lower priority, likely separate scope" note) — larger, multi-host-format project.

--- a/docs/dream-cycle/LEDGER.md
+++ b/docs/dream-cycle/LEDGER.md
@@ -98,3 +98,16 @@ cross-file consistency. 565/565 tests (+2), `tsc --noEmit` clean, no
 behavior change. Posted as a PR comment distinguishing "the base branch
 moving fixed this" from "this session fixed this" rather than claiming
 credit for the former.
+
+| 2026-09-08 | security-adversarial | `score.ts`'s `scoreMcpSafety()` and `oia-manifest.ts`'s `readHarnessProfile()` shared threat-model.ts's pre-#276 narrow MCP-detection bug (issue #280); fixed by routing both through `scanMcp().mcpEnabled`. Direct repo inspection found the real blast radius: 20/22 scaffold templates unconditionally register a self-referential MCP server, 0/22 ever ship the governing `.harness/mcp-policy.json` — every default scaffold was scored falsely-safe. Found+fixed a real downstream test regression along the way (`harness-score.test.ts`'s stale MCP-off assumption for the `minimal` template), not swept under | #297 | #298 | yes | ACCEPT | create-agent-harness 572→587/589 (2 pre-existing skips, 0 regressions), root oia-manifest 9→10, root harness-score 1 assertion corrected+strengthened (2 pre-existing unrelated failures confirmed identical on baseline, not caused by this candidate); full monorepo run cross-checked vs. true baseline, 0 regressions; tsc clean; npm audit 0 vuln; live CLI smoke test confirmed | `0041151680...` | #293 (09-07) and #288 (09-06) both OPEN, ≤2 days old, not stale; 18/21 last dream/* PRs merged/closed — healthy merge rate, no zero-merge bias needed |
+
+**Note on 2026-09-08 (added same night):** an earlier attempt at tonight's cycle was started but lost to
+a mid-run container restart before any `dream/2026-09-08-*` branch was ever pushed — confirmed via
+`git ls-remote --heads origin "dream/*"` before starting, per direct evidence, not inferred. Tonight's row
+above is a fresh first attempt, not a resume. Also disclosed, not fixed tonight (out of one-conceptual-
+change scope): the deeper architecture gap that no scaffold template ever ships the ADR-022-mandated
+default-deny `.harness/mcp-policy.json` even though 20/22 templates turn MCP on by default (candidate #2
+in issue #297, score 3.60 vs. selected 4.80 — larger, riskier, touches the generator + every template);
+2 pre-existing unrelated `harness-score.test.ts` failures (stale 6-key vs. real 7-key badge shape, from
+an earlier unrelated PR #15); `mcp-scan.ts`'s missing per-host MCP surfaces and weak-typed policy-value
+comparisons (candidates #4/#5 in issue #297).

--- a/packages/create-agent-harness/__tests__/score-mcp-detection.test.ts
+++ b/packages/create-agent-harness/__tests__/score-mcp-detection.test.ts
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+//
+// Dream Cycle 2026-09-08 (security-adversarial), closing issue #280: the
+// same narrow MCP-detection gap PR #276 (2026-09-03) closed in
+// threat-model.ts also existed in `scoreMcpSafety()` (score.ts) — `hasMcp`
+// only checked `.harness/mcp-policy.json` and `.mcp.json`, missing
+// `.claude/settings.json`'s `mcpServers` key. A harness that registers MCP
+// only through `.claude/settings.json` was scored as the SAFEST possible
+// posture (`mcpRisk: 'None'`, MCP-safety score 100) even though a real,
+// ungoverned MCP server was present — the false negative feeds directly
+// into publish-readiness / overall scoring. Fixed by routing `hasMcp`
+// through `scanMcp()`'s `mcpEnabled`, the one place all 3 valid
+// registration surfaces are already OR'd together (see mcp-scan.ts).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildScorecard } from '../src/score.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  while (dirs.length) rmSync(dirs.pop()!, { recursive: true, force: true });
+});
+
+function fixture(opts: {
+  policy?: Record<string, unknown> | null;
+  mcpJson?: boolean;
+  settingsMcpServers?: Record<string, unknown> | null;
+}): string {
+  const d = mkdtempSync(join(tmpdir(), 'score-mcp-detect-'));
+  dirs.push(d);
+  writeFileSync(join(d, 'package.json'), JSON.stringify({ name: 'demo', version: '1.0.0' }));
+  if (opts.policy) {
+    mkdirSync(join(d, '.harness'), { recursive: true });
+    writeFileSync(join(d, '.harness', 'mcp-policy.json'), JSON.stringify(opts.policy));
+  }
+  if (opts.mcpJson) {
+    writeFileSync(join(d, '.mcp.json'), JSON.stringify({ mcpServers: { bot: { command: 'npx' } } }));
+  }
+  if (opts.settingsMcpServers) {
+    mkdirSync(join(d, '.claude'), { recursive: true });
+    writeFileSync(join(d, '.claude', 'settings.json'), JSON.stringify({ mcpServers: opts.settingsMcpServers }));
+  }
+  return d;
+}
+
+function mcpDim(sc: ReturnType<typeof buildScorecard>) {
+  const d = sc.dimensions.find((x) => x.name === 'MCP safety');
+  if (!d) throw new Error('MCP safety dimension not found');
+  return d as typeof d & { mcpRisk: 'None' | 'Low' | 'Medium' | 'High' };
+}
+
+describe('scoreMcpSafety — MCP-in-use detection covers all 3 registration surfaces (issue #280)', () => {
+  it('no policy, no .mcp.json, no settings mcpServers: correctly None (true negative, unaffected by the fix)', () => {
+    const d = fixture({});
+    const sc = buildScorecard(d);
+    const mcp = mcpDim(sc);
+    expect(mcp.mcpRisk).toBe('None');
+    expect(mcp.score).toBe(100);
+    expect(sc.badges.mcpRisk).toBe('None');
+  });
+
+  it('BUG REPRO (pre-fix would score mcpRisk:"None"/100): .claude/settings.json-only MCP registration is detected as in-use and ungoverned', () => {
+    const d = fixture({ settingsMcpServers: { bot: { command: 'npx' } } });
+    const sc = buildScorecard(d);
+    const mcp = mcpDim(sc);
+    expect(mcp.mcpRisk).not.toBe('None');
+    expect(mcp.mcpRisk).toBe('High'); // no .harness/mcp-policy.json => default-deny OFF
+    expect(mcp.score).not.toBe(100);
+    expect(mcp.signals).not.toContain('MCP not in use (mode=off — safest)');
+    expect(sc.badges.mcpRisk).toBe('High');
+  });
+
+  it('.mcp.json-only registration (no settings.json) still detected as in-use (regression guard, not touched by this fix)', () => {
+    const d = fixture({ mcpJson: true });
+    const sc = buildScorecard(d);
+    expect(mcpDim(sc).mcpRisk).not.toBe('None');
+  });
+
+  it('a compliant .harness/mcp-policy.json is unaffected by the fix — still scores fully governed', () => {
+    const d = fixture({
+      policy: { defaultDeny: true, auditLog: true, allowShell: false, allowNetwork: false, allowFileWrite: false },
+    });
+    const sc = buildScorecard(d);
+    const mcp = mcpDim(sc);
+    expect(mcp.mcpRisk).toBe('Low');
+    expect(mcp.score).toBe(100); // 40+15+15+15+15 — fully compliant policy
+  });
+
+  it('policy present AND settings.json also registers MCP: no double-counting, still exactly the policy-derived score', () => {
+    const d = fixture({
+      policy: { defaultDeny: true, auditLog: true, allowShell: false, allowNetwork: false, allowFileWrite: false },
+      settingsMcpServers: { bot: { command: 'npx' } },
+    });
+    const sc = buildScorecard(d);
+    const mcp = mcpDim(sc);
+    expect(mcp.mcpRisk).toBe('Low');
+    expect(mcp.score).toBe(100);
+  });
+});

--- a/packages/create-agent-harness/src/oia-manifest.ts
+++ b/packages/create-agent-harness/src/oia-manifest.ts
@@ -20,6 +20,7 @@
 
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { scanMcp } from './mcp-scan.js';
 
 export type SubcommandResult = { code: number; lines: string[] };
 
@@ -79,7 +80,13 @@ function readHarnessProfile(dir: string): HarnessProfile {
   const pkg = safeReadJson(join(root, 'package.json')) ?? {};
   const manifest = safeReadJson(join(root, '.harness', 'manifest.json')) ?? {};
   const mcpPolicy = safeReadJson(join(root, '.harness', 'mcp-policy.json'));
-  const hasMcp = mcpPolicy != null || existsSync(join(root, '.mcp.json'));
+  // In-use detection routes through scanMcp()'s mcpEnabled (the authoritative
+  // OR of all 3 valid registration surfaces — policy file, .mcp.json, and
+  // .claude/settings.json's mcpServers) rather than re-deriving a narrower,
+  // policy-file-or-.mcp.json-only check here. A settings.json-only harness
+  // was previously reported ADR-034 mcp.mode:"off" / security span "partial"
+  // even with a live, ungoverned MCP server registered — see issue #280.
+  const hasMcp = scanMcp(root).mcpEnabled;
   // mcpMode inference: presence of mcp-policy with `mode: remote` → remote;
   // policy present without remote signal → local; otherwise off.
   let mcpMode: 'off' | 'local' | 'remote' = 'off';

--- a/packages/create-agent-harness/src/score.ts
+++ b/packages/create-agent-harness/src/score.ts
@@ -22,6 +22,7 @@
 import { existsSync, statSync, writeFileSync, readFileSync, readdirSync } from 'node:fs';
 import { resolve, join } from 'node:path';
 import { redactSecretsDeep } from './redact.js';
+import { scanMcp } from './mcp-scan.js';
 
 export type SubcommandResult = { code: number; lines: string[] };
 
@@ -152,8 +153,14 @@ interface McpScore extends DimensionScore {
 function scoreMcpSafety(dir: string): McpScore {
   const signals: string[] = [];
   const policy = safeReadJson(join(dir, '.harness', 'mcp-policy.json'));
-  // No policy + no .mcp.json at all = MCP not in use, which is the safest possible.
-  const hasMcp = policy != null || fileExists(dir, '.mcp.json');
+  // "In use" is decided by scanMcp()'s mcpEnabled — the one place that ORs
+  // all three valid registration surfaces (.harness/mcp-policy.json,
+  // .mcp.json, and .claude/settings.json's mcpServers key). A policy-file-
+  // or-.mcp.json-only check here missed the settings.json-only case and
+  // scored it as the safest possible posture (mcpRisk: 'None') even when a
+  // server was actually registered and ungoverned — see issue #280 (the
+  // same class of gap #276 closed in threat-model.ts on 2026-09-03).
+  const hasMcp = scanMcp(dir).mcpEnabled;
   if (!hasMcp) {
     signals.push('MCP not in use (mode=off — safest)');
     return { name: 'MCP safety', weight: 0.2, score: 100, signals, mcpRisk: 'None' };


### PR DESCRIPTION
MetaHarness Dream Cycle, 2026-09-08. Deep surface: `security-adversarial` (slot 3). Full research, candidate-selection scoring, competitor review, and sbom/policy scan findings: #297.

## Hypothesis

Given a harness directory that registers MCP through `.claude/settings.json`'s `mcpServers` key only (no `.harness/mcp-policy.json`, no `.mcp.json`), when `harness score --json` or `harness oia-manifest` runs against it, then `mcpRisk` should not be `"None"` and `adjacentStandards.mcp.mode` should not be `"off"`, subject to: (a) a directory with no MCP surface at all is unaffected (true negative preserved); (b) a compliant `.harness/mcp-policy.json` scores identically whether or not settings.json also registers MCP (no double-counting); (c) 0 regressions in existing suites; (d) new tests fail non-vacuously pre-patch. Frozen before implementation, not modified after evaluation began.

## Candidate

`packages/create-agent-harness/src/score.ts`'s `scoreMcpSafety()` and `packages/create-agent-harness/src/oia-manifest.ts`'s `readHarnessProfile()` each computed `hasMcp` from only `.harness/mcp-policy.json`/`.mcp.json` — the exact narrow check `threat-model.ts` had before PR #276 (2026-09-03) fixed it by routing through `mcp-scan.ts`'s `scanMcp().mcpEnabled` (which additionally ORs in `.claude/settings.json`'s `mcpServers`). Issue #280, filed by #276's own round-2 critic, named these two siblings explicitly as a future-night candidate.

Fix: both files now compute `hasMcp = scanMcp(dir).mcpEnabled` instead of re-deriving a narrower check. 2 source files touched (~14 changed lines), 1 new test file (5 cases), 1 new test case in an existing root test file — well under the 300-line target, one conceptual change.

**Real-world blast radius found via direct repo inspection, not assumed**: `grep`/`find` over `packages/create-agent-harness/templates/` shows 20 of 22 scaffold templates unconditionally register a self-referential `mcpServers` entry in `.claude/settings.json.tmpl`, and 0 of 22 templates — including `minimal` — ever ship a `.harness/mcp-policy.json`. This bug was not an edge case: every default-scaffolded harness this generator has ever produced was scored `mcpRisk: "None"` / `oia mcp.mode: "off"` (the safest possible reading) when the true state is MCP-in-use and fully ungoverned.

**Downstream regression found and correctly fixed, not swept under**: root `__tests__/harness-score.test.ts`'s `MCP risk reads default-deny policy correctly` test asserted `mcpRisk ∈ {'None','Low'}` for a real scaffolded `minimal`-template harness, built on the same false assumption the bug caused. Updated the assertion to the correct `'High'` with a comment explaining why — mirrors PR #276's own precedent of correcting a downstream consumer (there: AGNTCY's badge derivation; here: this repo's own test suite) that had baked in the same bug. This *strengthens* the assertion (loose membership check → exact equality), not weakens it.

## Evaluation Receipt

`evaluated: accepted`. Deterministic, $0, zero LLM calls (`LLM_EVAL=available` tonight but not needed — pure static-file-detection logic, matching #276's precedent):

- **Non-vacuous red/green proof, both files independently**: reverting only `score.ts`'s fix fails the new BUG REPRO case (`mcpRisk` stays `'None'` for a settings.json-only-registered directory, confirmed live via `git stash`). Reverting only `oia-manifest.ts`'s fix fails its BUG REPRO case (`mcp.mode` stays `'off'`). Both pass post-patch.
- **True-negative guard**: a directory with no MCP surface at all is unaffected (`None`/`off` unchanged) — explicit test case, both files.
- **No-double-counting guard**: a compliant `.harness/mcp-policy.json` *plus* a settings.json registration scores identically to policy-only.
- Package suite: `create-agent-harness` **572 → 587 passed / 2 skipped** (589 total), 0 regressions. `tsc --noEmit -p packages/create-agent-harness/tsconfig.json` clean.
- Root `__tests__/harness-oia-manifest.test.ts`: **9 → 10** tests, all passing.
- Root `__tests__/harness-score.test.ts`: the 1 assertion this candidate's fix legitimately changes now passes correctly. **2 pre-existing, unrelated failures** (`--json emits the 6-field badges shape` / `--out writes the badges JSON to a file`, both expecting a stale 6-key badge shape vs. the real 7-key shape shipped by an earlier, unrelated PR #15's `schema` discriminator field) are **confirmed present identically on baseline `main`** before any candidate change (verified via `git stash` + rerun) — disclosed, not fixed tonight, out of one-conceptual-change scope.
- **Full monorepo run cross-checked against true baseline**: `npx vitest run` on the candidate shows 12 failed files / 20 failed tests (3037 passed, 58 skipped, 3115 total). Re-ran the exact same 11 unrelated failing files (workflows, ADR-index, marketplace-plugin, e2e-lifecycle, e2e-scaffold-validate, examples-quickstart, harness-diag, metaharness-subcommands, publish-workspace, upgrade-cmd, agent-harness-generator-lib) against true baseline (all source changes stashed) — **identical 18 failures present on `main` before this candidate**, confirming 0 regressions attributable to tonight's change across the entire monorepo, not just the touched package.
- `npm audit --omit=dev --audit-level=high --json`: 0 vulnerabilities (no dependency touched, unchanged before/after).
- **Live CLI smoke test** on a real built scaffold (`minimal` template, rebuilt `dist/`, not mocks): `harness score --json` on a fresh scaffold now reports `score: 55, mcpRisk: "High"` (was `"None"`); `harness oia-manifest --dry-run` now reports `adjacentStandards.mcp.mode: "local"` (was `"off"`), `layerAlignment.L4_toolsAndIntegrations: "full"` (was `"partial"`) — matching `threat-model`'s already-correct reading of the same directory.

## Baseline Comparison

Baseline = `main` at session start (`d5833dc6512ac1adeeef91a331c29055cd8a4dbb`), same evaluator (vitest + tsc), before/after diff isolated to the 2 touched source files. No behavioral change for any harness already correctly detected as MCP-in-use via `.harness/mcp-policy.json` or `.mcp.json`; the fix only affects the previously-mis-detected `.claude/settings.json`-only case.

## Darwin Lineage

Not run — CLI security-scoring/manifest detection-logic correctness fix, not a genome/routing/topology/prompt/tool/tier parameter; no ADR-071 Darwin mutation surface applies (same reasoning as every prior non-parameter `security-adversarial` fix: 2026-08-14, 2026-08-28, 2026-09-02, 2026-09-03).

## Flywheel Evidence

Not applicable — not a flywheel-domain candidate. `docs/dream-cycle/2026-09-08-evidence.md` carries the full OBSERVATION/MEASUREMENT/INFERENCE/DECISION record.

## Reward Hack Check

No existing test weakened — the one downstream assertion changed was strengthened, not loosened, and disclosed with a comment explaining why the old assertion was itself a symptom of the bug. No gold/corpus data involved. No cost hidden (adds one `scanMcp()` call, already used elsewhere in this codebase). `redblue`'s attack families target LLM-facing conversational surfaces, not CLI security-tooling correctness — not directly applicable to this candidate class (same conclusion as every prior night in this class).

## Security Review

This candidate *is* the security-hardening fix — closes a real, universal-blast-radius detection-consistency gap in this repo's own security tooling. No credential/shell/network surface touched, no new dependency. Disclosed, **not fixed here** (out of one-conceptual-change scope): (1) the deeper architecture gap that no scaffold template ever ships the ADR-022-mandated default-deny policy file even though 20/22 templates turn MCP on by default — a real, human-decidable architecture question (candidate #2 in #297, score 3.60 vs. selected 4.80); (2) the 2 pre-existing unrelated `harness-score.test.ts` failures noted above; (3) `mcp-scan.ts`'s missing ADR-022-named per-host MCP surfaces and weak-typed policy-value comparisons (candidates #4/#5 in #297).

## Regression Analysis

Zero regression attributable to this candidate: 587/589 `create-agent-harness` tests (was 572/574, +15 net new, 2 pre-existing skips unchanged), 10/10 root oia-manifest tests (was 9/9), `tsc --noEmit` clean, full monorepo run cross-checked against true baseline confirms all remaining failures are pre-existing/environmental.

## ADR

None — this is a detection-consistency correctness fix to an existing, already-ADR'd mechanism (ADR-022's MCP primitive / `mcp-scan`), not a new architectural decision, matching #276's own precedent for the identical bug class. Searched `docs/adrs/INDEX.md`; no equivalent existing ADR for `score.ts`/`oia-manifest.ts` specifically. The larger architecture question this candidate's investigation surfaced (no template ships the governing policy file) is disclosed above as a human-decidable follow-up, not filed as an ADR tonight — it needs a decision, not documentation of one already made.

## Research Gist

`docs/dream-cycle/2026-09-08-gist.md` (this branch). `GIST=LOCAL` — no gist-creation tool available in this session's toolset, matching every prior Dream Cycle night.

## Issue

#297 (full findings, candidate-selection scoring table, competitor research, sbom/policy scan results, ledger check, learning signals).

## Witness

```
session_commit : d5833dc6512ac1adeeef91a331c29055cd8a4dbb
report_sha256  : da62180b1fe84539599fd1f293a24eb1365cd2a0c6f42a0574f0614ef0f035fe
witness        : 0041151680435ef32179466c0cf7081c4c149134fd0cfbfad15ddad1a5a9c779
```
Verifier procedure is in the gist's Witness section. Self-verified round-trip before this PR was opened.

## Merge Policy

**Human review required. Do not self-merge. Do not autonomously promote Flywheel state.**

Recommendation: **ACCEPT** — real, reproducible, non-vacuously proven fix to a previously-disclosed detection gap (issue #280, itself found by an independent critic on 2026-09-03) with confirmed universal-default-scaffold blast radius, and a genuine downstream regression found and correctly repaired along the way rather than discovered later or swept under.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011AW8fBcLa11YBSo4oBUucN

---
_Generated by [Claude Code](https://claude.ai/code/session_011AW8fBcLa11YBSo4oBUucN)_